### PR TITLE
Preserve original lifetime when performing pin-projection

### DIFF
--- a/pin-project-internal/src/pin_project/enums.rs
+++ b/pin-project-internal/src/pin_project/enums.rs
@@ -35,8 +35,6 @@ pub(super) fn parse(cx: &mut Context, mut item: ItemEnum) -> Result<TokenStream>
     let proj_generics = cx.proj_generics();
     let proj_ty_generics = proj_generics.split_for_impl().1;
 
-    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
-
     let ProjTraitGenerics { impl_generics, ty_generics, where_clause, orig_ty_generics }
         = cx.proj_trait_generics();
 

--- a/pin-project-internal/src/pin_project/enums.rs
+++ b/pin-project-internal/src/pin_project/enums.rs
@@ -35,9 +35,8 @@ pub(super) fn parse(cx: &mut Context, mut item: ItemEnum) -> Result<TokenStream>
     let proj_generics = cx.proj_generics();
     let proj_ty_generics = proj_generics.split_for_impl().1;
 
-    let ProjTraitGenerics { impl_generics, ty_generics, where_clause, orig_ty_generics }
-        = cx.proj_trait_generics();
-
+    let ProjTraitGenerics { impl_generics, ty_generics, where_clause, orig_ty_generics } =
+        cx.proj_trait_generics();
 
     let mut proj_items = quote! {
         #[allow(dead_code)]

--- a/pin-project-internal/src/pin_project/mod.rs
+++ b/pin-project-internal/src/pin_project/mod.rs
@@ -138,7 +138,7 @@ impl Context {
         generics
     }
 
-    fn proj_trait_generics<'a>(&'a self) -> ProjTraitGenerics<'a> {
+    fn proj_trait_generics(&self) -> ProjTraitGenerics<'_> {
         //let mut orig_generics_for_impl = orig.clone();
         //crate::utils::proj_generics(&mut orig_generics_for_impl, self.lifetime.clone());
         //let (impl_generics, modified_ty_generics, _) = orig_generics_for_impl.split_for_impl();

--- a/pin-project-internal/src/pin_project/mod.rs
+++ b/pin-project-internal/src/pin_project/mod.rs
@@ -83,7 +83,7 @@ struct ProjTraitGenerics<'a> {
     impl_generics: ImplGenerics<'a>,
     ty_generics: TypeGenerics<'a>,
     where_clause: Option<&'a WhereClause>,
-    orig_ty_generics: TypeGenerics<'a>
+    orig_ty_generics: TypeGenerics<'a>,
 }
 
 impl Context {
@@ -116,7 +116,6 @@ impl Context {
         let mut proj_trait_generics = generics.clone();
         crate::utils::proj_generics(&mut proj_trait_generics, lifetime.clone());
 
-
         Ok(Self {
             orig_ident: orig_ident.clone(),
             proj_ident,
@@ -128,7 +127,7 @@ impl Context {
             pinned_fields: vec![],
             unsafe_unpin: unsafe_unpin.is_some(),
             pinned_drop,
-            proj_trait_generics
+            proj_trait_generics,
         })
     }
 
@@ -150,7 +149,7 @@ impl Context {
             impl_generics,
             ty_generics: modified_ty_generics,
             where_clause,
-            orig_ty_generics: ty_generics
+            orig_ty_generics: ty_generics,
         }
     }
 

--- a/pin-project-internal/src/pin_project/structs.rs
+++ b/pin-project-internal/src/pin_project/structs.rs
@@ -32,15 +32,14 @@ pub(super) fn parse(cx: &mut Context, mut item: ItemStruct) -> Result<TokenStrea
     let proj_generics = cx.proj_generics();
     let proj_ty_generics = proj_generics.split_for_impl().1;
 
-
     /*let mut orig_generics_for_impl = item.generics.clone();
     crate::utils::proj_generics(&mut orig_generics_for_impl, lifetime.clone());
     let (impl_generics, modified_ty_generics, _) = orig_generics_for_impl.split_for_impl();
 
     let (_, ty_generics, where_clause) = item.generics.split_for_impl();*/
 
-    let ProjTraitGenerics { impl_generics, ty_generics, where_clause, orig_ty_generics }
-        = cx.proj_trait_generics();
+    let ProjTraitGenerics { impl_generics, ty_generics, where_clause, orig_ty_generics } =
+        cx.proj_trait_generics();
 
     let mut proj_items = quote! {
         #[allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,22 @@ pub unsafe trait UnsafeUnpin {}
 
 use core::pin::Pin;
 
+/// A helper trait to allow projecting through a mutable reference,
+/// while preserving lifetimes.
+///
+/// Normally, `Pin::as_mut` can be used to convert a '&mut Pin' to a owned 'Pin'
+/// However, since 'Pin::as_mut' needs to work with generic DerefMut impls,
+/// it loses lifetime information. Specifically, it returns a 'Pin<&'a mut P::Target>',
+/// where 'a is tied to the lifetime of the original '&mut Pin'. If you started
+/// with a `&mut Pin<'pin &mut T>`, the 'pin lifetime is lost.
+///
+/// This can cause issues when trying to return the result of a pin projection
+/// from a method - e.g. `fn foo<'a>(mut self: Pin<&'a mut Self>) -> Pin<&'a mut T>`
+/// 
+/// The ProjectThrough trait was introduced to solve this issue.
+/// Normally, you'll never need to interact with this type
+/// directly - it's used internally by pin-project to allow expressing
+/// the proper lifetime.
 pub trait ProjectThrough<'a> {
     type Target;
     fn proj_through(&mut self) -> Pin<&'a mut Self::Target>;
@@ -172,11 +188,45 @@ pub trait ProjectThrough<'a> {
 impl<'a, T> ProjectThrough<'a> for Pin<&'a mut T> {
     type Target = T;
     fn proj_through(&mut self) -> Pin<&'a mut Self::Target> {
-        let as_mut: Pin<&mut T> = self.as_mut();
+        // This method is fairly tricky. We start out with
+        // a `&'p mut Pin<&'a mut T>`, which we want
+        // to convert into a `Pin<&'a mut T>`
+        //
+        // Effectively, we want to discard the outer '&mut'
+        // reference, and just work with the inner 'Pin'
+        // We accomplish this in four steps:
+        //
+        // First, call Pin::as_mut(self). This
+        // converts our '&'p mut Pin<&'a mut T>` to
+        // a `Pin<&mut T>`. This is *almost* what we want -
+        // however, the lifetime is wrong. Since 'as_mut'
+        // uses the `DerefMut` impl of `&mut T`, it loses
+        // the lifetime associated with the `&mut T`.
+        // However, we know that we're dealing with a
+        // `Pin<&mut T>`, so we can soundly recover the original
+        // lifetime.
+        //
+        // This relies on the following property:
+        // The lifetime of the reference returned by <&'a mut T as DerefMut>::deref_mut
+        // is the same as 'a. In order words, calling deref_mut on a mutable reference
+        // is a no-op.
+        let as_mut: Pin<&mut T> = Pin::as_mut(self);
+
+        // Next, we unwrap the Pin<&mut T> by calling 'Pin::get_unchecked_mut'.
+        // This gives us access to the underlying mutable reference
         #[allow(unsafe_code)]
         let raw_mut: &mut T = unsafe { Pin::get_unchecked_mut(as_mut) };
+
+        // NExt, we transmute the mutable reference, changing its lifetime to 'a.
+        // Here, we rely on the behavior of DerefMut for mutable references
+        // described above.
+        //
+        // This is the core of this method - everything else is just to deconstruct
+        // and reconstrut a Pin
         #[allow(unsafe_code)]
         let raw_transmuted: &'a mut T = unsafe { core::mem::transmute(raw_mut) };
+
+        // Finally, we construct a Pin from our 'upgraded' mutable reference
         #[allow(unsafe_code)]
         unsafe { Pin::new_unchecked(raw_transmuted) }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,9 +174,11 @@ impl<'a, T> ProjectThrough<'a> for Pin<&'a mut T> {
     type Target = T;
     fn proj_through(&mut self) -> Pin<&'a mut Self::Target> {
         let as_mut: Pin<&mut T> = self.as_mut();
+        #[allow(unsafe_code)]
         let raw_mut: &mut T = unsafe { Pin::into_inner_unchecked(as_mut) };
+        #[allow(unsafe_code)]
         let raw_transmuted: &'a mut T = unsafe { core::mem::transmute(raw_mut) };
-        
+        #[allow(unsafe_code)]
         unsafe { Pin::new_unchecked(raw_transmuted) }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,15 +167,15 @@ use core::pin::Pin;
 /// while preserving lifetimes.
 ///
 /// Normally, `Pin::as_mut` can be used to convert a '&mut Pin' to a owned 'Pin'
-/// However, since 'Pin::as_mut' needs to work with generic DerefMut impls,
-/// it loses lifetime information. Specifically, it returns a 'Pin<&'a mut P::Target>',
+/// However, since `Pin::as_mut'`needs to work with generic `DerefMut` impls,
+/// it loses lifetime information. Specifically, it returns a `Pin<&'a mut P::Target>`,
 /// where 'a is tied to the lifetime of the original '&mut Pin'. If you started
 /// with a `&mut Pin<'pin &mut T>`, the 'pin lifetime is lost.
 ///
 /// This can cause issues when trying to return the result of a pin projection
 /// from a method - e.g. `fn foo<'a>(mut self: Pin<&'a mut Self>) -> Pin<&'a mut T>`
 ///
-/// The ProjectThrough trait was introduced to solve this issue.
+/// The `ProjectThrough` trait was introduced to solve this issue.
 /// Normally, you'll never need to interact with this type
 /// directly - it's used internally by pin-project to allow expressing
 /// the proper lifetime.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,6 @@ pub use pin_project_internal::project;
 #[allow(unsafe_code)]
 pub unsafe trait UnsafeUnpin {}
 
-
 use core::pin::Pin;
 
 /// A helper trait to allow projecting through a mutable reference,
@@ -175,7 +174,7 @@ use core::pin::Pin;
 ///
 /// This can cause issues when trying to return the result of a pin projection
 /// from a method - e.g. `fn foo<'a>(mut self: Pin<&'a mut Self>) -> Pin<&'a mut T>`
-/// 
+///
 /// The ProjectThrough trait was introduced to solve this issue.
 /// Normally, you'll never need to interact with this type
 /// directly - it's used internally by pin-project to allow expressing
@@ -228,7 +227,9 @@ impl<'a, T> ProjectThrough<'a> for Pin<&'a mut T> {
 
         // Finally, we construct a Pin from our 'upgraded' mutable reference
         #[allow(unsafe_code)]
-        unsafe { Pin::new_unchecked(raw_transmuted) }
+        unsafe {
+            Pin::new_unchecked(raw_transmuted)
+        }
     }
 }
 
@@ -251,8 +252,6 @@ pub mod __private {
         #[doc(hidden)]
         unsafe fn pinned_drop(self: Pin<&mut Self>);
     }
-
-
 
     // This is an internal helper struct used by `pin-project-internal`.
     // This allows us to force an error if the user tries to provide

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,6 @@
 #![warn(single_use_lifetimes)]
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::use_self)]
-#![feature(pin_into_inner)]
 
 #[doc(hidden)]
 pub use pin_project_internal::pin_project;
@@ -175,7 +174,7 @@ impl<'a, T> ProjectThrough<'a> for Pin<&'a mut T> {
     fn proj_through(&mut self) -> Pin<&'a mut Self::Target> {
         let as_mut: Pin<&mut T> = self.as_mut();
         #[allow(unsafe_code)]
-        let raw_mut: &mut T = unsafe { Pin::into_inner_unchecked(as_mut) };
+        let raw_mut: &mut T = unsafe { Pin::get_unchecked_mut(as_mut) };
         #[allow(unsafe_code)]
         let raw_transmuted: &'a mut T = unsafe { core::mem::transmute(raw_mut) };
         #[allow(unsafe_code)]

--- a/tests/pin_project.rs
+++ b/tests/pin_project.rs
@@ -265,16 +265,16 @@ fn test_private_type_in_public_type() {
 
 #[test]
 fn test_lifetime_project() {
-	#[pin_project::pin_project]
-	struct Struct<T, U> {
-		#[pin]
-		pinned: T,
-		unpinned: U,
-	}
+    #[pin_project::pin_project]
+    struct Struct<T, U> {
+        #[pin]
+        pinned: T,
+        unpinned: U,
+    }
 
-	impl<T, U> Struct<T, U> {
-		fn get_pin_mut<'a>(mut self: Pin<&'a mut Self>) -> Pin<&'a mut T> {
-			self.project().pinned
-		}
-	}
+    impl<T, U> Struct<T, U> {
+        fn get_pin_mut<'a>(mut self: Pin<&'a mut Self>) -> Pin<&'a mut T> {
+            self.project().pinned
+        }
+    }
 }

--- a/tests/pin_project.rs
+++ b/tests/pin_project.rs
@@ -262,3 +262,19 @@ fn test_private_type_in_public_type() {
         OtherVariant(u8),
     }
 }
+
+#[test]
+fn test_lifetime_project() {
+	#[pin_project::pin_project]
+	struct Struct<T, U> {
+		#[pin]
+		pinned: T,
+		unpinned: U,
+	}
+
+	impl<T, U> Struct<T, U> {
+		fn get_pin_mut<'a>(mut self: Pin<&'a mut Self>) -> Pin<&'a mut T> {
+			self.project().pinned
+		}
+	}
+}


### PR DESCRIPTION
As described in issue https://github.com/taiki-e/pin-project/issues/65, the `project` method currently loses lifetime information.

Specifically, given a `&'a mut Pin<&'pin mut T>`, we would like `project` to return a `ProjectionType<'pin>` - that is, a type with a lifetime tied to the lifetime of the inside of the original `Pin`.

However, `project` currently returns a `ProjectionType<'a>` - that is, a type with a lifetime tied to the lifetime of the 'outside' of the `Pin`. This means that pin-projected types will not live as long as the inside of the `Pin` they were derived from - which prevents returning fields from methods.

This PR lifts this limitation, by ensuring that the returning projection struct/enum has a lifetime of `'pin` - that is, the lifetime in the `Pin<&'pin mut T>` that the projection was performed on.

Most of this PR is just boilerplate to make things work on arbitrary structs and enums. The important part is the additional `unsafe` code added. Ultimately, it relies on this code being valid:

```rust
use std::ops::DerefMut;

fn upgrade_deref_mut<'a, T>(mut val: &'a mut T) -> &'a mut T {
    let my_ref: &mut T = val.deref_mut();
    let transmuted: &'a mut T = unsafe { core::mem::transmute(my_ref) };
    transmuted
}
```

That is, we need to be able to 'upgrade' the lifetime of the mutable reference returned from the `<&mut T as DerefMut>::deref_mut`. I believe this is sound - `DerefMut` is essentially a no-op for mutable references. We're only adjusting the compiler's view of the lifetime, not performing any raw pointer tricks that might make Stacked Borrows angry.

That being said, I'm not 100% sure that this is correct.

@RalfJung: Would you be able to take a look at this?

Note that this only relies on the built-in `DerefMut` impl for `&mut T`, not any user-provided `&mut DerefMut` impls. I think that this kind of 'upgrading' logic could potentially be extended to user-provided types that fulfill the requirement of `StableDeref` - that is, the mutable references they return live for as long as the original type. However, pin-project doesn't need to care about this.