### PR TITLE
Remove `_` from UnpinStruct

### DIFF
--- a/pin-project-internal/src/pin_project/mod.rs
+++ b/pin-project-internal/src/pin_project/mod.rs
@@ -153,7 +153,7 @@ impl Context {
                 }
             };
 
-            let struct_ident = format_ident!("__UnpinStruct{}", orig_ident, span = make_span());
+            let struct_ident = format_ident!("UnpinStruct{}", orig_ident, span = make_span());
             let always_unpin_ident = format_ident!("AlwaysUnpin{}", orig_ident, span = make_span());
 
             // Generate a field in our new struct for every
@@ -246,6 +246,7 @@ impl Context {
                 ///
                 /// [taiki-e/pin-project#53]: https://github.com/taiki-e/pin-project/pull/53#issuecomment-525906867
                 /// [rust-lang/rust#63281]: https://github.com/rust-lang/rust/issues/63281
+                #[allow(dead_code)]
                 #vis struct #struct_ident #full_generics #where_clause {
                     __pin_project_use_generics: #always_unpin_ident <(#(#type_params),*)>,
 


### PR DESCRIPTION
[As `UnpinStruct` is displayed in the documents](https://github.com/taiki-e/pin-project/pull/62), I think it looks better when `_` is removed.

Before (https://docs.rs/hyper/0.13.0-alpha.1/hyper/server/index.html):
<img width="1015" alt="docs-1" src="https://user-images.githubusercontent.com/43724913/64283683-e07d6580-cf92-11e9-9bda-1421b4532375.png">

After:
<img width="1015" alt="docs-2" src="https://user-images.githubusercontent.com/43724913/64283702-e7a47380-cf92-11e9-8e72-6ce36acc8bd7.png">

cc @seanmonstar @LucioFranco