### PR TITLE
Add impl block support to #[project] attribute

### DIFF
--- a/pin-project-internal/src/lib.rs
+++ b/pin-project-internal/src/lib.rs
@@ -289,7 +289,7 @@ pub fn pin_project(args: TokenStream, input: TokenStream) -> TokenStream {
 /// `Pin<&mut Self>`. In particular, it will never be called more than once,
 /// just like [`Drop::drop`].
 ///
-/// Example:
+/// ## Example
 ///
 /// ```rust
 /// use pin_project::{pin_project, pinned_drop};
@@ -325,14 +325,55 @@ pub fn pinned_drop(args: TokenStream, input: TokenStream) -> TokenStream {
 /// *This attribute is available if pin-project is built with the
 /// `"project_attr"` feature.*
 ///
-/// The attribute at the expression position is not stable, so you need to use
-/// a dummy `#[project]` attribute for the function.
+/// The following three syntaxes are supported.
 ///
-/// ## Examples
+/// ## `impl` blocks
 ///
-/// The following two syntaxes are supported.
+/// All methods (and associated functions) in `#[project] impl` block become
+/// methods of the projected type. If you want to implement methods on the
+/// original type, you need to create another (non-`#[project]`) `impl` block.
 ///
-/// ### `let` bindings
+/// To call a method implemented in `#[project] impl` block, you need to first
+/// get the projected-type with `let this = self.project();`.
+///
+/// ### Examples
+///
+/// ```rust
+/// use pin_project::{pin_project, project};
+/// use std::pin::Pin;
+///
+/// #[pin_project]
+/// struct Foo<T, U> {
+///     #[pin]
+///     future: T,
+///     field: U,
+/// }
+///
+/// // impl for the original type
+/// impl<T, U> Foo<T, U> {
+///     fn bar(mut self: Pin<&mut Self>) {
+///         self.project().baz()
+///     }
+/// }
+///
+/// // impl for the projected type
+/// #[project]
+/// impl<T, U> Foo<T, U> {
+///     fn baz(self) {
+///         let Self { future, field } = self;
+///
+///         let _: Pin<&mut T> = future;
+///         let _: &mut U = field;
+///     }
+/// }
+/// ```
+///
+/// ## `let` bindings
+///
+/// *The attribute at the expression position is not stable, so you need to use
+/// a dummy `#[project]` attribute for the function.*
+///
+/// ### Examples
 ///
 /// ```rust
 /// use pin_project::{pin_project, project};
@@ -357,7 +398,12 @@ pub fn pinned_drop(args: TokenStream, input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// ### `match` expressions
+/// ## `match` expressions
+///
+/// *The attribute at the expression position is not stable, so you need to use
+/// a dummy `#[project]` attribute for the function.*
+///
+/// ### Examples
 ///
 /// ```rust
 /// use pin_project::{project, pin_project};

--- a/pin-project-internal/src/pin_project/mod.rs
+++ b/pin-project-internal/src/pin_project/mod.rs
@@ -7,7 +7,7 @@ use syn::{
     *,
 };
 
-use crate::utils::{crate_path, proj_ident, proj_trait_ident};
+use crate::utils::{self, crate_path, proj_ident, proj_trait_ident};
 
 mod enums;
 mod structs;
@@ -208,34 +208,14 @@ fn ensure_not_packed(item: &ItemStruct) -> Result<TokenStream> {
 /// Determine the lifetime names. Ensure it doesn't overlap with any existing lifetime names.
 fn proj_lifetime(generics: &Punctuated<GenericParam, Comma>) -> Lifetime {
     let mut lifetime_name = String::from("'_pin");
-    let existing_lifetimes: Vec<String> = generics
-        .iter()
-        .filter_map(|param| {
-            if let GenericParam::Lifetime(LifetimeDef { lifetime, .. }) = param {
-                Some(lifetime.to_string())
-            } else {
-                None
-            }
-        })
-        .collect();
-    while existing_lifetimes.iter().any(|name| *name == lifetime_name) {
-        lifetime_name.push('_');
-    }
+    utils::proj_lifetime_name(&mut lifetime_name, generics);
     Lifetime::new(&lifetime_name, Span::call_site())
 }
 
 /// Makes the generics of projected type from the reference of the original generics.
 fn proj_generics(generics: &Generics, lifetime: &Lifetime) -> Generics {
     let mut generics = generics.clone();
-    generics.params.insert(
-        0,
-        GenericParam::Lifetime(LifetimeDef {
-            attrs: Vec::new(),
-            lifetime: lifetime.clone(),
-            colon_token: None,
-            bounds: Punctuated::new(),
-        }),
-    );
+    utils::proj_generics(&mut generics, lifetime.clone());
     generics
 }
 

--- a/pin-project-internal/src/pinned_drop.rs
+++ b/pin-project-internal/src/pinned_drop.rs
@@ -31,7 +31,7 @@ fn parse_arg(arg: &FnArg) -> Result<&Type> {
         }
     }
 
-    Err(error!(&arg, "#[pinned_drop] function must take a argument `Pin<&mut Type>`"))
+    Err(error!(arg, "#[pinned_drop] function must take a argument `Pin<&mut Type>`"))
 }
 
 fn parse(input: TokenStream) -> Result<TokenStream> {

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -10,7 +10,7 @@ use pin_project::{pin_project, project};
 
 #[project] // Nightly does not need a dummy attribute to the function.
 #[test]
-fn test_project_attr() {
+fn project_stmt_expr() {
     // struct
 
     #[pin_project]
@@ -85,7 +85,7 @@ fn test_project_attr() {
 }
 
 #[test]
-fn test_project_attr_nightly() {
+fn project_stmt_expr_nightly() {
     // enum
 
     #[pin_project]
@@ -135,4 +135,66 @@ fn test_project_attr_nightly() {
         }
         Baz::None => {}
     };
+}
+
+#[test]
+fn project_impl() {
+    #[pin_project]
+    struct HasGenerics<T, U> {
+        #[pin]
+        field1: T,
+        field2: U,
+    }
+
+    #[project]
+    impl<T, U> HasGenerics<T, U> {
+        fn a(self) {
+            let Self { field1, field2 } = self;
+
+            let _x: Pin<&mut T> = field1;
+            let _y: &mut U = field2;
+        }
+    }
+
+    #[pin_project]
+    struct NoneGenerics {
+        #[pin]
+        field1: i32,
+        field2: u32,
+    }
+
+    #[project]
+    impl NoneGenerics {}
+
+    #[pin_project]
+    struct HasLifetimes<'a, T, U> {
+        #[pin]
+        field1: &'a mut T,
+        field2: U,
+    }
+
+    #[project]
+    impl<T, U> HasLifetimes<'_, T, U> {}
+
+    #[pin_project]
+    struct HasOverlappingLifetimes<'_pin, T, U> {
+        #[pin]
+        field1: &'_pin mut T,
+        field2: U,
+    }
+
+    #[project]
+    impl<'_pin, T, U> HasOverlappingLifetimes<'_pin, T, U> {}
+
+    #[pin_project]
+    struct HasOverlappingLifetimes2<T, U> {
+        #[pin]
+        field1: T,
+        field2: U,
+    }
+
+    #[project]
+    impl<T, U> HasOverlappingLifetimes2<T, U> {
+        fn foo<'_pin>(&'_pin self) {}
+    }
 }


### PR DESCRIPTION
This adds a feature to convert an annotated impl to a projected type's impl.

Example:

```rust
#[project]
impl<T, U> Foo<T, U> {
    fn baz(self) {
        let Self { future, field } = self;
    }
}

// convert to:
impl<'_pin, T, U> __FooProjection<'_pin, T, U> {
    fn baz(self) {
        let Self { future, field } = self;
    }
}
```

Closes #43

cc @Nemo157

