### PR TITLE
Allow `#[project]` to be used on `if let` expressions

### DIFF
--- a/pin-project-internal/src/project.rs
+++ b/pin-project-internal/src/project.rs
@@ -25,7 +25,7 @@ fn replace_stmt(stmt: &mut Stmt, mutability: Mutability) -> Result<()> {
                 if let Some((_, ref mut expr)) = expr_if.else_branch {
                     if let Expr::If(new_expr_if) = &mut **expr {
                         expr_if = new_expr_if;
-                        continue
+                        continue;
                     }
                 }
                 break;

--- a/pin-project-internal/src/project.rs
+++ b/pin-project-internal/src/project.rs
@@ -13,16 +13,32 @@ pub(crate) fn attribute(args: &TokenStream, input: Stmt, mutability: Mutability)
         .unwrap_or_else(|e| e.to_compile_error())
 }
 
-fn parse(mut stmt: Stmt, mutability: Mutability) -> Result<TokenStream> {
-    match &mut stmt {
+fn replace_stmt(stmt: &mut Stmt, mutability: Mutability) -> Result<bool> {
+    match stmt {
         Stmt::Expr(Expr::Match(expr)) | Stmt::Semi(Expr::Match(expr), _) => {
-            Context::new(mutability).replace_expr_match(expr)
+            Context::new(mutability).replace_expr_match(expr);
+            return Ok(true)
+        }
+        Stmt::Expr(Expr::If(expr_if)) => {
+            if let Expr::Let(ref mut expr) = &mut *expr_if.cond {
+                Context::new(mutability).replace_expr_let(expr);
+                return Ok(true);
+            }
         }
         Stmt::Local(local) => Context::new(mutability).replace_local(local)?,
-        Stmt::Item(Item::Fn(item)) => replace_item_fn(item, mutability)?,
-        Stmt::Item(Item::Impl(item)) => replace_item_impl(item, mutability),
-        Stmt::Item(Item::Use(item)) => replace_item_use(item, mutability)?,
         _ => {}
+    }
+    Ok(false)
+}
+
+fn parse(mut stmt: Stmt, mutability: Mutability) -> Result<TokenStream> {
+    if !replace_stmt(&mut stmt, mutability)? {
+        match &mut stmt {
+            Stmt::Item(Item::Fn(item)) => replace_item_fn(item, mutability)?,
+            Stmt::Item(Item::Impl(item)) => replace_item_impl(item, mutability),
+            Stmt::Item(Item::Use(item)) => replace_item_use(item, mutability)?,
+            _ => {}
+        }
     }
 
     Ok(stmt.into_token_stream())
@@ -71,6 +87,10 @@ impl Context {
         }
 
         Ok(())
+    }
+
+    fn replace_expr_let(&mut self, expr: &mut ExprLet) {
+        self.replace_pat(&mut expr.pat, true)
     }
 
     fn replace_expr_match(&mut self, expr: &mut ExprMatch) {
@@ -195,17 +215,18 @@ impl FnVisitor {
                 expr.attrs.find_remove(self.name())?
             }
             Stmt::Local(local) => local.attrs.find_remove(self.name())?,
+            Stmt::Expr(Expr::If(expr_if)) => {
+                if let Expr::Let(_) = &*expr_if.cond {
+                    expr_if.attrs.find_remove(self.name())?
+                } else {
+                    None
+                }
+            }
             _ => return Ok(()),
         };
         if let Some(attr) = attr {
             parse_as_empty(&attr.tokens)?;
-            match node {
-                Stmt::Expr(Expr::Match(expr)) | Stmt::Semi(Expr::Match(expr), _) => {
-                    Context::new(self.mutability).replace_expr_match(expr)
-                }
-                Stmt::Local(local) => Context::new(self.mutability).replace_local(local)?,
-                _ => unreachable!(),
-            }
+            replace_stmt(node, self.mutability)?;
         }
         Ok(())
     }

--- a/pin-project-internal/src/project.rs
+++ b/pin-project-internal/src/project.rs
@@ -17,7 +17,7 @@ fn replace_stmt(stmt: &mut Stmt, mutability: Mutability) -> Result<bool> {
     match stmt {
         Stmt::Expr(Expr::Match(expr)) | Stmt::Semi(Expr::Match(expr), _) => {
             Context::new(mutability).replace_expr_match(expr);
-            return Ok(true)
+            return Ok(true);
         }
         Stmt::Expr(Expr::If(expr_if)) => {
             if let Expr::Let(ref mut expr) = &mut *expr_if.cond {

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -86,6 +86,33 @@ fn project_stmt_expr() {
     assert_eq!(val, true);
 }
 
+#[rustversion::nightly]
+#[test]
+#[project]
+fn project_if_let() {
+    #[pin_project]
+    enum Foo<A, B> {
+        Variant1(#[pin] A),
+        Variant2(u8),
+        Variant3 {
+            #[pin] field: B
+        }
+    }
+
+    let mut foo: Foo<bool, f32> = Foo::Variant1(true);
+    let foo = Pin::new(&mut foo).project();
+
+    #[project]
+    if let Foo::Variant1(a) = foo {
+        let a: Pin<&mut bool> = a;
+        assert_eq!(*a, true);
+    } else if let Foo::Variant2(_) = foo {
+        unreachable!();
+    } else if let Foo::Variant3 { .. } = foo {
+        unreachable!();
+    }
+}
+
 #[test]
 fn project_impl() {
     #[pin_project]

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -2,6 +2,16 @@
 #![warn(rust_2018_idioms, single_use_lifetimes)]
 #![allow(dead_code)]
 
+// This hack is needed until https://github.com/rust-lang/rust/pull/69201
+// makes it way into stable.
+// Ceurrently, `#[attr] if true {}` doesn't even *parse* on stable,
+// which means that it will error even behind a `#[rustversion::nightly]`
+//
+// This trick makes sure that we don't even attempt to parse
+// the `#[project] if let _` test on stable.
+#[rustversion::nightly]
+include!("project_if_attr.rs.in");
+
 use pin_project::{pin_project, project};
 use std::pin::Pin;
 
@@ -84,33 +94,6 @@ fn project_stmt_expr() {
         Baz::None => false,
     };
     assert_eq!(val, true);
-}
-
-#[rustversion::nightly]
-#[test]
-#[project]
-fn project_if_let() {
-    #[pin_project]
-    enum Foo<A, B> {
-        Variant1(#[pin] A),
-        Variant2(u8),
-        Variant3 {
-            #[pin] field: B
-        }
-    }
-
-    let mut foo: Foo<bool, f32> = Foo::Variant1(true);
-    let foo = Pin::new(&mut foo).project();
-
-    #[project]
-    if let Foo::Variant1(a) = foo {
-        let a: Pin<&mut bool> = a;
-        assert_eq!(*a, true);
-    } else if let Foo::Variant2(_) = foo {
-        unreachable!();
-    } else if let Foo::Variant3 { .. } = foo {
-        unreachable!();
-    }
 }
 
 #[test]

--- a/tests/project_if_attr.rs.in
+++ b/tests/project_if_attr.rs.in
@@ -1,0 +1,29 @@
+// FIXME: Once https://github.com/rust-lang/rust/pull/69201 makes its
+// way into stable, move this back into `project.rs
+
+#[test]
+#[project]
+fn project_if_let() {
+    #[pin_project]
+    enum Foo<A, B> {
+        Variant1(#[pin] A),
+        Variant2(u8),
+        Variant3 {
+            #[pin] field: B
+        }
+    }
+
+    let mut foo: Foo<bool, f32> = Foo::Variant1(true);
+    let foo = Pin::new(&mut foo).project();
+
+    #[project]
+    if let Foo::Variant1(a) = foo {
+        let a: Pin<&mut bool> = a;
+        assert_eq!(*a, true);
+    } else if let Foo::Variant2(_) = foo {
+        unreachable!();
+    } else if let Foo::Variant3 { .. } = foo {
+        unreachable!();
+    }
+}
+


### PR DESCRIPTION
This PR would work correctly, except for the fact that
rust-lang/rust#68618 causes a compilation error to be emitted before we
even have a chance to run. That issue is independent of the
implementation of this PR, so this PR should start working automatically
once the issue is resolved.