### PR TITLE
Fix compile error with `dyn` types

### DIFF
--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -370,10 +370,10 @@ impl<'a> Context<'a> {
 
                 let lifetime = &self.proj.lifetime;
                 proj_fields.push(quote! {
-                    #vis #ident: ::core::pin::Pin<&#lifetime mut #ty>
+                    #vis #ident: ::core::pin::Pin<&#lifetime mut (#ty)>
                 });
                 proj_ref_fields.push(quote! {
-                    #vis #ident: ::core::pin::Pin<&#lifetime #ty>
+                    #vis #ident: ::core::pin::Pin<&#lifetime (#ty)>
                 });
                 proj_body.push(quote! {
                     #ident: ::core::pin::Pin::new_unchecked(#ident)
@@ -381,10 +381,10 @@ impl<'a> Context<'a> {
             } else {
                 let lifetime = &self.proj.lifetime;
                 proj_fields.push(quote! {
-                    #vis #ident: &#lifetime mut #ty
+                    #vis #ident: &#lifetime mut (#ty)
                 });
                 proj_ref_fields.push(quote! {
-                    #vis #ident: &#lifetime #ty
+                    #vis #ident: &#lifetime (#ty)
                 });
                 proj_body.push(quote! {
                     #ident
@@ -417,10 +417,10 @@ impl<'a> Context<'a> {
 
                 let lifetime = &self.proj.lifetime;
                 proj_fields.push(quote! {
-                    #vis ::core::pin::Pin<&#lifetime mut #ty>
+                    #vis ::core::pin::Pin<&#lifetime mut (#ty)>
                 });
                 proj_ref_fields.push(quote! {
-                    #vis ::core::pin::Pin<&#lifetime #ty>
+                    #vis ::core::pin::Pin<&#lifetime (#ty)>
                 });
                 proj_body.push(quote! {
                     ::core::pin::Pin::new_unchecked(#id)
@@ -428,10 +428,10 @@ impl<'a> Context<'a> {
             } else {
                 let lifetime = &self.proj.lifetime;
                 proj_fields.push(quote! {
-                    #vis &#lifetime mut #ty
+                    #vis &#lifetime mut (#ty)
                 });
                 proj_ref_fields.push(quote! {
-                    #vis &#lifetime #ty
+                    #vis &#lifetime (#ty)
                 });
                 proj_body.push(quote! {
                     #id

--- a/tests/ui/pin_project/run-pass/dyn-type.rs
+++ b/tests/ui/pin_project/run-pass/dyn-type.rs
@@ -1,0 +1,29 @@
+use pin_project::pin_project;
+
+#[pin_project]
+struct Struct1 {
+    a: i32,
+    f: dyn std::fmt::Debug,
+}
+
+#[pin_project]
+struct Struct2 {
+    a: i32,
+    #[pin]
+    f: dyn std::fmt::Debug,
+}
+
+#[pin_project]
+struct Struct3 {
+    a: i32,
+    f: dyn std::fmt::Debug + Send,
+}
+
+#[pin_project]
+struct Struct4 {
+    a: i32,
+    #[pin]
+    f: dyn std::fmt::Debug + Send,
+}
+
+fn main() {}


### PR DESCRIPTION
Add parentheses around original types in generated code.

Currently, it will cause a compile error when field type is like `dyn Trait1 + Trait2`.
```rust
use pin_project::pin_project;
#[pin_project]
struct Struct {
    a: i32,
    #[pin]
    f: dyn std::fmt::Debug + Send,
}
```
will result in,
```
error: ambiguous `+` in a type
 --> src/main.rs:6:8
  |
6 |     f: dyn std::fmt::Debug + Send,
  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use parentheses to disambiguate: `(dyn std::fmt::Debug + Send)`

error: proc-macro derive produced unparseable tokens
 --> src/main.rs:2:1
  |
2 | #[pin_project]
  | ^^^^^^^^^^^^^^
```
