### PR TITLE
Make unsafe_fields to be able to opt-out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ matrix:
       os: linux
 
     - rust: nightly
+      name: cargo test (--no-default-features)
+      script:
+        - cargo test --no-default-features
+        - cargo test --no-default-features --release
+
+    - rust: nightly
       name: cargo test (minimal versions)
       script:
         - cargo update -Zminimal-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* `unsafe_fields` can now opt-out.
+
 # 0.1.5 - 2019-01-17
 
 * Add support for tuple struct to `unsafe_project`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,12 @@ travis-ci = { repository = "taiki-e/pin-project" }
 [lib]
 proc-macro = true
 
+[features]
+# Default features.
+default = ["unsafe_fields"]
+# Use `unsafe_fields` attribute.
+unsafe_fields = []
+
 [dependencies]
 proc-macro2 = "^0.4.13"
 quote = "^0.6.8"

--- a/src/compile_fail/unpin_conflict.rs
+++ b/src/compile_fail/unpin_conflict.rs
@@ -147,4 +147,5 @@ mod unsafe_project {}
 /// // conflicting implementations
 /// impl<T: Unpin, U: Unpin> Unpin for Foo<T, U> {} // Conditional Unpin impl
 /// ```
+#[cfg(feature = "unsafe_fields")]
 mod unsafe_fields {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@
 
 extern crate proc_macro;
 
+#[cfg(feature = "unsafe_fields")]
 mod fields;
 mod variants {}
 mod enums {}
@@ -188,6 +189,9 @@ pub fn unsafe_project(args: TokenStream, input: TokenStream) -> TokenStream {
 /// This is similar to [`unsafe_project`], but it is compatible with
 /// [pin-utils].
 ///
+/// *This attribute is available if pin-project is built with the
+/// "unsafe_fields" feature (in version 0.1.*, it is enabled by default).*
+///
 /// This attribute creates methods according to the following rules:
 ///
 /// - For the field that uses `#[pin]` attribute, the method that makes the
@@ -273,6 +277,7 @@ pub fn unsafe_project(args: TokenStream, input: TokenStream) -> TokenStream {
 /// [pin-utils]: https://github.com/rust-lang-nursery/pin-utils
 /// [`pin_utils::unsafe_pinned`]: https://docs.rs/pin-utils/0.1.0-alpha/pin_utils/macro.unsafe_pinned.html
 /// [`pin_utils::unsafe_unpinned`]: https://docs.rs/pin-utils/0.1.0-alpha/pin_utils/macro.unsafe_unpinned.html
+#[cfg(feature = "unsafe_fields")]
 #[proc_macro_attribute]
 pub fn unsafe_fields(args: TokenStream, input: TokenStream) -> TokenStream {
     fields::unsafe_fields(args, input)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,10 +1,11 @@
 #![deny(warnings)]
 
-use pin_project::{unsafe_fields, unsafe_project};
 use std::pin::Pin;
 
 #[test]
 fn test_unsafe_project() {
+    use pin_project::unsafe_project;
+
     // struct
 
     #[unsafe_project(Unpin)]
@@ -43,8 +44,11 @@ fn test_unsafe_project() {
     assert_eq!(*y, 2);
 }
 
+#[cfg(feature = "unsafe_fields")]
 #[test]
 fn test_unsafe_fields() {
+    use pin_project::unsafe_fields;
+
     #[unsafe_fields(Unpin)]
     struct Foo<T, U> {
         #[pin]


### PR DESCRIPTION
There is a restriction that `unsafe_project` cannot support the tuple structs, so it will be optional in the future. In this change, we will prepare for that.