### PR TITLE
More ergonomic enum support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ before_script:
 script:
   - cargo test
   - cargo test --no-default-features
+  - cargo test --no-default-features --features=project_attr
   - cargo test --all-features
   - cargo test --all-features --release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+* Add the feature to create projected enums to `unsafe_project`.
+
+* Add `project` attribute to support pattern matching.
+
 # 0.1.7 - 2019-01-19
 
 * Fix documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,11 @@ proc-macro = true
 
 [features]
 # Default features.
-default = ["unsafe_fields"]
+default = ["project_attr", "unsafe_fields"]
+
+# Use `project` attribute.
+project_attr = ["syn/visit-mut"]
+
 # Use `unsafe_fields` attribute.
 unsafe_fields = []
 # Use `unsafe_variants` attribute.

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,0 +1,203 @@
+use proc_macro::TokenStream;
+use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
+use quote::{quote, ToTokens};
+use syn::{Field, Fields, FieldsNamed, FieldsUnnamed, ItemEnum, Variant};
+
+use crate::utils::*;
+
+pub(super) fn unsafe_project(args: TokenStream, item: ItemEnum) -> TokenStream {
+    Enum::parse(args, item)
+        .map(|parsed| TokenStream::from(parsed.proj_impl()))
+        .unwrap_or_else(|e| e)
+}
+
+struct Enum {
+    item: ItemEnum,
+    impl_unpin: ImplUnpin,
+    proj_ident: Ident,
+}
+
+impl Enum {
+    fn parse(args: TokenStream, item: ItemEnum) -> Result<Self> {
+        if item.variants.is_empty() {
+            parse_failed("unsafe_project", "enums without variants")?;
+        }
+
+        item.variants
+            .iter()
+            .filter(|v| v.discriminant.is_some())
+            .try_for_each(|_| parse_failed("unsafe_project", "enums with discriminants"))?;
+
+        Ok(Self {
+            impl_unpin: ImplUnpin::parse(args, &item.generics, "unsafe_project")?,
+            proj_ident: proj_ident(&item.ident),
+            item,
+        })
+    }
+
+    fn proj_impl(mut self) -> TokenStream2 {
+        let ItemEnum {
+            variants, ident, ..
+        } = &mut self.item;
+        let proj_ident = &self.proj_ident;
+
+        let mut arm_vec = Vec::with_capacity(variants.len());
+        let mut ty_vec = Vec::with_capacity(variants.len());
+        let mut impl_unpin = self.impl_unpin.take();
+        variants.iter_mut().for_each(|variant| {
+            let (proj_arm, proj_ty) = match &variant.fields {
+                Fields::Unnamed(_) => unnamed(variant, ident, proj_ident, &mut impl_unpin),
+                Fields::Named(_) => named(variant, ident, proj_ident, &mut impl_unpin),
+                Fields::Unit => unit(variant, ident, proj_ident),
+            };
+
+            arm_vec.push(proj_arm);
+            ty_vec.push(proj_ty);
+        });
+        self.impl_unpin = impl_unpin;
+
+        let pin = pin();
+        let ident = &self.item.ident;
+        let proj_ident = &self.proj_ident;
+        let proj_generics = proj_generics(&self.item.generics);
+        let (impl_generics, ty_generics, where_clause) = self.item.generics.split_for_impl();
+
+        let proj_item = quote! {
+            enum #proj_ident #proj_generics {
+                #(#ty_vec,)*
+            }
+        };
+
+        let proj_impl = quote! {
+            impl #impl_generics #ident #ty_generics #where_clause {
+                fn project<'__a>(self: #pin<&'__a mut Self>) -> #proj_ident #proj_generics {
+                    unsafe {
+                        match #pin::get_unchecked_mut(self) {
+                            #(#arm_vec,)*
+                        }
+                    }
+                }
+            }
+        };
+
+        let impl_unpin = self.impl_unpin.build(impl_generics, ident, ty_generics);
+        let mut item = self.item.into_token_stream();
+        item.extend(proj_item);
+        item.extend(proj_impl);
+        item.extend(impl_unpin);
+        item
+    }
+}
+
+fn named(
+    variant: &mut Variant,
+    ident: &Ident,
+    proj_ident: &Ident,
+    impl_unpin: &mut ImplUnpin,
+) -> (TokenStream2, TokenStream2) {
+    let Variant {
+        fields,
+        ident: variant_ident,
+        ..
+    } = variant;
+
+    let fields = match fields {
+        Fields::Named(FieldsNamed { named, .. }) => named,
+        _ => unreachable!(),
+    };
+
+    let pin = pin();
+    let mut pat_vec = Vec::with_capacity(fields.len());
+    let mut expr_vec = Vec::with_capacity(fields.len());
+    let mut ty_vec = Vec::with_capacity(fields.len());
+    fields.iter_mut().for_each(
+        |Field {
+             attrs, ident, ty, ..
+         }| {
+            if find_remove(attrs, "pin").is_some() {
+                impl_unpin.push(ty);
+                expr_vec.push(quote!(#ident: #pin::new_unchecked(#ident)));
+                ty_vec.push(quote!(#ident: #pin<&'__a mut #ty>));
+            } else {
+                expr_vec.push(quote!(#ident: #ident));
+                ty_vec.push(quote!(#ident: &'__a mut #ty));
+            }
+
+            pat_vec.push(ident);
+        },
+    );
+
+    let proj_arm = quote! {
+        #ident::#variant_ident { #(#pat_vec),* } => #proj_ident::#variant_ident { #(#expr_vec),* }
+    };
+    let proj_ty = quote!(#variant_ident { #(#ty_vec),* });
+
+    (proj_arm, proj_ty)
+}
+
+fn unnamed(
+    variant: &mut Variant,
+    ident: &Ident,
+    proj_ident: &Ident,
+    impl_unpin: &mut ImplUnpin,
+) -> (TokenStream2, TokenStream2) {
+    let Variant {
+        fields,
+        ident: variant_ident,
+        ..
+    } = variant;
+
+    let fields = match fields {
+        Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => unnamed,
+        _ => unreachable!(),
+    };
+
+    let pin = pin();
+    let mut pat_vec = Vec::with_capacity(fields.len());
+    let mut expr_vec = Vec::with_capacity(fields.len());
+    let mut ty_vec = Vec::with_capacity(fields.len());
+    fields
+        .iter_mut()
+        .enumerate()
+        .for_each(|(i, Field { attrs, ty, .. })| {
+            let x = Ident::new(&format!("_x{}", i), Span::call_site());
+
+            if find_remove(attrs, "pin").is_some() {
+                impl_unpin.push(ty);
+                expr_vec.push(quote!(#pin::new_unchecked(#x)));
+                ty_vec.push(quote!(#pin<&'__a mut #ty>));
+            } else {
+                expr_vec.push(quote!(#x));
+                ty_vec.push(quote!(&'__a mut #ty));
+            }
+
+            pat_vec.push(x);
+        });
+
+    let proj_arm = quote! {
+        #ident::#variant_ident(#(#pat_vec),*) => #proj_ident::#variant_ident(#(#expr_vec),*)
+    };
+    let proj_ty = quote!(#variant_ident(#(#ty_vec),*));
+
+    (proj_arm, proj_ty)
+}
+
+fn unit(variant: &Variant, ident: &Ident, proj_ident: &Ident) -> (TokenStream2, TokenStream2) {
+    let Variant {
+        fields,
+        ident: variant_ident,
+        ..
+    } = variant;
+
+    match fields {
+        Fields::Unit => {}
+        _ => unreachable!(),
+    }
+
+    let proj_arm = quote! {
+        #ident::#variant_ident => #proj_ident::#variant_ident
+    };
+    let proj_ty = quote!(#variant_ident);
+
+    (proj_arm, proj_ty)
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,254 @@
+use proc_macro::TokenStream;
+use quote::ToTokens;
+use syn::{punctuated::Punctuated, token::Or, *};
+
+use crate::utils::*;
+
+pub(super) fn project(input: TokenStream) -> TokenStream {
+    match syn::parse(input) {
+        Ok(mut stmt) => {
+            replace_stmt(&mut stmt);
+            TokenStream::from(stmt.into_token_stream())
+        }
+        Err(err) => TokenStream::from(err.to_compile_error()),
+    }
+}
+
+fn replace_stmt(stmt: &mut Stmt) {
+    match stmt {
+        Stmt::Expr(expr) => replace_expr(expr, &mut Register(None)),
+        Stmt::Local(local) => replace_local(local, &mut Register(None)),
+        Stmt::Item(Item::Fn(item)) => attr::dummy(item),
+        _ => {}
+    }
+}
+
+fn replace_local(local: &mut Local, register: &mut Register) {
+    replace_pats(&mut local.pats, register);
+}
+
+fn replace_expr(expr: &mut Expr, register: &mut Register) {
+    match expr {
+        Expr::If(expr) => expr_if(expr, register),
+        Expr::ForLoop(ExprForLoop { pat, .. }) => replace_pat(&mut **pat, register),
+        Expr::Let(ExprLet { pats, .. }) => replace_pats(pats, register),
+        Expr::Match(ExprMatch { arms, .. }) => arms
+            .iter_mut()
+            .for_each(|Arm { pats, .. }| replace_pats(pats, register)),
+
+        Expr::Unsafe(ExprUnsafe { block, .. }) | Expr::Block(ExprBlock { block, .. }) => {
+            if let Some(Stmt::Expr(expr)) = block.stmts.last_mut() {
+                replace_expr(expr, register);
+            }
+        }
+
+        Expr::While(ExprWhile { cond: expr, .. })
+        | Expr::Type(ExprType { expr, .. })
+        | Expr::Paren(ExprParen { expr, .. })
+        | Expr::Reference(ExprReference { expr, .. }) => replace_expr(&mut **expr, register),
+
+        Expr::Path(ExprPath {
+            qself: None, path, ..
+        })
+        | Expr::Struct(ExprStruct { path, .. }) => replace_path(path, register),
+        _ => {}
+    }
+}
+
+fn expr_if(expr: &mut ExprIf, register: &mut Register) {
+    replace_expr(&mut *expr.cond, register);
+    if let Some(Expr::If(expr)) = expr.else_branch.as_mut().map(|(_, expr)| &mut **expr) {
+        expr_if(expr, register);
+    }
+}
+
+fn replace_pats(pats: &mut Punctuated<Pat, Or>, register: &mut Register) {
+    pats.iter_mut().for_each(|pat| replace_pat(pat, register));
+}
+
+fn replace_pat(pat: &mut Pat, register: &mut Register) {
+    match pat {
+        Pat::Ident(PatIdent {
+            subpat: Some((_, pat)),
+            ..
+        })
+        | Pat::Ref(PatRef { pat, .. })
+        | Pat::Box(PatBox { pat, .. }) => replace_pat(pat, register),
+
+        Pat::Struct(PatStruct { path, .. })
+        | Pat::TupleStruct(PatTupleStruct { path, .. })
+        | Pat::Path(PatPath { qself: None, path }) => replace_path(path, register),
+
+        _ => {}
+    }
+}
+
+fn replace_path(path: &mut Path, register: &mut Register) {
+    fn is_none(args: &PathArguments) -> bool {
+        match args {
+            PathArguments::None => true,
+            _ => false,
+        }
+    }
+
+    fn replace_ident(ident: &mut Ident) {
+        *ident = proj_ident(&ident);
+    }
+
+    let len = match path.segments.len() {
+        // structs
+        1 if is_none(&path.segments[0].arguments) => 1,
+        // enums
+        2 if is_none(&path.segments[0].arguments) && is_none(&path.segments[1].arguments) => 2,
+        _ => return,
+    };
+
+    if register.0.is_none() || register.eq(&path.segments[0].ident, len) {
+        register.update(&path.segments[0].ident, len);
+        replace_ident(&mut path.segments[0].ident);
+    }
+}
+
+struct Register(Option<(String, usize)>);
+
+impl Register {
+    fn update(&mut self, ident: &Ident, len: usize) {
+        if self.0.is_none() {
+            self.0 = Some((ident.to_string(), len));
+        }
+    }
+
+    fn eq(&self, ident: &Ident, len: usize) -> bool {
+        match &self.0 {
+            Some((i, l)) => *l == len && ident == i,
+            None => false,
+        }
+    }
+}
+
+mod attr {
+    use super::*;
+    use syn::visit_mut::{self, VisitMut};
+
+    const NAMES: &[&str] = &["project", "project_attr"];
+
+    pub(super) fn dummy(item: &mut ItemFn) {
+        Dummy.visit_item_fn_mut(item)
+    }
+
+    struct Dummy;
+
+    impl VisitMut for Dummy {
+        fn visit_stmt_mut(&mut self, stmt: &mut Stmt) {
+            visit_mut::visit_stmt_mut(self, stmt);
+            visit_stmt_mut(stmt);
+        }
+
+        // Stop at item bounds
+        fn visit_item_mut(&mut self, _item: &mut Item) {}
+    }
+
+    fn visit_stmt_mut(stmt: &mut Stmt) {
+        fn parse_attr<A: AttrsMut, F: FnOnce(&mut A, &mut Register)>(attrs: &mut A, f: F) {
+            if attrs.find_remove().is_some() {
+                f(attrs, &mut Register(None));
+            }
+        }
+
+        match stmt {
+            Stmt::Expr(expr) => parse_attr(expr, replace_expr),
+            Stmt::Local(local) => parse_attr(local, replace_local),
+            _ => {}
+        }
+    }
+
+    trait AttrsMut {
+        fn attrs_mut<T, F: FnOnce(&mut Vec<Attribute>) -> T>(&mut self, f: F) -> T;
+
+        fn find_remove(&mut self) -> Option<Attribute> {
+            fn find_remove(attrs: &mut Vec<Attribute>) -> Option<Attribute> {
+                attrs
+                    .iter()
+                    .position(|Attribute { path, tts, .. }| {
+                        NAMES.iter().any(|i| path.is_ident(i)) && tts.is_empty()
+                    })
+                    .map(|i| remove(attrs, i))
+            }
+
+            self.attrs_mut(find_remove)
+        }
+    }
+
+    impl<A: AttrsMut> AttrsMut for &'_ mut A {
+        fn attrs_mut<T, F: FnOnce(&mut Vec<Attribute>) -> T>(&mut self, f: F) -> T {
+            (**self).attrs_mut(f)
+        }
+    }
+
+    impl AttrsMut for Vec<Attribute> {
+        fn attrs_mut<T, F: FnOnce(&mut Vec<Attribute>) -> T>(&mut self, f: F) -> T {
+            f(self)
+        }
+    }
+
+    impl AttrsMut for Local {
+        fn attrs_mut<T, F: FnOnce(&mut Vec<Attribute>) -> T>(&mut self, f: F) -> T {
+            f(&mut self.attrs)
+        }
+    }
+
+    macro_rules! attrs_impl {
+        ($($Expr:ident),*) => {
+            impl AttrsMut for Expr {
+                fn attrs_mut<T, F: FnOnce(&mut Vec<Attribute>) -> T>(&mut self, f: F) -> T {
+                    match self {
+                        $(Expr::$Expr(expr) => f(&mut expr.attrs),)*
+                        Expr::Verbatim(_) => f(&mut Vec::with_capacity(0)),
+                    }
+                }
+            }
+        };
+    }
+
+    attrs_impl! {
+        Box,
+        InPlace,
+        Array,
+        Call,
+        MethodCall,
+        Tuple,
+        Binary,
+        Unary,
+        Lit,
+        Cast,
+        Type,
+        Let,
+        If,
+        While,
+        ForLoop,
+        Loop,
+        Match,
+        Closure,
+        Unsafe,
+        Block,
+        Assign,
+        AssignOp,
+        Field,
+        Index,
+        Range,
+        Path,
+        Reference,
+        Break,
+        Continue,
+        Return,
+        Macro,
+        Struct,
+        Repeat,
+        Paren,
+        Group,
+        Try,
+        Async,
+        TryBlock,
+        Yield
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,9 @@
 use std::result;
 
 use proc_macro::TokenStream;
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::quote;
-use syn::{Attribute, Generics};
+use syn::{parse_quote, Attribute, Generics, ImplGenerics, Type, TypeGenerics};
 
 pub(super) type Result<T> = result::Result<T, TokenStream>;
 
@@ -12,39 +12,82 @@ pub(super) fn compile_err(msg: &str) -> TokenStream {
     TokenStream::from(quote!(compile_error!(#msg);))
 }
 
+#[inline(never)]
+pub(super) fn parse_failed<T>(name: &str, msg: &str) -> Result<T> {
+    Err(compile_err(&format!(
+        "`{}` cannot be implemented for {}",
+        name, msg
+    )))
+}
+
 pub(super) fn pin() -> TokenStream2 {
     quote!(::core::pin::Pin)
 }
-pub(super) fn unpin() -> TokenStream2 {
-    quote!(::core::marker::Unpin)
-}
 
 pub(super) fn find_remove(attrs: &mut Vec<Attribute>, ident: &str) -> Option<Attribute> {
-    fn remove<T>(v: &mut Vec<T>, index: usize) -> T {
-        match v.len() {
-            1 => v.pop().unwrap(),
-            2 => v.swap_remove(index),
-            _ => v.remove(index),
-        }
-    }
-
     attrs
         .iter()
         .position(|Attribute { path, tts, .. }| path.is_ident(ident) && tts.is_empty())
         .map(|i| remove(attrs, i))
 }
 
-pub(super) fn parse_args(
-    args: TokenStream,
-    generics: &Generics,
-    name: &str,
-) -> Result<Option<Generics>> {
-    match &*args.to_string() {
-        "" => Ok(None),
-        "Unpin" => Ok(Some(generics.clone())),
-        _ => Err(compile_err(&format!(
-            "`{}` an invalid argument was passed",
-            name
-        )))?,
+pub(super) fn remove<T>(v: &mut Vec<T>, index: usize) -> T {
+    match v.len() {
+        1 => v.pop().unwrap(),
+        2 => v.swap_remove(index),
+        _ => v.remove(index),
+    }
+}
+
+pub(super) fn proj_ident(ident: &Ident) -> Ident {
+    Ident::new(&format!("__{}Projection", ident), Span::call_site())
+}
+
+pub(super) fn proj_generics(generics: &Generics) -> TokenStream2 {
+    let generics = generics.params.iter();
+    quote!(<'__a, #(#generics),*>)
+}
+
+pub(super) struct ImplUnpin(Option<Generics>);
+
+impl ImplUnpin {
+    pub(super) fn parse(args: TokenStream, generics: &Generics, name: &str) -> Result<Self> {
+        match &*args.to_string() {
+            "" => Ok(Self(None)),
+            "Unpin" => Ok(Self(Some(generics.clone()))),
+            _ => Err(compile_err(&format!(
+                "`{}` an invalid argument was passed",
+                name
+            )))?,
+        }
+    }
+
+    pub(super) fn take(&mut self) -> Self {
+        Self(self.0.take())
+    }
+
+    pub(super) fn push(&mut self, ty: &Type) {
+        if let Some(generics) = &mut self.0 {
+            generics
+                .make_where_clause()
+                .predicates
+                .push(parse_quote!(#ty: ::core::marker::Unpin));
+        }
+    }
+
+    pub(super) fn build(
+        self,
+        impl_generics: ImplGenerics,
+        ident: &Ident,
+        ty_generics: TypeGenerics,
+    ) -> TokenStream2 {
+        self.0
+            .map(|generics| {
+                let where_clause = generics.split_for_impl().2;
+                quote! {
+                    impl #impl_generics ::core::marker::Unpin for #ident #ty_generics #where_clause {}
+                }
+            })
+            .unwrap_or_default()
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,11 +1,12 @@
+#![recursion_limit = "128"]
 #![deny(warnings)]
+#![allow(dead_code)]
 
+use pin_project::unsafe_project;
 use std::pin::Pin;
 
 #[test]
 fn test_unsafe_project() {
-    use pin_project::unsafe_project;
-
     // struct
 
     #[unsafe_project(Unpin)]
@@ -42,6 +43,161 @@ fn test_unsafe_project() {
 
     let y: &mut i32 = bar.1;
     assert_eq!(*y, 2);
+
+    // enum
+
+    #[unsafe_project(Unpin)]
+    enum Baz<A, B, C, D> {
+        Variant1(#[pin] A, B),
+        Variant2 {
+            #[pin]
+            field1: C,
+            field2: D,
+        },
+        None,
+    }
+
+    let mut baz = Baz::Variant1(1, 2);
+
+    let baz = Pin::new(&mut baz).project();
+
+    match baz {
+        __BazProjection::Variant1(x, y) => {
+            let x: Pin<&mut i32> = x;
+            assert_eq!(*x, 1);
+
+            let y: &mut i32 = y;
+            assert_eq!(*y, 2);
+        }
+        __BazProjection::Variant2 { field1, field2 } => {
+            let _x: Pin<&mut i32> = field1;
+            let _y: &mut i32 = field2;
+        }
+        __BazProjection::None => {}
+    }
+
+    let mut baz = Baz::Variant2 {
+        field1: 3,
+        field2: 4,
+    };
+
+    let mut baz = Pin::new(&mut baz).project();
+
+    match &mut baz {
+        __BazProjection::Variant1(x, y) => {
+            let _x: &mut Pin<&mut i32> = x;
+            let _y: &mut &mut i32 = y;
+        }
+        __BazProjection::Variant2 { field1, field2 } => {
+            let x: &mut Pin<&mut i32> = field1;
+            assert_eq!(**x, 3);
+
+            let y: &mut &mut i32 = field2;
+            assert_eq!(**y, 4);
+        }
+        __BazProjection::None => {}
+    }
+
+    if let __BazProjection::Variant2 { field1, field2 } = baz {
+        let x: Pin<&mut i32> = field1;
+        assert_eq!(*x, 3);
+
+        let y: &mut i32 = field2;
+        assert_eq!(*y, 4);
+    }
+}
+
+#[cfg(feature = "project_attr")]
+use pin_project::project;
+
+#[cfg(feature = "project_attr")]
+#[project] // Nightly does not need a dummy attribute to the function.
+#[test]
+fn test_project_attr() {
+    // struct
+
+    #[unsafe_project(Unpin)]
+    struct Foo<T, U> {
+        #[pin]
+        field1: T,
+        field2: U,
+    }
+
+    let mut foo = Foo {
+        field1: 1,
+        field2: 2,
+    };
+
+    #[project]
+    let Foo { field1, field2 } = Pin::new(&mut foo).project();
+
+    let x: Pin<&mut i32> = field1;
+    assert_eq!(*x, 1);
+
+    let y: &mut i32 = field2;
+    assert_eq!(*y, 2);
+
+    // tuple struct
+
+    #[unsafe_project(Unpin)]
+    struct Bar<T, U>(#[pin] T, U);
+
+    let mut bar = Bar(1, 2);
+
+    #[project]
+    let Bar(x, y) = Pin::new(&mut bar).project();
+
+    let x: Pin<&mut i32> = x;
+    assert_eq!(*x, 1);
+
+    let y: &mut i32 = y;
+    assert_eq!(*y, 2);
+
+    // enum
+
+    #[unsafe_project(Unpin)]
+    enum Baz<A, B, C, D> {
+        Variant1(#[pin] A, B),
+        Variant2 {
+            #[pin]
+            field1: C,
+            field2: D,
+        },
+        None,
+    }
+
+    let mut baz = Baz::Variant1(1, 2);
+
+    let mut baz = Pin::new(&mut baz).project();
+
+    #[project]
+    match &mut baz {
+        Baz::Variant1(x, y) => {
+            let x: &mut Pin<&mut i32> = x;
+            assert_eq!(**x, 1);
+
+            let y: &mut &mut i32 = y;
+            assert_eq!(**y, 2);
+        }
+        Baz::Variant2 { field1, field2 } => {
+            let _x: &mut Pin<&mut i32> = field1;
+            let _y: &mut &mut i32 = field2;
+        }
+        Baz::None => {}
+    }
+
+    #[project]
+    {
+        if let Baz::Variant1(x, y) = baz {
+            let x: Pin<&mut i32> = x;
+            assert_eq!(*x, 1);
+
+            let y: &mut i32 = y;
+            assert_eq!(*y, 2);
+        } else if let Option::Some(_) = Some(1) {
+            // Check that don't replace different types by mistake
+        }
+    }
 }
 
 #[cfg(feature = "unsafe_fields")]
@@ -100,8 +256,6 @@ fn test_unsafe_fields() {
 #[cfg(feature = "unsafe_variants")]
 #[test]
 fn test_unsafe_variants() {
-    #![allow(dead_code)]
-
     use pin_project::unsafe_variants;
 
     #[unsafe_variants(Unpin)]


### PR DESCRIPTION
See rust-lang-nursery/pin-utils#21

~~This has not been completed, but~~ this will make the following changes:

* Add the feature to create projected enums to `unsafe_project`.
* Add ~~a macro and~~ an attribute to support pattern matching.