### PR TITLE
Avoid recompilation with compiletest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,16 +73,10 @@ jobs:
         if: matrix.rust != '1.33.0'
         run: |
           cargo test --all
-      - name: compiletest
-        if: matrix.rust == 'nightly'
-        run: |
-          cargo test -p pin-project --all-features --test compiletest
-        env:
-          RUSTFLAGS: -Dwarnings --cfg compiletest --cfg pin_project_show_unpin_struct
       - name: cargo test --cfg pin_project_show_unpin_struct
         if: matrix.rust == 'nightly'
         run: |
-          cargo test --all --all-features
+          cargo test --all --all-features -- -Zunstable-options --include-ignored
         env:
           RUSTFLAGS: -Dwarnings --cfg pin_project_show_unpin_struct
       # Refs: https://github.com/rust-lang/cargo/issues/5657

--- a/compiletest.sh
+++ b/compiletest.sh
@@ -8,5 +8,5 @@
 # . ./compiletest.sh
 # ```
 
-TRYBUILD=overwrite RUSTFLAGS='--cfg compiletest --cfg pin_project_show_unpin_struct' cargo +nightly test -p pin-project --all-features --test compiletest
-# RUSTFLAGS='--cfg compiletest --cfg pin_project_show_unpin_struct' cargo +nightly test -p pin-project --all-features --test compiletest
+TRYBUILD=overwrite RUSTFLAGS='--cfg pin_project_show_unpin_struct' cargo +nightly test -p pin-project --all-features --test compiletest -- --ignored
+# RUSTFLAGS='--cfg pin_project_show_unpin_struct' cargo +nightly test -p pin-project --all-features --test compiletest -- --ignored

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,7 +1,8 @@
-#![cfg(compiletest)]
 #![cfg(pin_project_show_unpin_struct)]
+#![warn(unsafe_code)]
 #![warn(rust_2018_idioms, single_use_lifetimes)]
 
+#[ignore]
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();


### PR DESCRIPTION
This may reduce CI time because dependencies are recompiled each time `RUSTFLAGS` is changed.
