### PR TITLE
Fix an issue where PinnedDrop implementations can call unsafe code without an unsafe block

### DIFF
--- a/examples/pinned_drop-expanded.rs
+++ b/examples/pinned_drop-expanded.rs
@@ -94,7 +94,10 @@ impl<T> ::pin_project::__private::PinnedDrop for Foo<'_, T> {
     // Since calling it twice on the same object would be UB,
     // this method is unsafe.
     unsafe fn drop(self: Pin<&mut Self>) {
-        **self.project().was_dropped = true;
+        fn __drop_inner<T>(__self: Pin<&mut Foo<'_, T>>) {
+            **__self.project().was_dropped = true;
+        }
+        __drop_inner(self);
     }
 }
 

--- a/tests/pinned_drop.rs
+++ b/tests/pinned_drop.rs
@@ -25,3 +25,107 @@ fn safe_project() {
     drop(Foo { was_dropped: &mut was_dropped, field: 42 });
     assert!(was_dropped);
 }
+
+#[test]
+fn test_mut_argument() {
+    #[pin_project(PinnedDrop)]
+    struct Struct {
+        data: usize,
+    }
+
+    #[pinned_drop]
+    impl PinnedDrop for Struct {
+        fn drop(mut self: Pin<&mut Self>) {
+            let _: &mut _ = &mut self.data;
+        }
+    }
+}
+
+#[test]
+fn test_self_in_vec() {
+    #[pin_project(PinnedDrop)]
+    struct Struct {
+        data: usize,
+    }
+
+    #[pinned_drop]
+    impl PinnedDrop for Struct {
+        fn drop(self: Pin<&mut Self>) {
+            let _: Vec<_> = vec![self.data];
+        }
+    }
+}
+
+#[test]
+fn test_self_in_macro_containing_fn() {
+    #[pin_project(PinnedDrop)]
+    pub struct Struct {
+        data: usize,
+    }
+
+    macro_rules! emit {
+        ($($tt:tt)*) => {
+            $($tt)*
+        };
+    }
+
+    #[pinned_drop]
+    impl PinnedDrop for Struct {
+        fn drop(self: Pin<&mut Self>) {
+            let _ = emit!({
+                impl Struct {
+                    pub fn f(self) {}
+                }
+            });
+            self.data;
+        }
+    }
+}
+
+#[test]
+fn test_call_self() {
+    #[pin_project(PinnedDrop)]
+    pub struct Struct {
+        data: usize,
+    }
+
+    trait Trait {
+        fn self_ref(&self) {}
+        fn self_pin_ref(self: Pin<&Self>) {}
+        fn self_mut(&mut self) {}
+        fn self_pin_mut(self: Pin<&mut Self>) {}
+        fn assoc_fn(_this: Pin<&mut Self>) {}
+    }
+
+    impl Trait for Struct {}
+
+    #[pinned_drop]
+    impl PinnedDrop for Struct {
+        fn drop(mut self: Pin<&mut Self>) {
+            self.self_ref();
+            self.as_ref().self_pin_ref();
+            self.self_mut();
+            self.as_mut().self_pin_mut();
+            Self::assoc_fn(self.as_mut());
+            <Self>::assoc_fn(self.as_mut());
+        }
+    }
+}
+
+#[test]
+fn test_self_match() {
+    #[pin_project(PinnedDrop)]
+    pub struct TupleStruct(usize);
+
+    #[pinned_drop]
+    impl PinnedDrop for TupleStruct {
+        #[allow(irrefutable_let_patterns)]
+        fn drop(mut self: Pin<&mut Self>) {
+            match *self {
+                Self(_) => {}
+            }
+            if let Self(_) = *self {}
+            let _: Self = Self(0);
+        }
+    }
+}

--- a/tests/ui/pin_project/self-in-where-clause.rs
+++ b/tests/ui/pin_project/self-in-where-clause.rs
@@ -1,0 +1,14 @@
+use pin_project::pin_project;
+
+trait Trait {}
+
+#[pin_project]
+pub struct Struct<T>
+where
+    Self: Trait, //~ ERROR cannot find type `Self` in this scope [E0411]
+{
+    x: usize,
+    y: T,
+}
+
+fn main() {}

--- a/tests/ui/pin_project/self-in-where-clause.stderr
+++ b/tests/ui/pin_project/self-in-where-clause.stderr
@@ -1,0 +1,32 @@
+error[E0411]: cannot find type `Self` in this scope
+ --> $DIR/self-in-where-clause.rs:8:5
+  |
+8 |     Self: Trait, //~ ERROR cannot find type `Self` in this scope [E0411]
+  |     ^^^^ `Self` is only available in impls, traits, and type definitions
+
+error[E0277]: the trait bound `__Struct<'pin, T>: Trait` is not satisfied
+ --> $DIR/self-in-where-clause.rs:5:1
+  |
+5 | #[pin_project]
+  | ^^^^^^^^^^^^^-
+  | |            |
+  | |            required by `__Struct`
+  | the trait `Trait` is not implemented for `__Struct<'pin, T>`
+
+error[E0277]: the trait bound `__StructProjection<'pin, T>: Trait` is not satisfied
+ --> $DIR/self-in-where-clause.rs:5:14
+  |
+5 | #[pin_project]
+  |              ^
+  |              |
+  |              the trait `Trait` is not implemented for `__StructProjection<'pin, T>`
+  |              required by `__StructProjection`
+
+error[E0277]: the trait bound `__StructProjectionRef<'pin, T>: Trait` is not satisfied
+ --> $DIR/self-in-where-clause.rs:5:14
+  |
+5 | #[pin_project]
+  |              ^
+  |              |
+  |              the trait `Trait` is not implemented for `__StructProjectionRef<'pin, T>`
+  |              required by `__StructProjectionRef`

--- a/tests/ui/pinned_drop/ref-self.rs
+++ b/tests/ui/pinned_drop/ref-self.rs
@@ -1,0 +1,12 @@
+use std::pin::Pin;
+
+pub struct Foo {
+    field: u8,
+}
+
+impl Foo {
+    fn method_ref(ref self: Pin<&mut Self>) {} //~ ERROR expected identifier, found keyword `self`
+    fn method_ref_mut(ref mut self: Pin<&mut Self>) {} //~ ERROR expected identifier, found keyword `self`
+}
+
+fn main() {}

--- a/tests/ui/pinned_drop/ref-self.stderr
+++ b/tests/ui/pinned_drop/ref-self.stderr
@@ -1,0 +1,11 @@
+error: expected identifier, found keyword `self`
+ --> $DIR/ref-self.rs:8:23
+  |
+8 |     fn method_ref(ref self: Pin<&mut Self>) {} //~ ERROR expected identifier, found keyword `self`
+  |                       ^^^^ expected identifier, found keyword
+
+error: expected identifier, found keyword `self`
+ --> $DIR/ref-self.rs:9:31
+  |
+9 |     fn method_ref_mut(ref mut self: Pin<&mut Self>) {} //~ ERROR expected identifier, found keyword `self`
+  |                               ^^^^ expected identifier, found keyword

--- a/tests/ui/pinned_drop/self-match.rs
+++ b/tests/ui/pinned_drop/self-match.rs
@@ -1,0 +1,54 @@
+use pin_project::{pin_project, pinned_drop};
+use std::pin::Pin;
+
+#[pin_project(PinnedDrop)]
+pub struct Struct {
+    x: usize,
+}
+
+#[pinned_drop]
+impl PinnedDrop for Struct {
+    fn drop(mut self: Pin<&mut Self>) {
+        match *self {
+            Self { x: _ } => {} //~ ERROR can't use generic parameters from outer function [E0401]
+        }
+        if let Self { x: _ } = *self {} //~ ERROR can't use generic parameters from outer function [E0401]
+        let _: Self = Self { x: 0 }; //~ ERROR can't use generic parameters from outer function [E0401]
+    }
+}
+
+#[pin_project(PinnedDrop)]
+pub struct TupleStruct(usize);
+
+#[pinned_drop]
+impl PinnedDrop for TupleStruct {
+    fn drop(mut self: Pin<&mut Self>) {
+        match *self {
+            Self(_) => {}
+        }
+        if let Self(_) = *self {}
+        let _: Self = Self(0);
+    }
+}
+
+#[pin_project(PinnedDrop)]
+pub enum Enum {
+    StructVariant { x: usize },
+    TupleVariant(usize),
+}
+
+#[pinned_drop]
+impl PinnedDrop for Enum {
+    fn drop(mut self: Pin<&mut Self>) {
+        match *self {
+            Self::StructVariant { x: _ } => {} //~ ERROR can't use generic parameters from outer function [E0401]
+            Self::TupleVariant(_) => {} //~ ERROR can't use generic parameters from outer function [E0401]
+        }
+        if let Self::StructVariant { x: _ } = *self {} //~ ERROR can't use generic parameters from outer function [E0401]
+        if let Self::TupleVariant(_) = *self {} //~ ERROR can't use generic parameters from outer function [E0401]
+        let _: Self = Self::StructVariant { x: 0 }; //~ ERROR can't use generic parameters from outer function [E0401]
+        let _: Self = Self::TupleVariant(0);
+    }
+}
+
+fn main() {}

--- a/tests/ui/pinned_drop/self-match.stderr
+++ b/tests/ui/pinned_drop/self-match.stderr
@@ -1,0 +1,95 @@
+error[E0401]: can't use generic parameters from outer function
+  --> $DIR/self-match.rs:13:13
+   |
+10 | impl PinnedDrop for Struct {
+   | ---- `Self` type implicitly declared here, by this `impl`
+...
+13 |             Self { x: _ } => {} //~ ERROR can't use generic parameters from outer function [E0401]
+   |             ^^^^
+   |             |
+   |             use of generic parameter from outer function
+   |             use a type here instead
+
+error[E0401]: can't use generic parameters from outer function
+  --> $DIR/self-match.rs:15:16
+   |
+10 | impl PinnedDrop for Struct {
+   | ---- `Self` type implicitly declared here, by this `impl`
+...
+15 |         if let Self { x: _ } = *self {} //~ ERROR can't use generic parameters from outer function [E0401]
+   |                ^^^^
+   |                |
+   |                use of generic parameter from outer function
+   |                use a type here instead
+
+error[E0401]: can't use generic parameters from outer function
+  --> $DIR/self-match.rs:16:23
+   |
+10 | impl PinnedDrop for Struct {
+   | ---- `Self` type implicitly declared here, by this `impl`
+...
+16 |         let _: Self = Self { x: 0 }; //~ ERROR can't use generic parameters from outer function [E0401]
+   |                       ^^^^
+   |                       |
+   |                       use of generic parameter from outer function
+   |                       use a type here instead
+
+error[E0401]: can't use generic parameters from outer function
+  --> $DIR/self-match.rs:44:13
+   |
+41 | impl PinnedDrop for Enum {
+   | ---- `Self` type implicitly declared here, by this `impl`
+...
+44 |             Self::StructVariant { x: _ } => {} //~ ERROR can't use generic parameters from outer function [E0401]
+   |             ^^^^^^^^^^^^^^^^^^^
+   |             |
+   |             use of generic parameter from outer function
+   |             use a type here instead
+
+error[E0401]: can't use generic parameters from outer function
+  --> $DIR/self-match.rs:45:13
+   |
+41 | impl PinnedDrop for Enum {
+   | ---- `Self` type implicitly declared here, by this `impl`
+...
+45 |             Self::TupleVariant(_) => {} //~ ERROR can't use generic parameters from outer function [E0401]
+   |             ^^^^^^^^^^^^^^^^^^
+   |             |
+   |             use of generic parameter from outer function
+   |             use a type here instead
+
+error[E0401]: can't use generic parameters from outer function
+  --> $DIR/self-match.rs:47:16
+   |
+41 | impl PinnedDrop for Enum {
+   | ---- `Self` type implicitly declared here, by this `impl`
+...
+47 |         if let Self::StructVariant { x: _ } = *self {} //~ ERROR can't use generic parameters from outer function [E0401]
+   |                ^^^^^^^^^^^^^^^^^^^
+   |                |
+   |                use of generic parameter from outer function
+   |                use a type here instead
+
+error[E0401]: can't use generic parameters from outer function
+  --> $DIR/self-match.rs:48:16
+   |
+41 | impl PinnedDrop for Enum {
+   | ---- `Self` type implicitly declared here, by this `impl`
+...
+48 |         if let Self::TupleVariant(_) = *self {} //~ ERROR can't use generic parameters from outer function [E0401]
+   |                ^^^^^^^^^^^^^^^^^^
+   |                |
+   |                use of generic parameter from outer function
+   |                use a type here instead
+
+error[E0401]: can't use generic parameters from outer function
+  --> $DIR/self-match.rs:49:23
+   |
+41 | impl PinnedDrop for Enum {
+   | ---- `Self` type implicitly declared here, by this `impl`
+...
+49 |         let _: Self = Self::StructVariant { x: 0 }; //~ ERROR can't use generic parameters from outer function [E0401]
+   |                       ^^^^^^^^^^^^^^^^^^^
+   |                       |
+   |                       use of generic parameter from outer function
+   |                       use a type here instead

--- a/tests/ui/pinned_drop/unsafe-code.rs
+++ b/tests/ui/pinned_drop/unsafe-code.rs
@@ -1,0 +1,17 @@
+use pin_project::{pin_project, pinned_drop};
+use std::pin::Pin;
+
+#[pin_project(PinnedDrop)]
+pub struct Foo {
+    #[pin]
+    field: u8,
+}
+
+#[pinned_drop]
+impl PinnedDrop for Foo {
+    fn drop(self: Pin<&mut Self>) {
+        self.project().field.get_unchecked_mut(); //~ ERROR call to unsafe function is unsafe and requires unsafe function or block [E0133]
+    }
+}
+
+fn main() {}

--- a/tests/ui/pinned_drop/unsafe-code.stderr
+++ b/tests/ui/pinned_drop/unsafe-code.stderr
@@ -1,0 +1,7 @@
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/unsafe-code.rs:13:9
+   |
+13 |         self.project().field.get_unchecked_mut(); //~ ERROR call to unsafe function is unsafe and requires unsafe function or block [E0133]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior


### PR DESCRIPTION
This change will generate code similar to the following:

from:

```rust
impl PinnedDrop for Foo {
    fn drop(self: Pin<&mut Self>) {
        // ...
    }
}
```
into:
```rust
impl PinnedDrop for Foo {
    unsafe fn drop(self: Pin<&mut Self>) {
        fn __drop_inner<T>(__self: Pin<&mut Foo<'_, T>>) {
            // ...
        }
        __drop_inner(self);
    }
}
```

Fixes #148 
