### PR TITLE
Hide all generated items except for projected types from calling code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,12 +72,10 @@ jobs:
       - name: cargo test
         run: |
           cargo test --all
-      - name: cargo test --cfg pin_project_show_unpin_struct
+      - name: cargo test -- --ignored
         if: matrix.rust == 'nightly'
-        env:
-          RUSTFLAGS: -Dwarnings --cfg pin_project_show_unpin_struct
         run: |
-          cargo test --all --all-features -- -Zunstable-options --include-ignored
+          cargo test --all -- --ignored
       # Refs: https://github.com/rust-lang/cargo/issues/5657
       - name: cargo check -Zminimal-versions
         if: matrix.rust == 'nightly'

--- a/compiletest.sh
+++ b/compiletest.sh
@@ -8,5 +8,5 @@
 # . ./compiletest.sh
 # ```
 
-TRYBUILD=overwrite RUSTFLAGS='--cfg pin_project_show_unpin_struct' cargo +nightly test -p pin-project --all-features --test compiletest -- --ignored
-# RUSTFLAGS='--cfg pin_project_show_unpin_struct' cargo +nightly test -p pin-project --all-features --test compiletest -- --ignored
+TRYBUILD=overwrite cargo +nightly test -p pin-project --all-features --test compiletest -- --ignored
+# cargo +nightly test -p pin-project --all-features --test compiletest -- --ignored

--- a/examples/enum-default-expanded.rs
+++ b/examples/enum-default-expanded.rs
@@ -25,62 +25,75 @@ enum Enum<T, U> {
 
 #[allow(clippy::mut_mut)] // This lint warns `&mut &mut <ty>`.
 #[allow(dead_code)] // This lint warns unused fields/variants.
-enum __EnumProjection<'pin, T, U> {
+enum __EnumProjection<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
     Pinned(::core::pin::Pin<&'pin mut (T)>),
     Unpinned(&'pin mut (U)),
 }
-
 #[allow(dead_code)] // This lint warns unused fields/variants.
-enum __EnumProjectionRef<'pin, T, U> {
+enum __EnumProjectionRef<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
     Pinned(::core::pin::Pin<&'pin (T)>),
     Unpinned(&'pin (U)),
 }
 
-impl<T, U> Enum<T, U> {
-    fn project<'pin>(self: ::core::pin::Pin<&'pin mut Self>) -> __EnumProjection<'pin, T, U> {
-        unsafe {
-            match self.get_unchecked_mut() {
-                Enum::Pinned(_0) => __EnumProjection::Pinned(::core::pin::Pin::new_unchecked(_0)),
-                Enum::Unpinned(_0) => __EnumProjection::Unpinned(_0),
-            }
-        }
-    }
-    fn project_ref<'pin>(self: ::core::pin::Pin<&'pin Self>) -> __EnumProjectionRef<'pin, T, U> {
-        unsafe {
-            match self.get_ref() {
-                Enum::Pinned(_0) => {
-                    __EnumProjectionRef::Pinned(::core::pin::Pin::new_unchecked(_0))
+#[allow(non_upper_case_globals)]
+const __SCOPE_Enum: () = {
+    impl<T, U> Enum<T, U> {
+        fn project<'pin>(self: ::core::pin::Pin<&'pin mut Self>) -> __EnumProjection<'pin, T, U> {
+            unsafe {
+                match self.get_unchecked_mut() {
+                    Enum::Pinned(_0) => {
+                        __EnumProjection::Pinned(::core::pin::Pin::new_unchecked(_0))
+                    }
+                    Enum::Unpinned(_0) => __EnumProjection::Unpinned(_0),
                 }
-                Enum::Unpinned(_0) => __EnumProjectionRef::Unpinned(_0),
+            }
+        }
+        fn project_ref<'pin>(
+            self: ::core::pin::Pin<&'pin Self>,
+        ) -> __EnumProjectionRef<'pin, T, U> {
+            unsafe {
+                match self.get_ref() {
+                    Enum::Pinned(_0) => {
+                        __EnumProjectionRef::Pinned(::core::pin::Pin::new_unchecked(_0))
+                    }
+                    Enum::Unpinned(_0) => __EnumProjectionRef::Unpinned(_0),
+                }
             }
         }
     }
-}
 
-// Automatically create the appropriate conditional `Unpin` implementation.
-//
-// See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/53.
-// for details.
-#[allow(non_snake_case)]
-fn __unpin_scope_Enum() {
+    // Automatically create the appropriate conditional `Unpin` implementation.
+    //
+    // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/53.
+    // for details.
     struct __Enum<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T, U)>,
         __field0: T,
     }
     impl<'pin, T, U> ::core::marker::Unpin for Enum<T, U> where __Enum<'pin, T, U>: ::core::marker::Unpin
     {}
-}
 
-// Ensure that enum does not implement `Drop`.
-//
-// See ./struct-default-expanded.rs for details.
-trait EnumMustNotImplDrop {}
-#[allow(clippy::drop_bounds)]
-impl<T: ::core::ops::Drop> EnumMustNotImplDrop for T {}
-#[allow(single_use_lifetimes)]
-impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
+    // Ensure that enum does not implement `Drop`.
+    //
+    // See ./struct-default-expanded.rs for details.
+    trait EnumMustNotImplDrop {}
+    #[allow(clippy::drop_bounds)]
+    impl<T: ::core::ops::Drop> EnumMustNotImplDrop for T {}
+    #[allow(single_use_lifetimes)]
+    impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
+    #[allow(single_use_lifetimes)]
+    impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
+        unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
+    }
 
-// We don't need to check for '#[repr(packed)]',
-// since it does not apply to enums.
+    // We don't need to check for `#[repr(packed)]`,
+    // since it does not apply to enums.
+};
 
 fn main() {}

--- a/examples/pinned_drop-expanded.rs
+++ b/examples/pinned_drop-expanded.rs
@@ -34,79 +34,84 @@ pub struct Foo<'a, T> {
 
 #[allow(clippy::mut_mut)] // This lint warns `&mut &mut <ty>`.
 #[allow(dead_code)] // This lint warns unused fields/variants.
-pub(crate) struct __FooProjection<'pin, 'a, T> {
+pub(crate) struct __FooProjection<'pin, 'a, T>
+where
+    Foo<'a, T>: 'pin,
+{
     was_dropped: &'pin mut (&'a mut bool),
     field: ::core::pin::Pin<&'pin mut (T)>,
 }
-
 #[allow(dead_code)] // This lint warns unused fields/variants.
-pub(crate) struct __FooProjectionRef<'pin, 'a, T> {
+pub(crate) struct __FooProjectionRef<'pin, 'a, T>
+where
+    Foo<'a, T>: 'pin,
+{
     was_dropped: &'pin (&'a mut bool),
     field: ::core::pin::Pin<&'pin (T)>,
 }
 
-impl<'a, T> Foo<'a, T> {
-    pub(crate) fn project<'pin>(
-        self: ::core::pin::Pin<&'pin mut Self>,
-    ) -> __FooProjection<'pin, 'a, T> {
-        unsafe {
-            let Foo { was_dropped, field } = self.get_unchecked_mut();
-            __FooProjection { was_dropped, field: ::core::pin::Pin::new_unchecked(field) }
+#[allow(non_upper_case_globals)]
+const __SCOPE_Foo: () = {
+    impl<'a, T> Foo<'a, T> {
+        pub(crate) fn project<'pin>(
+            self: ::core::pin::Pin<&'pin mut Self>,
+        ) -> __FooProjection<'pin, 'a, T> {
+            unsafe {
+                let Foo { was_dropped, field } = self.get_unchecked_mut();
+                __FooProjection { was_dropped, field: ::core::pin::Pin::new_unchecked(field) }
+            }
+        }
+        pub(crate) fn project_ref<'pin>(
+            self: ::core::pin::Pin<&'pin Self>,
+        ) -> __FooProjectionRef<'pin, 'a, T> {
+            unsafe {
+                let Foo { was_dropped, field } = self.get_ref();
+                __FooProjectionRef { was_dropped, field: ::core::pin::Pin::new_unchecked(field) }
+            }
         }
     }
-    pub(crate) fn project_ref<'pin>(
-        self: ::core::pin::Pin<&'pin Self>,
-    ) -> __FooProjectionRef<'pin, 'a, T> {
-        unsafe {
-            let Foo { was_dropped, field } = self.get_ref();
-            __FooProjectionRef { was_dropped, field: ::core::pin::Pin::new_unchecked(field) }
-        }
-    }
-}
 
-#[allow(single_use_lifetimes)]
-impl<'a, T> ::core::ops::Drop for Foo<'a, T> {
-    fn drop(&mut self) {
-        // Safety - we're in 'drop', so we know that 'self' will
-        // never move again.
-        let pinned_self = unsafe { ::core::pin::Pin::new_unchecked(self) };
-        // We call `pinned_drop` only once. Since `PinnedDrop::drop`
-        // is an unsafe function and a private API, it is never called again in safe
-        // code *unless the user uses a maliciously crafted macro*.
-        unsafe {
-            ::pin_project::__private::PinnedDrop::drop(pinned_self);
+    #[allow(single_use_lifetimes)]
+    impl<'a, T> ::core::ops::Drop for Foo<'a, T> {
+        fn drop(&mut self) {
+            // Safety - we're in 'drop', so we know that 'self' will
+            // never move again.
+            let pinned_self = unsafe { ::core::pin::Pin::new_unchecked(self) };
+            // We call `pinned_drop` only once. Since `PinnedDrop::drop`
+            // is an unsafe method and a private API, it is never called again in safe
+            // code *unless the user uses a maliciously crafted macro*.
+            unsafe {
+                ::pin_project::__private::PinnedDrop::drop(pinned_self);
+            }
         }
     }
-}
 
-// It is safe to implement PinnedDrop::drop, but it is not safe to call it.
-// This is because destructors can be called multiple times (double dropping
-// is unsound: rust-lang/rust#62360).
-//
-// Ideally, it would be desirable to be able to prohibit manual calls in the
-// same way as Drop::drop, but the library cannot. So, by using macros and
-// replacing them with private traits, we prevent users from calling
-// PinnedDrop::drop.
-//
-// Users can implement `Drop` safely using `#[pinned_drop]`.
-// **Do not call or implement this trait directly.**
-impl<T> ::pin_project::__private::PinnedDrop for Foo<'_, T> {
-    // Since calling it twice on the same object would be UB,
-    // this method is unsafe.
-    unsafe fn drop(self: Pin<&mut Self>) {
-        fn __drop_inner<T>(__self: Pin<&mut Foo<'_, T>>) {
-            **__self.project().was_dropped = true;
+    // It is safe to implement PinnedDrop::drop, but it is not safe to call it.
+    // This is because destructors can be called multiple times (double dropping
+    // is unsound: rust-lang/rust#62360).
+    //
+    // Ideally, it would be desirable to be able to prohibit manual calls in the
+    // same way as Drop::drop, but the library cannot. So, by using macros and
+    // replacing them with private traits, we prevent users from calling
+    // PinnedDrop::drop.
+    //
+    // Users can implement `Drop` safely using `#[pinned_drop]`.
+    // **Do not call or implement this trait directly.**
+    impl<T> ::pin_project::__private::PinnedDrop for Foo<'_, T> {
+        // Since calling it twice on the same object would be UB,
+        // this method is unsafe.
+        unsafe fn drop(self: Pin<&mut Self>) {
+            fn __drop_inner<T>(__self: Pin<&mut Foo<'_, T>>) {
+                **__self.project().was_dropped = true;
+            }
+            __drop_inner(self);
         }
-        __drop_inner(self);
     }
-}
 
-// Automatically create the appropriate conditional `Unpin` implementation.
-//
-// See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/53.
-// for details.
-#[allow(non_snake_case)]
-fn __unpin_scope_Foo() {
+    // Automatically create the appropriate conditional `Unpin` implementation.
+    //
+    // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/53.
+    // for details.
     pub struct __Foo<'pin, 'a, T> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T)>,
         __field0: T,
@@ -116,18 +121,17 @@ fn __unpin_scope_Foo() {
         __Foo<'pin, 'a, T>: ::core::marker::Unpin
     {
     }
-}
 
-// Ensure that it's impossible to use pin projections on a #[repr(packed)] struct.
-//
-// See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
-// for details.
-#[allow(single_use_lifetimes)]
-#[allow(non_snake_case)]
-#[deny(safe_packed_borrows)]
-fn __pin_project_assert_not_repr_packed_Foo<'a, T>(val: &Foo<'a, T>) {
-    &val.was_dropped;
-    &val.field;
-}
+    // Ensure that it's impossible to use pin projections on a #[repr(packed)] struct.
+    //
+    // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
+    // for details.
+    #[allow(single_use_lifetimes)]
+    #[deny(safe_packed_borrows)]
+    fn __assert_not_repr_packed<'a, T>(val: &Foo<'a, T>) {
+        &val.was_dropped;
+        &val.field;
+    }
+};
 
 fn main() {}

--- a/examples/struct-default-expanded.rs
+++ b/examples/struct-default-expanded.rs
@@ -27,58 +27,67 @@ struct Struct<T, U> {
 
 #[allow(clippy::mut_mut)] // This lint warns `&mut &mut <ty>`.
 #[allow(dead_code)] // This lint warns unused fields/variants.
-struct __StructProjection<'pin, T, U> {
+struct __StructProjection<'pin, T, U>
+where
+    Struct<T, U>: 'pin,
+{
     pinned: ::core::pin::Pin<&'pin mut (T)>,
     unpinned: &'pin mut (U),
 }
 #[allow(dead_code)] // This lint warns unused fields/variants.
-struct __StructProjectionRef<'pin, T, U> {
+struct __StructProjectionRef<'pin, T, U>
+where
+    Struct<T, U>: 'pin,
+{
     pinned: ::core::pin::Pin<&'pin (T)>,
     unpinned: &'pin (U),
 }
 
-impl<T, U> Struct<T, U> {
-    fn project<'pin>(self: ::core::pin::Pin<&'pin mut Self>) -> __StructProjection<'pin, T, U> {
-        unsafe {
-            let Struct { pinned, unpinned } = self.get_unchecked_mut();
-            __StructProjection { pinned: ::core::pin::Pin::new_unchecked(pinned), unpinned }
+#[allow(non_upper_case_globals)]
+const __SCOPE_Struct: () = {
+    impl<T, U> Struct<T, U> {
+        fn project<'pin>(self: ::core::pin::Pin<&'pin mut Self>) -> __StructProjection<'pin, T, U> {
+            unsafe {
+                let Struct { pinned, unpinned } = self.get_unchecked_mut();
+                __StructProjection { pinned: ::core::pin::Pin::new_unchecked(pinned), unpinned }
+            }
+        }
+        fn project_ref<'pin>(
+            self: ::core::pin::Pin<&'pin Self>,
+        ) -> __StructProjectionRef<'pin, T, U> {
+            unsafe {
+                let Struct { pinned, unpinned } = self.get_ref();
+                __StructProjectionRef { pinned: ::core::pin::Pin::new_unchecked(pinned), unpinned }
+            }
         }
     }
-    fn project_ref<'pin>(self: ::core::pin::Pin<&'pin Self>) -> __StructProjectionRef<'pin, T, U> {
-        unsafe {
-            let Struct { pinned, unpinned } = self.get_ref();
-            __StructProjectionRef { pinned: ::core::pin::Pin::new_unchecked(pinned), unpinned }
-        }
-    }
-}
 
-// Automatically create the appropriate conditional `Unpin` implementation.
-//
-// Basically this is equivalent to the following code:
-// ```rust
-// impl<T, U> Unpin for Struct<T, U> where T: Unpin {}
-// ```
-//
-// However, if struct is public and there is a private type field,
-// this would cause an E0446 (private type in public interface).
-//
-// When RFC 2145 is implemented (rust-lang/rust#48054),
-// this will become a lint, rather then a hard error.
-//
-// As a workaround for this, we generate a new struct, containing all of the pinned
-// fields from our #[pin_project] type. This struct is declared within
-// a function, which makes it impossible to be named by user code.
-// This guarantees that it will use the default auto-trait impl for Unpin -
-// that is, it will implement Unpin iff all of its fields implement Unpin.
-// This type can be safely declared as 'public', satisfying the privacy
-// checker without actually allowing user code to access it.
-//
-// This allows users to apply the #[pin_project] attribute to types
-// regardless of the privacy of the types of their fields.
-//
-// See also https://github.com/taiki-e/pin-project/pull/53.
-#[allow(non_snake_case)]
-fn __unpin_scope_Struct() {
+    // Automatically create the appropriate conditional `Unpin` implementation.
+    //
+    // Basically this is equivalent to the following code:
+    //
+    // ```rust
+    // impl<T, U> Unpin for Struct<T, U> where T: Unpin {}
+    // ```
+    //
+    // However, if struct is public and there is a private type field,
+    // this would cause an E0446 (private type in public interface).
+    //
+    // When RFC 2145 is implemented (rust-lang/rust#48054),
+    // this will become a lint, rather then a hard error.
+    //
+    // As a workaround for this, we generate a new struct, containing all of the pinned
+    // fields from our #[pin_project] type. This struct is declared within
+    // a function, which makes it impossible to be named by user code.
+    // This guarantees that it will use the default auto-trait impl for Unpin -
+    // that is, it will implement Unpin iff all of its fields implement Unpin.
+    // This type can be safely declared as 'public', satisfying the privacy
+    // checker without actually allowing user code to access it.
+    //
+    // This allows users to apply the #[pin_project] attribute to types
+    // regardless of the privacy of the types of their fields.
+    //
+    // See also https://github.com/taiki-e/pin-project/pull/53.
     struct __Struct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T, U)>,
         __field0: T,
@@ -87,42 +96,43 @@ fn __unpin_scope_Struct() {
         __Struct<'pin, T, U>: ::core::marker::Unpin
     {
     }
-}
 
-// Ensure that struct does not implement `Drop`.
-//
-// There are two possible cases:
-// 1. The user type does not implement Drop. In this case,
-// the first blanked impl will not apply to it. This code
-// will compile, as there is only one impl of MustNotImplDrop for the user type
-// 2. The user type does impl Drop. This will make the blanket impl applicable,
-// which will then conflict with the explicit MustNotImplDrop impl below.
-// This will result in a compilation error, which is exactly what we want.
-trait StructMustNotImplDrop {}
-#[allow(clippy::drop_bounds)]
-impl<T: ::core::ops::Drop> StructMustNotImplDrop for T {}
-#[allow(single_use_lifetimes)]
-impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
+    // Ensure that struct does not implement `Drop`.
+    //
+    // If you attempt to provide an Drop impl, the blanket impl will
+    // then apply to your type, causing a compile-time error due to
+    // the conflict with the second impl.
+    trait StructMustNotImplDrop {}
+    #[allow(clippy::drop_bounds)]
+    impl<T: ::core::ops::Drop> StructMustNotImplDrop for T {}
+    #[allow(single_use_lifetimes)]
+    impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
+    // A dummy impl of `PinnedDrop`, to ensure that users don't accidentally
+    // write a non-functional `PinnedDrop` impls.
+    #[allow(single_use_lifetimes)]
+    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
+    }
 
-// Ensure that it's impossible to use pin projections on a #[repr(packed)] struct.
-//
-// Taking a reference to a packed field is unsafe, and applying
-// #[deny(safe_packed_borrows)] makes sure that doing this without
-// an 'unsafe' block (which we deliberately do not generate)
-// is a hard error.
-//
-// If the struct ends up having #[repr(packed)] applied somehow,
-// this will generate an (unfriendly) error message. Under all reasonable
-// circumstances, we'll detect the #[repr(packed)] attribute, and generate
-// a much nicer error above.
-//
-// See https://github.com/taiki-e/pin-project/pull/34 for more details.
-#[allow(single_use_lifetimes)]
-#[allow(non_snake_case)]
-#[deny(safe_packed_borrows)]
-fn __pin_project_assert_not_repr_packed_Struct<T, U>(val: &Struct<T, U>) {
-    &val.pinned;
-    &val.unpinned;
-}
+    // Ensure that it's impossible to use pin projections on a #[repr(packed)] struct.
+    //
+    // Taking a reference to a packed field is unsafe, and applying
+    // #[deny(safe_packed_borrows)] makes sure that doing this without
+    // an 'unsafe' block (which we deliberately do not generate)
+    // is a hard error.
+    //
+    // If the struct ends up having #[repr(packed)] applied somehow,
+    // this will generate an (unfriendly) error message. Under all reasonable
+    // circumstances, we'll detect the #[repr(packed)] attribute, and generate
+    // a much nicer error above.
+    //
+    // See https://github.com/taiki-e/pin-project/pull/34 for more details.
+    #[allow(single_use_lifetimes)]
+    #[deny(safe_packed_borrows)]
+    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
+        &val.pinned;
+        &val.unpinned;
+    }
+};
 
 fn main() {}

--- a/examples/unsafe_unpin-expanded.rs
+++ b/examples/unsafe_unpin-expanded.rs
@@ -29,62 +29,74 @@ pub struct Foo<T, U> {
 
 #[allow(clippy::mut_mut)] // This lint warns `&mut &mut <ty>`.
 #[allow(dead_code)] // This lint warns unused fields/variants.
-pub(crate) struct __FooProjection<'pin, T, U> {
+pub(crate) struct __FooProjection<'pin, T, U>
+where
+    Foo<T, U>: 'pin,
+{
     pinned: ::core::pin::Pin<&'pin mut (T)>,
     unpinned: &'pin mut (U),
 }
 #[allow(dead_code)] // This lint warns unused fields/variants.
-pub(crate) struct __FooProjectionRef<'pin, T, U> {
+pub(crate) struct __FooProjectionRef<'pin, T, U>
+where
+    Foo<T, U>: 'pin,
+{
     pinned: ::core::pin::Pin<&'pin (T)>,
     unpinned: &'pin (U),
 }
 
-impl<T, U> Foo<T, U> {
-    pub(crate) fn project<'pin>(
-        self: ::core::pin::Pin<&'pin mut Self>,
-    ) -> __FooProjection<'pin, T, U> {
-        unsafe {
-            let Foo { pinned, unpinned } = self.get_unchecked_mut();
-            __FooProjection { pinned: ::core::pin::Pin::new_unchecked(pinned), unpinned }
+#[allow(non_upper_case_globals)]
+const __SCOPE_Foo: () = {
+    impl<T, U> Foo<T, U> {
+        pub(crate) fn project<'pin>(
+            self: ::core::pin::Pin<&'pin mut Self>,
+        ) -> __FooProjection<'pin, T, U> {
+            unsafe {
+                let Foo { pinned, unpinned } = self.get_unchecked_mut();
+                __FooProjection { pinned: ::core::pin::Pin::new_unchecked(pinned), unpinned }
+            }
+        }
+        pub(crate) fn project_ref<'pin>(
+            self: ::core::pin::Pin<&'pin Self>,
+        ) -> __FooProjectionRef<'pin, T, U> {
+            unsafe {
+                let Foo { pinned, unpinned } = self.get_ref();
+                __FooProjectionRef { pinned: ::core::pin::Pin::new_unchecked(pinned), unpinned }
+            }
         }
     }
-    pub(crate) fn project_ref<'pin>(
-        self: ::core::pin::Pin<&'pin Self>,
-    ) -> __FooProjectionRef<'pin, T, U> {
-        unsafe {
-            let Foo { pinned, unpinned } = self.get_ref();
-            __FooProjectionRef { pinned: ::core::pin::Pin::new_unchecked(pinned), unpinned }
-        }
+
+    unsafe impl<T: Unpin, U> UnsafeUnpin for Foo<T, U> {}
+
+    #[allow(single_use_lifetimes)]
+    impl<'pin, T, U> ::core::marker::Unpin for Foo<T, U> where
+        ::pin_project::__private::Wrapper<'pin, Self>: ::pin_project::UnsafeUnpin
+    {
     }
-}
 
-unsafe impl<T: Unpin, U> UnsafeUnpin for Foo<T, U> {}
+    // Ensure that struct does not implement `Drop`.
+    //
+    // See ./struct-default-expanded.rs for details.
+    trait FooMustNotImplDrop {}
+    #[allow(clippy::drop_bounds)]
+    impl<T: ::core::ops::Drop> FooMustNotImplDrop for T {}
+    #[allow(single_use_lifetimes)]
+    impl<T, U> FooMustNotImplDrop for Foo<T, U> {}
+    #[allow(single_use_lifetimes)]
+    impl<T, U> ::pin_project::__private::PinnedDrop for Foo<T, U> {
+        unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
+    }
 
-#[allow(single_use_lifetimes)]
-impl<'pin, T, U> ::core::marker::Unpin for Foo<T, U> where
-    ::pin_project::__private::Wrapper<'pin, Self>: ::pin_project::UnsafeUnpin
-{
-}
-
-// Ensure that struct does not implement `Drop`.
-//
-// See ./struct-default-expanded.rs for details.
-trait FooMustNotImplDrop {}
-#[allow(clippy::drop_bounds)]
-impl<T: ::core::ops::Drop> FooMustNotImplDrop for T {}
-#[allow(single_use_lifetimes)]
-impl<T, U> FooMustNotImplDrop for Foo<T, U> {}
-
-// Ensure that it's impossible to use pin projections on a #[repr(packed)] struct.
-//
-// See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
-// for details.
-#[allow(single_use_lifetimes)]
-#[allow(non_snake_case)]
-#[deny(safe_packed_borrows)]
-fn __pin_project_assert_not_repr_packed_Foo<T, U>(val: &Foo<T, U>) {
-    &val.pinned;
-    &val.unpinned;
-}
+    // Ensure that it's impossible to use pin projections on a #[repr(packed)] struct.
+    //
+    // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
+    // for details.
+    #[allow(single_use_lifetimes)]
+    #[deny(safe_packed_borrows)]
+    fn __assert_not_repr_packed<T, U>(val: &Foo<T, U>) {
+        &val.pinned;
+        &val.unpinned;
+    }
+};
 
 fn main() {}

--- a/pin-project-internal/src/lib.rs
+++ b/pin-project-internal/src/lib.rs
@@ -12,19 +12,6 @@
 // mem::take requires Rust 1.40
 #![allow(clippy::mem_replace_with_default)]
 #![allow(clippy::needless_doctest_main)]
-// While this crate supports stable Rust, it currently requires
-// nightly Rust in order for rustdoc to correctly document auto-generated
-// `Unpin` impls. This does not affect the runtime functionality of this crate,
-// nor does it affect the safety of the api provided by this crate.
-//
-// This is disabled by default and can be enabled using
-// `--cfg pin_project_show_unpin_struct` in RUSTFLAGS.
-//
-// Refs:
-// * https://github.com/taiki-e/pin-project/pull/53#issuecomment-525906867
-// * https://github.com/taiki-e/pin-project/pull/70
-// * https://github.com/rust-lang/rust/issues/63281
-#![cfg_attr(pin_project_show_unpin_struct, feature(proc_macro_def_site))]
 
 // older compilers require explicit `extern crate`.
 #[allow(unused_extern_crates)]

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,4 +1,3 @@
-#![cfg(pin_project_show_unpin_struct)]
 #![warn(unsafe_code)]
 #![warn(rust_2018_idioms, single_use_lifetimes)]
 

--- a/tests/ui/cfg/cfg_attr-unpin.stderr
+++ b/tests/ui/cfg/cfg_attr-unpin.stderr
@@ -16,7 +16,7 @@ error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
    |                ----- required by this bound in `is_unpin`
 ...
 20 |     is_unpin::<Bar<PhantomPinned>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `__Bar<'_, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `__SCOPE_Bar::__Bar<'_, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
    |
-   = note: required because it appears within the type `__Bar<'_, std::marker::PhantomPinned>`
+   = note: required because it appears within the type `__SCOPE_Bar::__Bar<'_, std::marker::PhantomPinned>`
    = note: required because of the requirements on the impl of `std::marker::Unpin` for `Bar<std::marker::PhantomPinned>`

--- a/tests/ui/cfg/proper_unpin.stderr
+++ b/tests/ui/cfg/proper_unpin.stderr
@@ -5,7 +5,7 @@ error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
    |                ----- required by this bound in `is_unpin`
 ...
 27 |     is_unpin::<Bar<PhantomPinned>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `__Bar<'_, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `__SCOPE_Bar::__Bar<'_, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
    |
-   = note: required because it appears within the type `__Bar<'_, std::marker::PhantomPinned>`
+   = note: required because it appears within the type `__SCOPE_Bar::__Bar<'_, std::marker::PhantomPinned>`
    = note: required because of the requirements on the impl of `std::marker::Unpin` for `Bar<std::marker::PhantomPinned>`

--- a/tests/ui/pin_project/add-pinned-field.stderr
+++ b/tests/ui/pin_project/add-pinned-field.stderr
@@ -5,9 +5,9 @@ error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
    |                ----- required by this bound in `is_unpin`
 ...
 21 |     is_unpin::<Foo>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^ within `__Foo<'_>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^ within `__SCOPE_Foo::__Foo<'_>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
    |
-   = note: required because it appears within the type `__Foo<'_>`
+   = note: required because it appears within the type `__SCOPE_Foo::__Foo<'_>`
    = note: required because of the requirements on the impl of `std::marker::Unpin` for `Foo`
 
 error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
@@ -17,7 +17,7 @@ error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
    |                ----- required by this bound in `is_unpin`
 ...
 22 |     is_unpin::<Bar>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^ within `__Bar<'_>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^ within `__SCOPE_Bar::__Bar<'_>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
    |
-   = note: required because it appears within the type `__Bar<'_>`
+   = note: required because it appears within the type `__SCOPE_Bar::__Bar<'_>`
    = note: required because of the requirements on the impl of `std::marker::Unpin` for `Bar`

--- a/tests/ui/pin_project/conflict-drop.stderr
+++ b/tests/ui/pin_project/conflict-drop.stderr
@@ -1,4 +1,4 @@
-error[E0119]: conflicting implementations of trait `FooMustNotImplDrop` for type `Foo<_, _>`:
+error[E0119]: conflicting implementations of trait `__SCOPE_Foo::FooMustNotImplDrop` for type `Foo<_, _>`:
  --> $DIR/conflict-drop.rs:4:1
   |
 4 | #[pin_project] //~ ERROR E0119

--- a/tests/ui/pin_project/overlapping_unpin_struct.stderr
+++ b/tests/ui/pin_project/overlapping_unpin_struct.stderr
@@ -5,7 +5,7 @@ error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
    |                ----- required by this bound in `is_unpin`
 ...
 17 |     is_unpin::<Foo<PhantomPinned>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `__Foo<'_, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `__SCOPE_Foo::__Foo<'_, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
    |
-   = note: required because it appears within the type `__Foo<'_, std::marker::PhantomPinned>`
+   = note: required because it appears within the type `__SCOPE_Foo::__Foo<'_, std::marker::PhantomPinned>`
    = note: required because of the requirements on the impl of `std::marker::Unpin` for `Foo<std::marker::PhantomPinned>`

--- a/tests/ui/pin_project/proper_unpin.stderr
+++ b/tests/ui/pin_project/proper_unpin.stderr
@@ -5,10 +5,10 @@ error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
    |                ----- required by this bound in `is_unpin`
 ...
 31 |     is_unpin::<Foo<PhantomPinned, ()>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `__Foo<'_, std::marker::PhantomPinned, ()>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `__SCOPE_Foo::__Foo<'_, std::marker::PhantomPinned, ()>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
    |
    = note: required because it appears within the type `Inner<std::marker::PhantomPinned>`
-   = note: required because it appears within the type `__Foo<'_, std::marker::PhantomPinned, ()>`
+   = note: required because it appears within the type `__SCOPE_Foo::__Foo<'_, std::marker::PhantomPinned, ()>`
    = note: required because of the requirements on the impl of `std::marker::Unpin` for `Foo<std::marker::PhantomPinned, ()>`
 
 error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
@@ -18,10 +18,10 @@ error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
    |                ----- required by this bound in `is_unpin`
 ...
 33 |     is_unpin::<Foo<PhantomPinned, PhantomPinned>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `__Foo<'_, std::marker::PhantomPinned, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `__SCOPE_Foo::__Foo<'_, std::marker::PhantomPinned, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
    |
    = note: required because it appears within the type `Inner<std::marker::PhantomPinned>`
-   = note: required because it appears within the type `__Foo<'_, std::marker::PhantomPinned, std::marker::PhantomPinned>`
+   = note: required because it appears within the type `__SCOPE_Foo::__Foo<'_, std::marker::PhantomPinned, std::marker::PhantomPinned>`
    = note: required because of the requirements on the impl of `std::marker::Unpin` for `Foo<std::marker::PhantomPinned, std::marker::PhantomPinned>`
 
 error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
@@ -31,7 +31,7 @@ error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
    |                ----- required by this bound in `is_unpin`
 ...
 35 |     is_unpin::<TrivialBounds>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ within `__TrivialBounds<'_>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ within `__SCOPE_TrivialBounds::__TrivialBounds<'_>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
    |
-   = note: required because it appears within the type `__TrivialBounds<'_>`
+   = note: required because it appears within the type `__SCOPE_TrivialBounds::__TrivialBounds<'_>`
    = note: required because of the requirements on the impl of `std::marker::Unpin` for `TrivialBounds`

--- a/tests/ui/pin_project/unpin_sneaky.stderr
+++ b/tests/ui/pin_project/unpin_sneaky.stderr
@@ -3,11 +3,6 @@ error[E0412]: cannot find type `__Foo` in this scope
   |
 9 | impl Unpin for __Foo {} //~ ERROR E0412,E0321
   |                ^^^^^ not found in this scope
-  |
-help: possible candidate is found in another module, you can import it into scope
-  |
-1 | use crate::__Foo;
-  |
 
 error[E0321]: cross-crate traits with a default impl, like `std::marker::Unpin`, can only be implemented for a struct/enum type, not `[type error]`
  --> $DIR/unpin_sneaky.rs:9:1


### PR DESCRIPTION
Generate all items except for projected types inside a `const` scope. This makes it impossible for user code to refer to these types. This removes redundant prefix/postfix based on the original type from many generate types. This also remove the `pin_project_show_unpin_struct` flag.