### PR TITLE
Make generated 'project' reference take an '&mut Pin<&mut Self>'

### DIFF
--- a/pin-project-internal/src/lib.rs
+++ b/pin-project-internal/src/lib.rs
@@ -92,7 +92,7 @@ use syn::parse::Nothing;
 /// }
 ///
 /// impl<T, U> Foo<T, U> {
-///     fn baz(self: Pin<&mut Self>) {
+///     fn baz(mut self: Pin<&mut Self>) {
 ///         let this = self.project();
 ///         let _: Pin<&mut T> = this.future; // Pinned reference to the field
 ///         let _: &mut U = this.field; // Normal reference to the field
@@ -115,7 +115,7 @@ use syn::parse::Nothing;
 /// }
 ///
 /// impl<T, U> Foo<T, U> {
-///     fn baz(self: Pin<&mut Self>) {
+///     fn baz(mut self: Pin<&mut Self>) {
 ///         let this = self.project();
 ///         let _: Pin<&mut T> = this.future; // Pinned reference to the field
 ///         let _: &mut U = this.field; // Normal reference to the field
@@ -162,7 +162,7 @@ use syn::parse::Nothing;
 /// }
 ///
 /// #[pinned_drop]
-/// fn my_drop_fn<T: Debug, U: Debug>(foo: Pin<&mut Foo<T, U>>) {
+/// fn my_drop_fn<T: Debug, U: Debug>(mut foo: Pin<&mut Foo<T, U>>) {
 ///     let foo = foo.project();
 ///     println!("Dropping pinned field: {:?}", foo.pinned_field);
 ///     println!("Dropping unpin field: {:?}", foo.unpin_field);
@@ -193,7 +193,7 @@ use syn::parse::Nothing;
 /// }
 ///
 /// impl<T, U> Foo<T, U> {
-///     fn baz(self: Pin<&mut Self>) {
+///     fn baz(mut self: Pin<&mut Self>) {
 ///         let this = self.project();
 ///         let _: Pin<&mut T> = this.future;
 ///         let _: &mut U = this.field;
@@ -211,7 +211,7 @@ use syn::parse::Nothing;
 /// struct Foo<T, U>(#[pin] T, U);
 ///
 /// impl<T, U> Foo<T, U> {
-///     fn baz(self: Pin<&mut Self>) {
+///     fn baz(mut self: Pin<&mut Self>) {
 ///         let this = self.project();
 ///         let _: Pin<&mut T> = this.0;
 ///         let _: &mut U = this.1;
@@ -250,7 +250,7 @@ use syn::parse::Nothing;
 /// # #[cfg(feature = "project_attr")]
 /// impl<A, B, C> Foo<A, B, C> {
 ///     #[project] // Nightly does not need a dummy attribute to the function.
-///     fn baz(self: Pin<&mut Self>) {
+///     fn baz(mut self: Pin<&mut Self>) {
 ///         #[project]
 ///         match self.project() {
 ///             Foo::Tuple(x, y) => {
@@ -347,7 +347,7 @@ pub fn pinned_drop(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// impl<T, U> Foo<T, U> {
 ///     #[project] // Nightly does not need a dummy attribute to the function.
-///     fn baz(self: Pin<&mut Self>) {
+///     fn baz(mut self: Pin<&mut Self>) {
 ///         #[project]
 ///         let Foo { future, field } = self.project();
 ///
@@ -372,7 +372,7 @@ pub fn pinned_drop(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// impl<A, B, C> Foo<A, B, C> {
 ///     #[project] // Nightly does not need a dummy attribute to the function.
-///     fn baz(self: Pin<&mut Self>) {
+///     fn baz(mut self: Pin<&mut Self>) {
 ///         #[project]
 ///         match self.project() {
 ///             Foo::Tuple(x, y) => {

--- a/pin-project-internal/src/pin_project/enums.rs
+++ b/pin-project-internal/src/pin_project/enums.rs
@@ -6,7 +6,7 @@ use crate::utils::VecExt;
 
 use super::{proj_generics, Context, PIN};
 
-pub(super) fn parse(mut cx: Context, mut item: ItemEnum) -> Result<TokenStream> {
+pub(super) fn parse(cx: &mut Context, mut item: ItemEnum) -> Result<TokenStream> {
     if item.variants.is_empty() {
         return Err(error!(item, "cannot be implemented for enums without variants"));
     }
@@ -23,9 +23,9 @@ pub(super) fn parse(mut cx: Context, mut item: ItemEnum) -> Result<TokenStream> 
         return Err(error!(item.variants, "cannot be implemented for enums that have no field"));
     }
 
-    let (proj_variants, proj_arms) = variants(&mut cx, &mut item)?;
+    let (proj_variants, proj_arms) = variants(cx, &mut item)?;
 
-    let impl_drop = cx.impl_drop(&item.generics);
+    let mut impl_drop = cx.impl_drop(&item.generics);
     let Context { original, projected, lifetime, impl_unpin, .. } = cx;
     let proj_generics = proj_generics(&item.generics, &lifetime);
     let proj_ty_generics = proj_generics.split_for_impl().1;

--- a/pin-project-internal/src/pin_project/mod.rs
+++ b/pin-project-internal/src/pin_project/mod.rs
@@ -4,7 +4,7 @@ use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
     token::Comma,
-    *
+    *,
 };
 
 use crate::utils::{crate_path, proj_ident, proj_trait_ident};
@@ -67,7 +67,15 @@ impl Context {
         let lifetime = proj_lifetime(&generics.params);
         let impl_unpin = ImplUnpin::new(generics, unsafe_unpin);
         let projected_trait = proj_trait_ident(&original);
-        Ok(Self { original, projected, projected_trait, lifetime, impl_unpin, pinned_drop, generics: generics.clone() })
+        Ok(Self {
+            original,
+            projected,
+            projected_trait,
+            lifetime,
+            impl_unpin,
+            pinned_drop,
+            generics: generics.clone(),
+        })
     }
 
     fn impl_drop<'a>(&self, generics: &'a Generics) -> ImplDrop<'a> {
@@ -76,7 +84,6 @@ impl Context {
 }
 
 fn parse(args: TokenStream, input: TokenStream) -> Result<TokenStream> {
-
     match syn::parse2(input)? {
         Item::Struct(item) => {
             let mut cx = Context::new(args, item.ident.clone(), &item.generics)?;
@@ -101,7 +108,7 @@ fn parse(args: TokenStream, input: TokenStream) -> Result<TokenStream> {
 }
 
 fn make_proj_trait(cx: &mut Context) -> Result<TokenStream> {
-    let proj_trait = &cx.projected_trait; 
+    let proj_trait = &cx.projected_trait;
     let lifetime = &cx.lifetime;
     let proj_ident = &cx.projected;
     let proj_generics = proj_generics(&cx.generics, &cx.lifetime);
@@ -114,7 +121,6 @@ fn make_proj_trait(cx: &mut Context) -> Result<TokenStream> {
             fn project<#lifetime>(&#lifetime mut self) -> #proj_ident #proj_ty_generics #orig_where_clause;
         }
     })
-
 }
 
 fn ensure_not_packed(item: &ItemStruct) -> Result<TokenStream> {

--- a/pin-project-internal/src/pin_project/mod.rs
+++ b/pin-project-internal/src/pin_project/mod.rs
@@ -4,11 +4,10 @@ use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
     token::Comma,
-    Fields, FieldsNamed, FieldsUnnamed, GenericParam, Generics, Index, Item, ItemStruct, Lifetime,
-    LifetimeDef, Meta, NestedMeta, Result, Type,
+    *
 };
 
-use crate::utils::{crate_path, proj_ident};
+use crate::utils::{crate_path, proj_ident, proj_trait_ident};
 
 mod enums;
 mod structs;
@@ -51,6 +50,10 @@ struct Context {
     original: Ident,
     /// Name of the projected type.
     projected: Ident,
+    /// Name of the trait generated
+    /// to provide a 'project' method
+    projected_trait: Ident,
+    generics: Generics,
 
     lifetime: Lifetime,
     impl_unpin: ImplUnpin,
@@ -63,7 +66,8 @@ impl Context {
         let projected = proj_ident(&original);
         let lifetime = proj_lifetime(&generics.params);
         let impl_unpin = ImplUnpin::new(generics, unsafe_unpin);
-        Ok(Self { original, projected, lifetime, impl_unpin, pinned_drop })
+        let projected_trait = proj_trait_ident(&original);
+        Ok(Self { original, projected, projected_trait, lifetime, impl_unpin, pinned_drop, generics: generics.clone() })
     }
 
     fn impl_drop<'a>(&self, generics: &'a Generics) -> ImplDrop<'a> {
@@ -72,22 +76,45 @@ impl Context {
 }
 
 fn parse(args: TokenStream, input: TokenStream) -> Result<TokenStream> {
+
     match syn::parse2(input)? {
         Item::Struct(item) => {
-            let cx = Context::new(args, item.ident.clone(), &item.generics)?;
+            let mut cx = Context::new(args, item.ident.clone(), &item.generics)?;
+            let mut res = make_proj_trait(&mut cx)?;
+
             let packed_check = ensure_not_packed(&item)?;
-            let mut res = structs::parse(cx, item)?;
+            res.extend(structs::parse(cx, item)?);
             res.extend(packed_check);
             Ok(res)
         }
         Item::Enum(item) => {
-            let cx = Context::new(args, item.ident.clone(), &item.generics)?;
+            let mut cx = Context::new(args, item.ident.clone(), &item.generics)?;
+            let mut res = make_proj_trait(&mut cx)?;
+
             // We don't need to check for '#[repr(packed)]',
             // since it does not apply to enums
-            enums::parse(cx, item)
+            res.extend(enums::parse(cx, item));
+            Ok(res)
         }
         item => Err(error!(item, "may only be used on structs or enums")),
     }
+}
+
+fn make_proj_trait(cx: &mut Context) -> Result<TokenStream> {
+    let proj_trait = &cx.projected_trait; 
+    let lifetime = &cx.lifetime;
+    let proj_ident = &cx.projected;
+    let proj_generics = proj_generics(&cx.generics, &cx.lifetime);
+    let proj_ty_generics = proj_generics.split_for_impl().1;
+
+    let (orig_generics, _orig_ty_generics, orig_where_clause) = cx.generics.split_for_impl();
+
+    Ok(quote! {
+        trait #proj_trait #orig_generics {
+            fn project<#lifetime>(&#lifetime mut self) -> #proj_ident #proj_ty_generics #orig_where_clause;
+        }
+    })
+
 }
 
 fn ensure_not_packed(item: &ItemStruct) -> Result<TokenStream> {

--- a/pin-project-internal/src/pin_project/structs.rs
+++ b/pin-project-internal/src/pin_project/structs.rs
@@ -36,7 +36,7 @@ pub(super) fn parse(mut cx: Context, mut item: ItemStruct) -> Result<TokenStream
         impl #impl_generics #proj_trait #ty_generics for ::core::pin::Pin<&mut #orig_ident #ty_generics> #where_clause {
             fn project<#lifetime>(&#lifetime mut self) -> #proj_ident #proj_ty_generics #where_clause {
                 unsafe {
-                    let this = self.as_mut().get_unchecked_mut(); 
+                    let this = self.as_mut().get_unchecked_mut();
                     #proj_ident #proj_init
                 }
             }

--- a/pin-project-internal/src/pin_project/structs.rs
+++ b/pin-project-internal/src/pin_project/structs.rs
@@ -6,7 +6,7 @@ use crate::utils::VecExt;
 
 use super::{proj_generics, Context, PIN};
 
-pub(super) fn parse(mut cx: Context, mut item: ItemStruct) -> Result<TokenStream> {
+pub(super) fn parse(cx: &mut Context, mut item: ItemStruct) -> Result<TokenStream> {
     let (proj_fields, proj_init) = match &mut item.fields {
         Fields::Named(FieldsNamed { named: fields, .. })
         | Fields::Unnamed(FieldsUnnamed { unnamed: fields, .. })
@@ -16,14 +16,14 @@ pub(super) fn parse(mut cx: Context, mut item: ItemStruct) -> Result<TokenStream
         }
         Fields::Unit => return Err(error!(item, "cannot be implemented for structs with units")),
 
-        Fields::Named(fields) => named(&mut cx, fields)?,
-        Fields::Unnamed(fields) => unnamed(&mut cx, fields)?,
+        Fields::Named(fields) => named(cx, fields)?,
+        Fields::Unnamed(fields) => unnamed(cx, fields)?,
     };
 
     let orig_ident = &cx.original;
     let proj_ident = &cx.projected;
     let lifetime = &cx.lifetime;
-    let impl_drop = cx.impl_drop(&item.generics);
+    let mut impl_drop = cx.impl_drop(&item.generics);
     let proj_generics = proj_generics(&item.generics, &cx.lifetime);
     let proj_ty_generics = proj_generics.split_for_impl().1;
     let proj_trait = &cx.projected_trait;

--- a/pin-project-internal/src/utils.rs
+++ b/pin-project-internal/src/utils.rs
@@ -7,6 +7,10 @@ pub(crate) fn proj_ident(ident: &Ident) -> Ident {
     format_ident!("__{}Projection", ident)
 }
 
+pub(crate) fn proj_trait_ident(ident: &Ident) -> Ident {
+    format_ident!("__{}ProjectionTrait", ident)
+}
+
 pub(crate) trait VecExt {
     fn find_remove(&mut self, ident: &str) -> Option<Attribute>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! }
 //!
 //! impl<T, U> Foo<T, U> {
-//!     fn baz(self: Pin<&mut Self>) {
+//!     fn baz(mut self: Pin<&mut Self>) {
 //!         let this = self.project();
 //!         let _: Pin<&mut T> = this.future; // Pinned reference to the field
 //!         let _: &mut U = this.field; // Normal reference to the field

--- a/tests/pin_project.rs
+++ b/tests/pin_project.rs
@@ -123,12 +123,11 @@ fn test_pin_project() {
 
 #[test]
 fn enum_project_set() {
-
     #[pin_project]
     #[derive(Eq, PartialEq, Debug)]
     enum Bar {
         Variant1(#[pin] u8),
-        Variant2(bool)
+        Variant2(bool),
     }
 
     let mut bar = Bar::Variant1(25);
@@ -139,8 +138,8 @@ fn enum_project_set() {
         __BarProjection::Variant1(val) => {
             let new_bar = Bar::Variant2(val.as_ref().get_ref() == &25);
             bar_orig.set(new_bar);
-        },
-        _ => unreachable!()
+        }
+        _ => unreachable!(),
     }
 
     assert_eq!(bar, Bar::Variant2(true));

--- a/tests/pinned_drop.rs
+++ b/tests/pinned_drop.rs
@@ -14,7 +14,7 @@ pub struct Foo<'a> {
 }
 
 #[pinned_drop]
-fn do_drop(foo: Pin<&mut Foo<'_>>) {
+fn do_drop(mut foo: Pin<&mut Foo<'_>>) {
     **foo.project().was_dropped = true;
 }
 

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -21,9 +21,10 @@ fn test_project_attr() {
     }
 
     let mut foo = Foo { field1: 1, field2: 2 };
+    let mut foo = Pin::new(&mut foo);
 
     #[project]
-    let Foo { field1, field2 } = Pin::new(&mut foo).project();
+    let Foo { field1, field2 } = foo.project();
 
     let x: Pin<&mut i32> = field1;
     assert_eq!(*x, 1);
@@ -37,9 +38,10 @@ fn test_project_attr() {
     struct Bar<T, U>(#[pin] T, U);
 
     let mut bar = Bar(1, 2);
+    let mut bar = Pin::new(&mut bar);
 
     #[project]
-    let Bar(x, y) = Pin::new(&mut bar).project();
+    let Bar(x, y) = bar.project();
 
     let x: Pin<&mut i32> = x;
     assert_eq!(*x, 1);
@@ -62,7 +64,8 @@ fn test_project_attr() {
 
     let mut baz = Baz::Variant1(1, 2);
 
-    let mut baz = Pin::new(&mut baz).project();
+    let mut baz = Pin::new(&mut baz);
+    let mut baz = baz.project();
 
     #[project]
     match &mut baz {
@@ -98,7 +101,8 @@ fn test_project_attr_nightly() {
 
     let mut baz = Baz::Variant1(1, 2);
 
-    let mut baz = Pin::new(&mut baz).project();
+    let mut baz = Pin::new(&mut baz);
+    let mut baz = baz.project();
 
     #[project]
     match &mut baz {


### PR DESCRIPTION
Based on https://github.com/rust-lang/unsafe-code-guidelines/issues/148#issuecomment-523711778
by @CAD97

Currently, the generated 'project' method takes a 'Pin<&mut Self>',
consuming it. This makes it impossible to use the original Pin<&mut Self>
after calling project(), since the 'Pin<&mut Self>' has been moved into
the the 'Project' method.

This makes it impossible to implement useful pattern when working with
enums:

```rust

enum Foo {
    Variant1(#[pin] SomeFuture),
    Variant2(OtherType)
}

fn process(foo: Pin<&mut Foo>) {
    match foo.project() {
        __FooProjection(fut) => {
            fut.poll();
            let new_foo: Foo = ...;
            foo.set(new_foo);
        },
        _ => {}
    }
}
```

This pattern is common when implementing a Future combinator - an inner
future is polled, and then the containing enum is changed to a new
variant. However, as soon as 'project()' is called, it becoms imposible
to call 'set' on the original 'Pin<&mut Self>'.

To support this pattern, this commit changes the 'project' method to
take a '&mut Pin<&mut Self>'. The projection types work exactly as
before - however, creating it no longer requires consuming the original
'Pin<&mut Self>'

Unfortunately, current limitations of Rust prevent us from simply
modifying the signature of the 'project' method in the inherent impl
of the projection type. While using 'Pin<&mut Self>' as a receiver is
supported on stable rust, using '&mut Pin<&mut Self>' as a receiver
requires the unstable `#![feature(arbitrary_self_types)]`

For compatibility with stable Rust, we instead dynamically define a new
trait, '__{Type}ProjectionTrait', where {Type} is the name of the type
with the `#[pin_project]` attribute.

This trait looks like this:

```rust
trait __FooProjectionTrait {
    fn project(&'a mut self) -> __FooProjection<'a>;
}
```

It is then implemented for `Pin<&mut {Type}>`. This allows the `project`
method to be invoked on `&mut Pin<&mut {Type}>`, which is what we want.

If Generic Associated Types (https://github.com/rust-lang/rust/issues/44265)
were implemented and stabilized, we could use a single trait for all pin
projections:

```rust
trait Projectable {
    type Projection<'a>;
    fn project(&'a mut self) -> Self::Projection<'a>;
}
```

However, Generic Associated Types are not even implemented on nightly
yet, so we need to generate a new trait per type for the foreseeable
future.