### PR TITLE
Add a dummy lifetime to Wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ A crate for safe and ergonomic pin-projection.
 
 [Documentation][docs-url]
 
+[Examples](examples/README.md)
+
 ## Usage
 
 Add this to your `Cargo.toml`:

--- a/examples/unsafe_unpin-expanded.rs
+++ b/examples/unsafe_unpin-expanded.rs
@@ -62,8 +62,9 @@ impl<T, U> Foo<T, U> {
 
 unsafe impl<T: Unpin, U> UnsafeUnpin for Foo<T, U> {}
 
-impl<T, U> ::core::marker::Unpin for Foo<T, U> where
-    ::pin_project::__private::Wrapper<Self>: ::pin_project::UnsafeUnpin
+#[allow(single_use_lifetimes)]
+impl<'_pin, T, U> ::core::marker::Unpin for Foo<T, U> where
+    ::pin_project::__private::Wrapper<'_pin, Self>: ::pin_project::UnsafeUnpin
 {
 }
 

--- a/pin-project-internal/src/lib.rs
+++ b/pin-project-internal/src/lib.rs
@@ -136,6 +136,10 @@ use utils::{Immutable, Mutable};
 /// }
 /// ```
 ///
+/// Note that borrowing the field where `#[pin]` attribute is used multiple
+/// times requires using [`.as_mut()`][`Pin::as_mut`] to avoid
+/// consuming the `Pin`.
+///
 /// If you want to implement [`Unpin`] manually, you must use the `UnsafeUnpin`
 /// argument to `#[pin_project]`.
 ///
@@ -167,11 +171,7 @@ use utils::{Immutable, Mutable};
 /// are being used. If you implement [`UnsafeUnpin`], you must ensure that it is
 /// only implemented when all pin-projected fields implement [`Unpin`].
 ///
-/// Note that borrowing the field where `#[pin]` attribute is used multiple
-/// times requires using [`.as_mut()`][`Pin::as_mut`] to avoid
-/// consuming the `Pin`.
-///
-/// See also [`UnsafeUnpin`] trait.
+/// See [`UnsafeUnpin`] trait for more details.
 ///
 /// ### `#[pinned_drop]`
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ pub unsafe trait UnsafeUnpin {}
 #[doc(hidden)]
 pub mod __private {
     use super::UnsafeUnpin;
-    use core::pin::Pin;
+    use core::{marker::PhantomData, pin::Pin};
 
     #[doc(hidden)]
     pub use pin_project_internal::__PinProjectAutoImplUnpin;
@@ -195,8 +195,8 @@ pub mod __private {
     // to making the type never implement Unpin), or provide an impl of `UnsafeUnpin`.
     // It is impossible for them to provide an impl of `Unpin`
     #[doc(hidden)]
-    pub struct Wrapper<T>(T);
+    pub struct Wrapper<'a, T>(T, PhantomData<&'a ()>);
 
     #[allow(unsafe_code)]
-    unsafe impl<T> UnsafeUnpin for Wrapper<T> where T: UnsafeUnpin {}
+    unsafe impl<T> UnsafeUnpin for Wrapper<'_, T> where T: UnsafeUnpin {}
 }

--- a/tests/ui/unsafe_unpin/not-implement-unsafe-unpin.rs
+++ b/tests/ui/unsafe_unpin/not-implement-unsafe-unpin.rs
@@ -1,7 +1,5 @@
 // compile-fail
 
-// FIXME?
-
 use pin_project::pin_project;
 
 #[pin_project(UnsafeUnpin)]

--- a/tests/ui/unsafe_unpin/not-implement-unsafe-unpin.stderr
+++ b/tests/ui/unsafe_unpin/not-implement-unsafe-unpin.stderr
@@ -1,13 +1,13 @@
 error[E0277]: the trait bound `Foo<(), ()>: pin_project::UnsafeUnpin` is not satisfied
-  --> $DIR/forget-unsafe-unpin-impl.rs:17:16
+  --> $DIR/not-implement-unsafe-unpin.rs:15:16
    |
-14 | fn is_unpin<T: Unpin>() {}
+12 | fn is_unpin<T: Unpin>() {}
    |    --------    ----- required by this bound in `is_unpin`
 ...
-17 |     is_unpin::<Foo<(), ()>>(); //~ ERROR E0277
+15 |     is_unpin::<Foo<(), ()>>(); //~ ERROR E0277
    |                ^^^^^^^^^^^ the trait `pin_project::UnsafeUnpin` is not implemented for `Foo<(), ()>`
    |
-   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `pin_project::__private::Wrapper<Foo<(), ()>>`
+   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `pin_project::__private::Wrapper<'_, Foo<(), ()>>`
    = note: required because of the requirements on the impl of `std::marker::Unpin` for `Foo<(), ()>`
 
 error: aborting due to previous error

--- a/tests/ui/unsafe_unpin/proper_unpin.stderr
+++ b/tests/ui/unsafe_unpin/proper_unpin.stderr
@@ -1,18 +1,75 @@
 error[E0277]: the trait bound `std::marker::PhantomPinned: std::marker::Unpin` is not satisfied
-  --> $DIR/proper_unpin.rs:18:5
+  --> $DIR/proper_unpin.rs:37:5
    |
-15 | fn is_unpin<T: Unpin>() {}
+6  | fn is_unpin<T: Unpin>() {}
    |    --------    ----- required by this bound in `is_unpin`
 ...
-18 |     is_unpin::<Foo<PhantomPinned, PhantomPinned>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+37 |     is_unpin::<Blah<PhantomPinned, ()>>(); //~ ERROR E0277
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
    |
    = help: the following implementations were found:
              <std::marker::PhantomPinned as std::marker::Unpin>
-   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `Foo<std::marker::PhantomPinned, std::marker::PhantomPinned>`
-   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `pin_project::__private::Wrapper<Foo<std::marker::PhantomPinned, std::marker::PhantomPinned>>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Foo<std::marker::PhantomPinned, std::marker::PhantomPinned>`
+   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `Blah<std::marker::PhantomPinned, ()>`
+   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `pin_project::__private::Wrapper<'_, Blah<std::marker::PhantomPinned, ()>>`
+   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Blah<std::marker::PhantomPinned, ()>`
 
-error: aborting due to previous error
+error[E0277]: the trait bound `std::marker::PhantomPinned: std::marker::Unpin` is not satisfied
+  --> $DIR/proper_unpin.rs:38:5
+   |
+6  | fn is_unpin<T: Unpin>() {}
+   |    --------    ----- required by this bound in `is_unpin`
+...
+38 |     is_unpin::<Blah<PhantomPinned, PhantomPinned>>(); //~ ERROR E0277
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |
+   = help: the following implementations were found:
+             <std::marker::PhantomPinned as std::marker::Unpin>
+   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `Blah<std::marker::PhantomPinned, std::marker::PhantomPinned>`
+   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `pin_project::__private::Wrapper<'_, Blah<std::marker::PhantomPinned, std::marker::PhantomPinned>>`
+   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Blah<std::marker::PhantomPinned, std::marker::PhantomPinned>`
+
+error[E0277]: the trait bound `NotImplementUnsafUnpin: pin_project::UnsafeUnpin` is not satisfied
+  --> $DIR/proper_unpin.rs:39:16
+   |
+6  | fn is_unpin<T: Unpin>() {}
+   |    --------    ----- required by this bound in `is_unpin`
+...
+39 |     is_unpin::<NotImplementUnsafUnpin>(); //~ ERROR E0277
+   |                ^^^^^^^^^^^^^^^^^^^^^^ the trait `pin_project::UnsafeUnpin` is not implemented for `NotImplementUnsafUnpin`
+   |
+   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `pin_project::__private::Wrapper<'_, NotImplementUnsafUnpin>`
+   = note: required because of the requirements on the impl of `std::marker::Unpin` for `NotImplementUnsafUnpin`
+
+error[E0277]: the trait bound `std::marker::PhantomPinned: std::marker::Unpin` is not satisfied
+  --> $DIR/proper_unpin.rs:40:5
+   |
+6  | fn is_unpin<T: Unpin>() {}
+   |    --------    ----- required by this bound in `is_unpin`
+...
+40 |     is_unpin::<OverlappingLifetimeNames<'_, PhantomPinned, ()>>(); //~ ERROR E0277
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |
+   = help: the following implementations were found:
+             <std::marker::PhantomPinned as std::marker::Unpin>
+   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `OverlappingLifetimeNames<'_, std::marker::PhantomPinned, ()>`
+   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `pin_project::__private::Wrapper<'_, OverlappingLifetimeNames<'_, std::marker::PhantomPinned, ()>>`
+   = note: required because of the requirements on the impl of `std::marker::Unpin` for `OverlappingLifetimeNames<'_, std::marker::PhantomPinned, ()>`
+
+error[E0277]: the trait bound `std::marker::PhantomPinned: std::marker::Unpin` is not satisfied
+  --> $DIR/proper_unpin.rs:41:5
+   |
+6  | fn is_unpin<T: Unpin>() {}
+   |    --------    ----- required by this bound in `is_unpin`
+...
+41 |     is_unpin::<OverlappingLifetimeNames<'_, (), PhantomPinned>>(); //~ ERROR E0277
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |
+   = help: the following implementations were found:
+             <std::marker::PhantomPinned as std::marker::Unpin>
+   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `OverlappingLifetimeNames<'_, (), std::marker::PhantomPinned>`
+   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `pin_project::__private::Wrapper<'_, OverlappingLifetimeNames<'_, (), std::marker::PhantomPinned>>`
+   = note: required because of the requirements on the impl of `std::marker::Unpin` for `OverlappingLifetimeNames<'_, (), std::marker::PhantomPinned>`
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/unstable-features/trivial_bounds-feature-gate.rs
+++ b/tests/ui/unstable-features/trivial_bounds-feature-gate.rs
@@ -7,7 +7,11 @@ use std::marker::PhantomPinned;
 
 struct Inner(PhantomPinned);
 
-#[pin_project] //~ ERROR E0277
+// As a workaround, you need to use `UnsafeUnpin`.
+#[pin_project(UnsafeUnpin)] // Ok
 struct Foo(#[pin] Inner);
+
+#[pin_project] //~ ERROR E0277
+struct Bar(#[pin] Inner);
 
 fn main() {}

--- a/tests/ui/unstable-features/trivial_bounds-feature-gate.stderr
+++ b/tests/ui/unstable-features/trivial_bounds-feature-gate.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `std::marker::PhantomPinned: std::marker::Unpin` is not satisfied in `UnpinStructFoo`
-  --> $DIR/trivial_bounds-feature-gate.rs:10:1
+error[E0277]: the trait bound `std::marker::PhantomPinned: std::marker::Unpin` is not satisfied in `UnpinStructBar`
+  --> $DIR/trivial_bounds-feature-gate.rs:14:1
    |
-10 | #[pin_project] //~ ERROR E0277
-   | ^^^^^^^^^^^^^^ within `UnpinStructFoo`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+14 | #[pin_project] //~ ERROR E0277
+   | ^^^^^^^^^^^^^^ within `UnpinStructBar`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
    |
    = help: the following implementations were found:
              <std::marker::PhantomPinned as std::marker::Unpin>
    = note: required because it appears within the type `Inner`
-   = note: required because it appears within the type `UnpinStructFoo`
+   = note: required because it appears within the type `UnpinStructBar`
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 


### PR DESCRIPTION
If we know that `Self` doesn't implement `Unpin` and `Self` doesn't contain any
generics or lifetimes, we get an error `E0277`.

To avoid this, add a dummy lifetime to the `Wrapper`. This allows
`Wrapper<Self>` to always compile regardless of whether `Self`
implements `UnsafeUnpin`.

As the `Wrapper` implements `UnsafeUnpin` regardless of a lifetime, this
should not change the actual bounds of the `Unpin` implementation.

This allows workaround of #102 that "using `pin_project(UnsafeUnpin)`
and not providing a manual `UnsafeUnpin` implementation" to work.

Closes #102 

cc @Aaron1011 @ogoffart