### PR TITLE
Support #[project] attribute on 'let var = match' exressions

### DIFF
--- a/pin-project-internal/src/project.rs
+++ b/pin-project-internal/src/project.rs
@@ -71,6 +71,14 @@ impl Replace for ItemImpl {
 impl Replace for Local {
     fn replace(&mut self, register: &mut Register) {
         self.pat.replace(register);
+        // We need to use two 'if let' expressions
+        // here, since we can't pattern-match through
+        // a Box
+        if let Some((_, expr)) = &mut self.init {
+            if let Expr::Match(expr) = &mut **expr {
+                expr.replace(register);
+            }
+        }
     }
 }
 

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -82,6 +82,14 @@ fn project_stmt_expr() {
         }
         Baz::None => {}
     }
+
+    #[project]
+    let val = match &mut baz {
+        Baz::Variant1(_, _) => true,
+        Baz::Variant2 { .. } => false,
+        Baz::None => false,
+    };
+    assert_eq!(val, true);
 }
 
 #[test]


### PR DESCRIPTION
Previously, the #[project] attribute would only apply to plain 'match'
expressions, not 'match' expressions immediately assigned to a local.

This commit checks for #[project] attributes in the initializer of a
'let' expression, if the initializer is a 'match' expression.