### PR TITLE
Add Rust 1.36 test to the merge requirement of bors

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,5 +1,6 @@
 status = [
     "test (1.33.0)",
+    "test (1.36.0)",
     "test (stable)",
     "test (beta)",
     "test (nightly)",


### PR DESCRIPTION
I forgot to do this in #137.