### PR TITLE
Ensure that users cannot implement `PinnedDrop` without proper attr

### DIFF
--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -611,7 +611,6 @@ impl Context {
         let ident = &self.orig.ident;
         let (impl_generics, ty_generics, where_clause) = self.orig.generics.split_for_impl();
 
-
         let private = Ident::new(CURRENT_PRIVATE_MODULE, Span::call_site());
         if let Some(pinned_drop) = self.pinned_drop {
             // Make the error message highlight `PinnedDrop` argument.

--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -677,6 +677,7 @@ impl Context {
                 // impls, we emit one ourselves. If the user ends up writing a `PinnedDrop` impl,
                 // they'll get a "conflicting implementations of trait" error when coherence
                 // checks are run
+                #[allow(single_use_lifetimes)]
                 impl #impl_generics ::pin_project::#private::PinnedDrop for #ident #ty_generics #where_clause {
                     unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
                 }

--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -611,8 +611,9 @@ impl Context {
         let ident = &self.orig.ident;
         let (impl_generics, ty_generics, where_clause) = self.orig.generics.split_for_impl();
 
+
+        let private = Ident::new(CURRENT_PRIVATE_MODULE, Span::call_site());
         if let Some(pinned_drop) = self.pinned_drop {
-            let private = Ident::new(CURRENT_PRIVATE_MODULE, Span::call_site());
             // Make the error message highlight `PinnedDrop` argument.
             // See https://github.com/taiki-e/pin-project/issues/16#issuecomment-513586812
             // for why this is only for the span of function calls, not the entire `impl` block.
@@ -666,6 +667,20 @@ impl Context {
                 impl<T: ::core::ops::Drop> #trait_ident for T {}
                 #[allow(single_use_lifetimes)]
                 impl #impl_generics #trait_ident for #ident #ty_generics #where_clause {}
+
+                // A dummy impl of `PinnedDrop`, to ensure that the user cannot implement it.
+                // Since the user did not pass `PinnedDrop` to `#[pin_project]`, any `PinnedDrop`
+                // impl will not actually be called. Unfortunately, we can't detect this situation
+                // directly from either the `#[pin_project]` or `#[pinned_drop]` attributes, since
+                // we don't know what other attirbutes/impl may exist.
+                //
+                // To ensure that users don't accidentally write a non-functional `PinnedDrop`
+                // impls, we emit one ourselves. If the user ends up writing a `PinnedDrop` impl,
+                // they'll get a "conflicting implementations of trait" error when coherence
+                // checks are run
+                impl #impl_generics ::pin_project::#private::PinnedDrop for #ident #ty_generics #where_clause {
+                    unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
+                }
             }
         }
     }

--- a/tests/ui/pinned_drop/pinned-drop-no-attr-arg.rs
+++ b/tests/ui/pinned_drop/pinned-drop-no-attr-arg.rs
@@ -1,0 +1,15 @@
+use pin_project::{pin_project, pinned_drop};
+use std::pin::Pin;
+
+#[pin_project]
+struct Foo {
+    #[pin]
+    field: u8,
+}
+
+#[pinned_drop]
+impl PinnedDrop for Foo { //~ ERROR E0119
+    fn drop(self: Pin<&mut Self>) {}
+}
+
+fn main() {}

--- a/tests/ui/pinned_drop/pinned-drop-no-attr-arg.stderr
+++ b/tests/ui/pinned_drop/pinned-drop-no-attr-arg.stderr
@@ -1,0 +1,8 @@
+error[E0119]: conflicting implementations of trait `pin_project::__private::PinnedDrop` for type `Foo`:
+  --> $DIR/pinned-drop-no-attr-arg.rs:11:1
+   |
+4  | #[pin_project]
+   | -------------- first implementation here
+...
+11 | impl PinnedDrop for Foo { //~ ERROR E0119
+   | ^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Foo`


### PR DESCRIPTION
Fixes #179

Previously, it was possible to provide a `#[pinned_drop]` implementation
without annotating the pin-projected type with
`#[pin_project(PinnedDrop)]`. This would result in the `PinnedDrop` impl
never being used, without any warnings or errors being emitted to the
user.

This commit makes us generate a dummy `PinnedDrop` impl if the user does
not pass `PinnedDrop` as an argument to `#[pin_project]`. This dummy
impl will conflict with any user-provided impl, ensuring that the user
cannot accidentally a non-functional `PinnedDrop` impl.