### PR TITLE
Remove #![warn(clippy::pedantic)]

### DIFF
--- a/examples/pinned_drop-expanded.rs
+++ b/examples/pinned_drop-expanded.rs
@@ -32,14 +32,14 @@ pub struct Foo<'a, T> {
     field: T,
 }
 
-#[allow(clippy::mut_mut)]
-#[allow(dead_code)]
+#[allow(clippy::mut_mut)] // This lint warns `&mut &mut <ty>`.
+#[allow(dead_code)] // This lint warns unused fields/variants.
 pub(crate) struct __FooProjection<'pin, 'a, T> {
     was_dropped: &'pin mut &'a mut bool,
     field: ::core::pin::Pin<&'pin mut T>,
 }
 
-#[allow(dead_code)]
+#[allow(dead_code)] // This lint warns unused fields/variants.
 pub(crate) struct __FooProjectionRef<'pin, 'a, T> {
     was_dropped: &'pin &'a mut bool,
     field: ::core::pin::Pin<&'pin T>,

--- a/examples/unsafe_unpin-expanded.rs
+++ b/examples/unsafe_unpin-expanded.rs
@@ -27,13 +27,13 @@ pub struct Foo<T, U> {
     unpinned: U,
 }
 
-#[allow(clippy::mut_mut)]
-#[allow(dead_code)]
+#[allow(clippy::mut_mut)] // This lint warns `&mut &mut <ty>`.
+#[allow(dead_code)] // This lint warns unused fields/variants.
 pub(crate) struct __FooProjection<'pin, T, U> {
     pinned: ::core::pin::Pin<&'pin mut T>,
     unpinned: &'pin mut U,
 }
-#[allow(dead_code)]
+#[allow(dead_code)] // This lint warns unused fields/variants.
 pub(crate) struct __FooProjectionRef<'pin, T, U> {
     pinned: ::core::pin::Pin<&'pin T>,
     unpinned: &'pin U,

--- a/pin-project-internal/src/lib.rs
+++ b/pin-project-internal/src/lib.rs
@@ -8,8 +8,8 @@
 ))]
 #![warn(unsafe_code)]
 #![warn(rust_2018_idioms, single_use_lifetimes, unreachable_pub)]
-#![warn(clippy::all, clippy::pedantic)]
-#![allow(clippy::use_self, clippy::needless_doctest_main, clippy::must_use_candidate)]
+#![warn(clippy::all)]
+#![allow(clippy::needless_doctest_main)]
 // While this crate supports stable Rust, it currently requires
 // nightly Rust in order for rustdoc to correctly document auto-generated
 // `Unpin` impls. This does not affect the runtime functionality of this crate,

--- a/pin-project-internal/src/pinned_drop.rs
+++ b/pin-project-internal/src/pinned_drop.rs
@@ -210,7 +210,6 @@ struct ReplaceReceiver<'a> {
     self_ty: &'a Type,
 }
 
-#[allow(clippy::similar_names)] // allow `qself`
 impl<'a> ReplaceReceiver<'a> {
     fn new(self_ty: &'a Type) -> Self {
         Self { self_ty }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,8 @@
 ))]
 #![warn(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, single_use_lifetimes, unreachable_pub)]
-#![warn(clippy::all, clippy::pedantic)]
-#![allow(clippy::use_self, clippy::needless_doctest_main, clippy::must_use_candidate)]
+#![warn(clippy::all)]
+#![allow(clippy::needless_doctest_main)]
 
 #[doc(inline)]
 pub use pin_project_internal::pin_project;

--- a/tests/ui/auxiliary/src/lib.rs
+++ b/tests/ui/auxiliary/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(unsafe_code)]
 #![warn(rust_2018_idioms, single_use_lifetimes, unreachable_pub)]
-#![warn(clippy::all, clippy::pedantic)]
-#![allow(clippy::use_self, clippy::must_use_candidate)]
+#![warn(clippy::all)]
 
 extern crate proc_macro;
 


### PR DESCRIPTION
I think pedantic lints are no longer useful.