### PR TITLE
Release 0.4.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Unreleased
 
+# 0.4.0-beta.1 - 2019-09-21
+
+* [Changed the argument type of project method back to `self: Pin<&mut Self>`.][90]
+
+* [Removed "project_attr" feature and always enable `#[project]` attribute.][94]
+
+* [Removed "renamed" feature.][100]
+
+* [`#[project]` attribute can now be used for `use` statements.][85]
+
+* [Added `project_ref` method and `#[project_ref]` attribute.][93]
+
+* [`#[pin_project]` attribute now determines the visibility of the projection type/method is based on the original type.][96]
+
+[85]: https://github.com/taiki-e/pin-project/pull/85
+[90]: https://github.com/taiki-e/pin-project/pull/90
+[93]: https://github.com/taiki-e/pin-project/pull/93
+[94]: https://github.com/taiki-e/pin-project/pull/94
+[96]: https://github.com/taiki-e/pin-project/pull/96
+[100]: https://github.com/taiki-e/pin-project/pull/100
+
 # 0.4.0-alpha.11 - 2019-09-11
 
 * [Changed #[pinned_drop] to trait implementation.][86]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pin-project"
-version = "0.4.0-alpha.11"
+version = "0.4.0-beta.1"
 authors = ["Taiki Endo <te316e89@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0/MIT"
@@ -20,7 +20,7 @@ all-features = true
 members = ["pin-project-internal"]
 
 [dependencies]
-pin-project-internal = { version = "=0.4.0-alpha.11", path = "pin-project-internal", default-features = false }
+pin-project-internal = { version = "=0.4.0-beta.1", path = "pin-project-internal", default-features = false }
 
 [dev-dependencies]
 compiletest = { version = "0.3.21", package = "compiletest_rs", features = ["stable", "tmp"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ documentation = "https://docs.rs/pin-project/"
 keywords = ["pin", "macros", "attribute"]
 categories = ["rust-patterns"]
 readme = "README.md"
-description = "A crate for safe and ergonomic pin-projection."
+description = """
+A crate for safe and ergonomic pin-projection.
+"""
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-pin-project = "0.4.0-alpha.11"
+pin-project = "0.4.0-beta.1"
 ```
 
 The current pin-project requires Rust 1.33 or later.

--- a/pin-project-internal/Cargo.toml
+++ b/pin-project-internal/Cargo.toml
@@ -8,7 +8,9 @@ repository = "https://github.com/taiki-e/pin-project"
 documentation = "https://docs.rs/pin-project-internal/"
 keywords = ["pin", "macros", "attribute"]
 categories = ["rust-patterns"]
-description = "An internal crate to support pin_project - do not use directly"
+description = """
+An internal crate to support pin_project - do not use directly
+"""
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pin-project-internal/Cargo.toml
+++ b/pin-project-internal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pin-project-internal"
-version = "0.4.0-alpha.11"
+version = "0.4.0-beta.1"
 authors = ["Taiki Endo <te316e89@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0/MIT"
@@ -24,4 +24,4 @@ quote = "1.0"
 syn = { version = "1.0", features = ["full", "visit-mut"] }
 
 [dev-dependencies]
-pin-project = { version = "0.4.0-alpha.11", path = ".." }
+pin-project = { version = "0.4.0-beta.1", path = ".." }

--- a/pin-project-internal/src/lib.rs
+++ b/pin-project-internal/src/lib.rs
@@ -1,7 +1,7 @@
 //! An internal crate to support pin_project - **do not use directly**
 
 #![recursion_limit = "256"]
-#![doc(html_root_url = "https://docs.rs/pin-project-internal/0.4.0-alpha.11")]
+#![doc(html_root_url = "https://docs.rs/pin-project-internal/0.4.0-beta.1")]
 #![doc(test(
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms, single_use_lifetimes), allow(dead_code))
@@ -313,7 +313,7 @@ use utils::{Immutable, Mutable};
 /// [`Pin::as_mut`]: core::pin::Pin::as_mut
 /// [`Pin::set`]: core::pin::Pin::set
 /// [`drop`]: Drop::drop
-/// [`UnsafeUnpin`]: https://docs.rs/pin-project/0.4.0-alpha.11/pin_project/trait.UnsafeUnpin.html
+/// [`UnsafeUnpin`]: https://docs.rs/pin-project/0.4.0-beta.1/pin_project/trait.UnsafeUnpin.html
 /// [`project`]: ./attr.project.html
 /// [`project_ref`]: ./attr.project_ref.html
 /// [`pinned_drop`]: ./attr.pinned_drop.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,13 +34,13 @@
 //!
 //! There are examples and generated code of each feature in [examples](https://github.com/taiki-e/pin-project/blob/master/examples/README.md) directory.
 //!
-//! [`pin_project`]: https://docs.rs/pin-project-internal/0.4.0-alpha.11/pin_project_internal/attr.pin_project.html
-//! [`pinned_drop`]: https://docs.rs/pin-project-internal/0.4.0-alpha.11/pin_project_internal/attr.pinned_drop.html
-//! [`project`]: https://docs.rs/pin-project-internal/0.4.0-alpha.11/pin_project_internal/attr.project.html
+//! [`pin_project`]: https://docs.rs/pin-project-internal/0.4.0-beta.1/pin_project_internal/attr.pin_project.html
+//! [`pinned_drop`]: https://docs.rs/pin-project-internal/0.4.0-beta.1/pin_project_internal/attr.pinned_drop.html
+//! [`project`]: https://docs.rs/pin-project-internal/0.4.0-beta.1/pin_project_internal/attr.project.html
 
 #![no_std]
 #![recursion_limit = "256"]
-#![doc(html_root_url = "https://docs.rs/pin-project/0.4.0-alpha.11")]
+#![doc(html_root_url = "https://docs.rs/pin-project/0.4.0-beta.1")]
 #![doc(test(
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms, single_use_lifetimes), allow(dead_code))
@@ -116,7 +116,7 @@ pub use pin_project_internal::project_ref;
 /// ```
 ///
 /// [`PhantomPinned`]: core::marker::PhantomPinned
-/// [`pin_project`]: https://docs.rs/pin-project-internal/0.4.0-alpha.11/pin_project_internal/attr.pin_project.html
+/// [`pin_project`]: https://docs.rs/pin-project-internal/0.4.0-beta.1/pin_project_internal/attr.pin_project.html
 #[allow(unsafe_code)]
 pub unsafe trait UnsafeUnpin {}
 


### PR DESCRIPTION
Changes:

* [Changed the argument type of project method back to `self: Pin<&mut Self>`.][90]

* [Removed "project_attr" feature and always enable `#[project]` attribute.][94]

* [Removed "renamed" feature.][100]

* [`#[project]` attribute can now be used for `use` statements.][85]

* [Added `project_ref` method and `#[project_ref]` attribute.][93]

* [`#[pin_project]` attribute now determines the visibility of the projection type/method is based on the original type.][96]

cc #21

[85]: https://github.com/taiki-e/pin-project/pull/85
[90]: https://github.com/taiki-e/pin-project/pull/90
[93]: https://github.com/taiki-e/pin-project/pull/93
[94]: https://github.com/taiki-e/pin-project/pull/94
[96]: https://github.com/taiki-e/pin-project/pull/96
[100]: https://github.com/taiki-e/pin-project/pull/100