### PR TITLE
Remove "renamed" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,6 @@ all-features = true
 [workspace]
 members = ["pin-project-internal"]
 
-[features]
-# Enable to allow using this crate as a renamed dependency
-renamed = ["pin-project-internal/renamed"]
-
 [dependencies]
 pin-project-internal = { version = "=0.4.0-alpha.11", path = "pin-project-internal", default-features = false }
 

--- a/ci/azure-test.yml
+++ b/ci/azure-test.yml
@@ -22,7 +22,6 @@ jobs:
 
     - script: |
         cargo ${{ parameters.cmd }} --all
-        cargo ${{ parameters.cmd }} --all --all-features
       displayName: cargo ${{ parameters.cmd }}
 
     - ${{ if eq(parameters.toolchain, 'nightly') }}:

--- a/pin-project-internal/Cargo.toml
+++ b/pin-project-internal/Cargo.toml
@@ -16,20 +16,10 @@ all-features = true
 [lib]
 proc-macro = true
 
-[features]
-# Enable to allow using the crate with a renamed 'pin-project' dependency
-renamed = ["proc-macro-crate", "serde", "lazy_static"]
-
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full", "visit-mut"] }
-
-proc-macro-crate = { version = "0.1.4", optional = true }
-# Required until a new toml-rs release is made with https://github.com/alexcrichton/toml-rs/pull/311,
-# and proc-macro-crate updates to that new version of toml-rs.
-serde = { version = "1.0.97", optional = true }
-lazy_static = { version = "1.3", optional = true }
 
 [dev-dependencies]
 pin-project = { version = "0.4.0-alpha.11", path = ".." }

--- a/pin-project-internal/src/lib.rs
+++ b/pin-project-internal/src/lib.rs
@@ -538,11 +538,3 @@ pub fn derive_unpin(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input);
     pin_project::derive(input).into()
 }
-
-#[cfg(feature = "renamed")]
-lazy_static::lazy_static! {
-    pub(crate) static ref PIN_PROJECT_CRATE: String = {
-        proc_macro_crate::crate_name("pin-project")
-            .expect("pin-project-internal was used without pin-project!")
-    };
-}

--- a/pin-project-internal/src/utils.rs
+++ b/pin-project-internal/src/utils.rs
@@ -94,31 +94,6 @@ impl VecExt for Vec<Attribute> {
     }
 }
 
-/// If the 'renamed' feature is enabled, we detect
-/// the actual name of the 'pin-project' crate in the consumer's Cargo.toml.
-#[cfg(feature = "renamed")]
-pub(crate) fn crate_path() -> Ident {
-    // This is fairly subtle.
-    // Normally, you would use `env!("CARGO_PKG_NAME")` to get the name of the package,
-    // since it's set at compile time.
-    // However, we're in a proc macro, which runs while *another* crate is being compiled.
-    // By retreiving the runtime value of `CARGO_PKG_NAME`, we can figure out the name
-    // of the crate that's calling us.
-    let cur_crate = std::env::var("CARGO_PKG_NAME")
-        .expect("Could not find CARGO_PKG_NAME environemnt variable");
-    format_ident!(
-        "{}",
-        if cur_crate == "pin-project" { "pin_project" } else { crate::PIN_PROJECT_CRATE.as_str() },
-    )
-}
-
-/// If the 'renamed' feature is not enabled, we just
-/// assume that the 'pin-project' dependency has not been renamed.
-#[cfg(not(feature = "renamed"))]
-pub(crate) fn crate_path() -> Ident {
-    format_ident!("pin_project")
-}
-
 macro_rules! error {
     ($span:expr, $msg:expr) => {
         syn::Error::new_spanned(&$span, $msg)


### PR DESCRIPTION
Unlike using `$crate` with declarative macros, re-export of procedural macros are not supported even if `proc-macro-crate` is used.
Also, crate name matches the macro name, so I don't think there is a need to rename it.

Related: https://github.com/taiki-e/pin-project/pull/18#discussion_r307995504