### PR TITLE
Add use statements support to #[project] attribute

### DIFF
--- a/pin-project-internal/src/lib.rs
+++ b/pin-project-internal/src/lib.rs
@@ -364,7 +364,7 @@ pub fn pinned_drop(args: TokenStream, input: TokenStream) -> TokenStream {
 // TODO: Move this doc into pin-project crate when https://github.com/rust-lang/rust/pull/62855 merged.
 /// An attribute to provide way to refer to the projected type.
 ///
-/// The following three syntaxes are supported.
+/// The following syntaxes are supported.
 ///
 /// ## `impl` blocks
 ///
@@ -471,6 +471,38 @@ pub fn pinned_drop(args: TokenStream, input: TokenStream) -> TokenStream {
 ///         }
 ///     }
 /// }
+/// ```
+///
+/// ## `use` statements
+///
+/// ### Examples
+///
+/// ```rust
+/// # mod dox {
+/// use pin_project::pin_project;
+///
+/// #[pin_project]
+/// struct Foo<A> {
+///     #[pin]
+///     field: A,
+/// }
+///
+/// mod bar {
+///     use super::Foo;
+///     use pin_project::project;
+///     use std::pin::Pin;
+///
+///     #[project]
+///     use super::Foo;
+///
+///     #[project]
+///     fn baz<A>(foo: Pin<&mut Foo<A>>) {
+///         #[project]
+///         let Foo { field } = foo.project();
+///         let _: Pin<&mut A> = field;
+///     }
+/// }
+/// # }
 /// ```
 #[proc_macro_attribute]
 pub fn project(args: TokenStream, input: TokenStream) -> TokenStream {

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -149,3 +149,38 @@ fn project_impl() {
         fn foo<'_pin>(&'_pin self) {}
     }
 }
+
+#[pin_project]
+struct A {
+    #[pin]
+    field: u8,
+}
+
+mod project_use_1 {
+    use crate::A;
+    use core::pin::Pin;
+    use pin_project::project;
+
+    #[project]
+    use crate::A;
+
+    #[project]
+    #[test]
+    fn project_use() {
+        let mut x = A { field: 0 };
+        #[project]
+        let A { field } = Pin::new(&mut x).project();
+        let _: Pin<&mut u8> = field;
+    }
+}
+
+mod project_use_2 {
+    #[project]
+    use crate::A;
+    use pin_project::project;
+
+    #[project]
+    impl A {
+        fn project_use(self) {}
+    }
+}

--- a/tests/ui/project/use-public.rs
+++ b/tests/ui/project/use-public.rs
@@ -1,0 +1,17 @@
+// compile-fail
+
+use pin_project::pin_project;
+
+#[pin_project]
+struct A {
+    field: u8,
+}
+
+pub mod b {
+    use pin_project::project;
+
+    #[project]
+    pub use crate::A;
+}
+
+fn main() {}

--- a/tests/ui/project/use-public.stderr
+++ b/tests/ui/project/use-public.stderr
@@ -1,0 +1,11 @@
+error[E0365]: `__AProjection` is private, and cannot be re-exported
+  --> $DIR/use-public.rs:14:13
+   |
+14 |     pub use crate::A;
+   |             ^^^^^^^^ re-export of private `__AProjection`
+   |
+   = note: consider declaring type or module `__AProjection` with `pub`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0365`.

--- a/tests/ui/project/use.rs
+++ b/tests/ui/project/use.rs
@@ -1,0 +1,19 @@
+// compile-fail
+
+use pin_project::pin_project;
+
+#[pin_project]
+struct A {
+    field: u8,
+}
+
+mod b {
+    use pin_project::project;
+
+    #[project]
+    use crate::A as B; //~ ERROR #[project] attribute may not be used on renamed imports
+    #[project]
+    use crate::*; //~ ERROR #[project] attribute may not be used on glob imports
+}
+
+fn main() {}

--- a/tests/ui/project/use.stderr
+++ b/tests/ui/project/use.stderr
@@ -1,0 +1,14 @@
+error: #[project] attribute may not be used on renamed imports
+  --> $DIR/use.rs:14:16
+   |
+14 |     use crate::A as B; //~ ERROR #[project] attribute may not be used on renamed imports
+   |                ^^^^^^
+
+error: #[project] attribute may not be used on glob imports
+  --> $DIR/use.rs:16:16
+   |
+16 |     use crate::*; //~ ERROR #[project] attribute may not be used on glob imports
+   |                ^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
This adds a feature to convert annotated imports to a projected type's imports.

~~For now, this works as an import for both projected type and projection trait.~~ Now, this works as an import for projected type.

### Examples

```rust
use pin_project::pin_project;

#[pin_project]
struct Foo<A> {
    #[pin]
    field: A,
}

mod bar {
    use pin_project::project;
    use super::Foo;
    use std::pin::Pin;

    #[project]
    use super::Foo;

    #[project]
    fn baz<A>(foo: Pin<&mut Foo<A>>) {
        #[project]
        let Foo { field } = foo.project();
        let _: Pin<&mut A> = field;
    }
}
```