### PR TITLE
Apply #[allow(dead_code)] to generated types

### DIFF
--- a/pin-project-internal/src/pin_project/enums.rs
+++ b/pin-project-internal/src/pin_project/enums.rs
@@ -31,6 +31,7 @@ pub(super) fn parse(cx: &mut Context, mut item: ItemEnum) -> Result<TokenStream>
     let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
 
     let mut proj_items = quote! {
+        #[allow(dead_code)]
         enum #proj_ident #proj_generics #where_clause { #(#proj_variants,)* }
     };
     proj_items.extend(quote! {

--- a/pin-project-internal/src/pin_project/structs.rs
+++ b/pin-project-internal/src/pin_project/structs.rs
@@ -26,6 +26,7 @@ pub(super) fn parse(cx: &mut Context, mut item: ItemStruct) -> Result<TokenStrea
     let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
 
     let mut proj_items = quote! {
+        #[allow(dead_code)]
         struct #proj_ident #proj_generics #where_clause #proj_fields
     };
     proj_items.extend(quote! {


### PR DESCRIPTION
This prevents users from seing pointless, unsuppressible warnings in
their build