### PR TITLE
Assert lack of Drop impl without implementing Drop

### DIFF
--- a/pin-project-internal/src/lib.rs
+++ b/pin-project-internal/src/lib.rs
@@ -48,7 +48,19 @@ use syn::parse::Nothing;
 ///
 /// 2. The destructor of the struct must not move structural fields out of its argument.
 ///
-///    To enforce this, this attribute will automatically generate a `Drop` impl.
+///    To enforce this, this attribute will generate code like this:
+///
+///    ```rust
+///    struct MyStruct {}
+///    trait MyStructMustNotImplDrop {}
+///    impl<T: Drop> MyStructMustNotImplDrop for T {}
+///    impl MyStructMustNotImplDrop for MyStruct {}
+///    ```
+///
+///    If you attempt to provide an Drop impl, the blanket impl will
+///    then apply to your type, causing a compile-time error due to
+///    the conflict with the second impl.
+///
 ///    If you wish to provide a custom `Drop` impl, you can annotate a function
 ///    with `#[pinned_drop]`. This function takes a pinned version of your struct -
 ///    that is, `Pin<&mut MyStruct>` where `MyStruct` is the type of your struct.

--- a/tests/pin_project.rs
+++ b/tests/pin_project.rs
@@ -172,6 +172,29 @@ fn where_clause_and_associated_type_fields() {
 }
 
 #[test]
+fn test_move_out() {
+    struct NotCopy;
+
+    #[pin_project]
+    struct Foo {
+        val: NotCopy,
+    }
+
+    let foo = Foo { val: NotCopy };
+    let _val: NotCopy = foo.val;
+
+    #[pin_project]
+    enum Bar {
+        Variant(NotCopy),
+    }
+
+    let bar = Bar::Variant(NotCopy);
+    let _val: NotCopy = match bar {
+        Bar::Variant(val) => val,
+    };
+}
+
+#[test]
 fn trait_bounds_on_type_generics() {
     // struct
 

--- a/tests/ui/pin_project/drop_conflict.stderr
+++ b/tests/ui/pin_project/drop_conflict.stderr
@@ -1,11 +1,11 @@
-error[E0119]: conflicting implementations of trait `std::ops::Drop` for type `Foo<_, _>`:
-  --> $DIR/drop_conflict.rs:8:1
-   |
-8  | #[pin_project] //~ ERROR E0119
-   | ^^^^^^^^^^^^^^ conflicting implementation for `Foo<_, _>`
-...
-15 | impl<T, U> Drop for Foo<T, U> {
-   | ----------------------------- first implementation here
+error[E0119]: conflicting implementations of trait `FooMustNotImplDrop` for type `Foo<_, _>`:
+ --> $DIR/drop_conflict.rs:8:1
+  |
+8 | #[pin_project] //~ ERROR E0119
+  | ^^^^^^^^^^^^^^
+  | |
+  | first implementation here
+  | conflicting implementation for `Foo<_, _>`
 
 error[E0119]: conflicting implementations of trait `std::ops::Drop` for type `Bar<_, _>`:
   --> $DIR/drop_conflict.rs:19:1


### PR DESCRIPTION
Previously, we would provide an empty Drop impl for types that did not
provide a pinned_drop method, in order to assert that the user was not
providing their own Drop impl.

However, the compiler places certain restrictions on types that
implement Drop. For example, you cannot move out of the fields of such
types, as that would cause the Drop impl to observe the fields in an
uninitialized state.

This commit changes to a purely trait-based approach, as used in
the assert-impl crate by @upsuper . This prevents the creation of
unnecessary Drop impls, while still ensuring that the user cannot
provide their own Drop impl without going through pinned_drop