### PR TITLE
Add expansion tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,17 @@ jobs:
         if: matrix.rust == 'nightly'
         run: |
           cargo install cargo-hack
+      - name: Install cargo-expand
+        if: matrix.rust == 'nightly'
+        run: |
+          cargo install cargo-expand
       - name: cargo test
         run: |
-          cargo test --all
+          cargo test --all --all-features
       - name: cargo test -- --ignored
         if: matrix.rust == 'nightly'
         run: |
-          cargo test --all -- --ignored
+          cargo test --all --all-features -- --ignored
       # Refs: https://github.com/rust-lang/cargo/issues/5657
       - name: cargo check -Zminimal-versions
         if: matrix.rust == 'nightly'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "pin-project-internal",
     "tests/ui/auxiliary",
     "tests/doc",
+    "tests/expand",
 ]
 
 [dependencies]

--- a/ci.sh
+++ b/ci.sh
@@ -22,3 +22,7 @@ cargo +nightly doc --no-deps --all --all-features
 
 echo "Running 'compiletest'"
 . ./compiletest.sh
+
+# See also https://docs.rs/macrotest/1/macrotest/#updating-expandedrs
+echo "Running 'expandtest'"
+cargo +nightly test --manifest-path tests/expand/Cargo.toml

--- a/tests/expand/Cargo.toml
+++ b/tests/expand/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "expandtest"
+version = "0.1.0"
+authors = ["Taiki Endo <te316e89@gmail.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+
+[dev-dependencies]
+pin-project = { path = "../.." }
+macrotest = "1.0"

--- a/tests/expand/build.rs
+++ b/tests/expand/build.rs
@@ -1,0 +1,43 @@
+#![warn(unsafe_code)]
+#![warn(rust_2018_idioms, single_use_lifetimes)]
+
+// Based on https://github.com/serde-rs/serde/blob/v1.0.106/test_suite/build.rs
+
+use std::{
+    env,
+    process::{Command, ExitStatus, Stdio},
+};
+
+#[cfg(not(windows))]
+const CARGO_EXPAND: &str = "cargo-expand";
+
+#[cfg(windows)]
+const CARGO_EXPAND: &str = "cargo-expand.exe";
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    if Command::new(CARGO_EXPAND)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .as_ref()
+        .map(ExitStatus::success)
+        .unwrap_or(false)
+    {
+        println!("cargo:rustc-cfg=cargo_expand");
+    }
+
+    if is_nightly() {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}
+
+fn is_nightly() -> bool {
+    env::var_os("RUSTC")
+        .and_then(|rustc| Command::new(rustc).arg("--version").output().ok())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map_or(false, |version| version.contains("nightly") || version.contains("dev"))
+}

--- a/tests/expand/tests/enum/enum-default.expanded.rs
+++ b/tests/expand/tests/enum/enum-default.expanded.rs
@@ -1,0 +1,66 @@
+use pin_project::pin_project;
+#[pin(__private())]
+enum Enum<T, U> {
+    Pinned(#[pin] T),
+    Unpinned(U),
+}
+#[allow(clippy::mut_mut)]
+#[allow(dead_code)]
+enum __EnumProjection<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Pinned(::core::pin::Pin<&'pin mut (T)>),
+    Unpinned(&'pin mut (U)),
+}
+#[allow(dead_code)]
+enum __EnumProjectionRef<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Pinned(::core::pin::Pin<&'pin (T)>),
+    Unpinned(&'pin (U)),
+}
+#[allow(non_upper_case_globals)]
+const __SCOPE_Enum: () = {
+    impl<T, U> Enum<T, U> {
+        fn project<'pin>(self: ::core::pin::Pin<&'pin mut Self>) -> __EnumProjection<'pin, T, U> {
+            unsafe {
+                match self.get_unchecked_mut() {
+                    Enum::Pinned(_0) => {
+                        __EnumProjection::Pinned(::core::pin::Pin::new_unchecked(_0))
+                    }
+                    Enum::Unpinned(_0) => __EnumProjection::Unpinned(_0),
+                }
+            }
+        }
+        fn project_ref<'pin>(
+            self: ::core::pin::Pin<&'pin Self>,
+        ) -> __EnumProjectionRef<'pin, T, U> {
+            unsafe {
+                match self.get_ref() {
+                    Enum::Pinned(_0) => {
+                        __EnumProjectionRef::Pinned(::core::pin::Pin::new_unchecked(_0))
+                    }
+                    Enum::Unpinned(_0) => __EnumProjectionRef::Unpinned(_0),
+                }
+            }
+        }
+    }
+    struct __Enum<'pin, T, U> {
+        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T, U)>,
+        __field0: T,
+    }
+    impl<'pin, T, U> ::core::marker::Unpin for Enum<T, U> where __Enum<'pin, T, U>: ::core::marker::Unpin
+    {}
+    trait EnumMustNotImplDrop {}
+    #[allow(clippy::drop_bounds)]
+    impl<T: ::core::ops::Drop> EnumMustNotImplDrop for T {}
+    #[allow(single_use_lifetimes)]
+    impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
+    #[allow(single_use_lifetimes)]
+    impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
+        unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
+    }
+};
+fn main() {}

--- a/tests/expand/tests/enum/enum-default.rs
+++ b/tests/expand/tests/enum/enum-default.rs
@@ -1,0 +1,9 @@
+use pin_project::pin_project;
+
+#[pin_project]
+enum Enum<T, U> {
+    Pinned(#[pin] T),
+    Unpinned(U),
+}
+
+fn main() {}

--- a/tests/expand/tests/expandtest.rs
+++ b/tests/expand/tests/expandtest.rs
@@ -1,0 +1,9 @@
+#![cfg(nightly)]
+#![cfg(target_os = "linux")]
+
+#[cfg_attr(not(cargo_expand), ignore)]
+#[test]
+fn expandtest() {
+    macrotest::expand("tests/enum/*.rs");
+    macrotest::expand("tests/struct/*.rs");
+}

--- a/tests/expand/tests/struct/pinned_drop.expanded.rs
+++ b/tests/expand/tests/struct/pinned_drop.expanded.rs
@@ -1,0 +1,85 @@
+use pin_project::{pin_project, pinned_drop};
+use std::pin::Pin;
+#[pin(__private(PinnedDrop))]
+pub struct Foo<'a, T> {
+    was_dropped: &'a mut bool,
+    #[pin]
+    field: T,
+}
+#[allow(clippy::mut_mut)]
+#[allow(dead_code)]
+pub(crate) struct __FooProjection<'pin, 'a, T>
+where
+    Foo<'a, T>: 'pin,
+{
+    was_dropped: &'pin mut (&'a mut bool),
+    field: ::core::pin::Pin<&'pin mut (T)>,
+}
+#[allow(dead_code)]
+pub(crate) struct __FooProjectionRef<'pin, 'a, T>
+where
+    Foo<'a, T>: 'pin,
+{
+    was_dropped: &'pin (&'a mut bool),
+    field: ::core::pin::Pin<&'pin (T)>,
+}
+#[allow(non_upper_case_globals)]
+const __SCOPE_Foo: () = {
+    impl<'a, T> Foo<'a, T> {
+        pub(crate) fn project<'pin>(
+            self: ::core::pin::Pin<&'pin mut Self>,
+        ) -> __FooProjection<'pin, 'a, T> {
+            unsafe {
+                let Foo { was_dropped, field } = self.get_unchecked_mut();
+                __FooProjection {
+                    was_dropped,
+                    field: ::core::pin::Pin::new_unchecked(field),
+                }
+            }
+        }
+        pub(crate) fn project_ref<'pin>(
+            self: ::core::pin::Pin<&'pin Self>,
+        ) -> __FooProjectionRef<'pin, 'a, T> {
+            unsafe {
+                let Foo { was_dropped, field } = self.get_ref();
+                __FooProjectionRef {
+                    was_dropped,
+                    field: ::core::pin::Pin::new_unchecked(field),
+                }
+            }
+        }
+    }
+    pub struct __Foo<'pin, 'a, T> {
+        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T)>,
+        __field0: T,
+        __lifetime0: &'a (),
+    }
+    impl<'pin, 'a, T> ::core::marker::Unpin for Foo<'a, T> where
+        __Foo<'pin, 'a, T>: ::core::marker::Unpin
+    {
+    }
+    #[allow(single_use_lifetimes)]
+    impl<'a, T> ::core::ops::Drop for Foo<'a, T> {
+        fn drop(&mut self) {
+            let pinned_self = unsafe { ::core::pin::Pin::new_unchecked(self) };
+            unsafe {
+                ::pin_project::__private::PinnedDrop::drop(pinned_self);
+            }
+        }
+    }
+    #[allow(single_use_lifetimes)]
+    #[deny(safe_packed_borrows)]
+    fn __assert_not_repr_packed<'a, T>(val: &Foo<'a, T>) {
+        &val.was_dropped;
+        &val.field;
+    }
+};
+impl<T> ::pin_project::__private::PinnedDrop for Foo<'_, T> {
+    unsafe fn drop(self: Pin<&mut Self>) {
+        fn __drop_inner<T>(__self: Pin<&mut Foo<'_, T>>) {
+            **__self.project().was_dropped = true;
+        }
+        __drop_inner(self);
+    }
+}
+fn main() {}

--- a/tests/expand/tests/struct/pinned_drop.rs
+++ b/tests/expand/tests/struct/pinned_drop.rs
@@ -1,0 +1,18 @@
+use pin_project::{pin_project, pinned_drop};
+use std::pin::Pin;
+
+#[pin_project(PinnedDrop)]
+pub struct Foo<'a, T> {
+    was_dropped: &'a mut bool,
+    #[pin]
+    field: T,
+}
+
+#[pinned_drop]
+impl<T> PinnedDrop for Foo<'_, T> {
+    fn drop(self: Pin<&mut Self>) {
+        **self.project().was_dropped = true;
+    }
+}
+
+fn main() {}

--- a/tests/expand/tests/struct/struct-default.expanded.rs
+++ b/tests/expand/tests/struct/struct-default.expanded.rs
@@ -1,0 +1,73 @@
+use pin_project::pin_project;
+#[pin(__private())]
+struct Struct<T, U> {
+    #[pin]
+    pinned: T,
+    unpinned: U,
+}
+#[allow(clippy::mut_mut)]
+#[allow(dead_code)]
+struct __StructProjection<'pin, T, U>
+where
+    Struct<T, U>: 'pin,
+{
+    pinned: ::core::pin::Pin<&'pin mut (T)>,
+    unpinned: &'pin mut (U),
+}
+#[allow(dead_code)]
+struct __StructProjectionRef<'pin, T, U>
+where
+    Struct<T, U>: 'pin,
+{
+    pinned: ::core::pin::Pin<&'pin (T)>,
+    unpinned: &'pin (U),
+}
+#[allow(non_upper_case_globals)]
+const __SCOPE_Struct: () = {
+    impl<T, U> Struct<T, U> {
+        fn project<'pin>(self: ::core::pin::Pin<&'pin mut Self>) -> __StructProjection<'pin, T, U> {
+            unsafe {
+                let Struct { pinned, unpinned } = self.get_unchecked_mut();
+                __StructProjection {
+                    pinned: ::core::pin::Pin::new_unchecked(pinned),
+                    unpinned,
+                }
+            }
+        }
+        fn project_ref<'pin>(
+            self: ::core::pin::Pin<&'pin Self>,
+        ) -> __StructProjectionRef<'pin, T, U> {
+            unsafe {
+                let Struct { pinned, unpinned } = self.get_ref();
+                __StructProjectionRef {
+                    pinned: ::core::pin::Pin::new_unchecked(pinned),
+                    unpinned,
+                }
+            }
+        }
+    }
+    struct __Struct<'pin, T, U> {
+        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T, U)>,
+        __field0: T,
+    }
+    impl<'pin, T, U> ::core::marker::Unpin for Struct<T, U> where
+        __Struct<'pin, T, U>: ::core::marker::Unpin
+    {
+    }
+    trait StructMustNotImplDrop {}
+    #[allow(clippy::drop_bounds)]
+    impl<T: ::core::ops::Drop> StructMustNotImplDrop for T {}
+    #[allow(single_use_lifetimes)]
+    impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
+    #[allow(single_use_lifetimes)]
+    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
+    }
+    #[allow(single_use_lifetimes)]
+    #[deny(safe_packed_borrows)]
+    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
+        &val.pinned;
+        &val.unpinned;
+    }
+};
+fn main() {}

--- a/tests/expand/tests/struct/struct-default.rs
+++ b/tests/expand/tests/struct/struct-default.rs
@@ -1,0 +1,10 @@
+use pin_project::pin_project;
+
+#[pin_project]
+struct Struct<T, U> {
+    #[pin]
+    pinned: T,
+    unpinned: U,
+}
+
+fn main() {}

--- a/tests/expand/tests/struct/unsafe_unpin.expanded.rs
+++ b/tests/expand/tests/struct/unsafe_unpin.expanded.rs
@@ -1,0 +1,73 @@
+use pin_project::{pin_project, UnsafeUnpin};
+#[pin(__private(UnsafeUnpin))]
+pub struct Foo<T, U> {
+    #[pin]
+    pinned: T,
+    unpinned: U,
+}
+#[allow(clippy::mut_mut)]
+#[allow(dead_code)]
+pub(crate) struct __FooProjection<'pin, T, U>
+where
+    Foo<T, U>: 'pin,
+{
+    pinned: ::core::pin::Pin<&'pin mut (T)>,
+    unpinned: &'pin mut (U),
+}
+#[allow(dead_code)]
+pub(crate) struct __FooProjectionRef<'pin, T, U>
+where
+    Foo<T, U>: 'pin,
+{
+    pinned: ::core::pin::Pin<&'pin (T)>,
+    unpinned: &'pin (U),
+}
+#[allow(non_upper_case_globals)]
+const __SCOPE_Foo: () = {
+    impl<T, U> Foo<T, U> {
+        pub(crate) fn project<'pin>(
+            self: ::core::pin::Pin<&'pin mut Self>,
+        ) -> __FooProjection<'pin, T, U> {
+            unsafe {
+                let Foo { pinned, unpinned } = self.get_unchecked_mut();
+                __FooProjection {
+                    pinned: ::core::pin::Pin::new_unchecked(pinned),
+                    unpinned,
+                }
+            }
+        }
+        pub(crate) fn project_ref<'pin>(
+            self: ::core::pin::Pin<&'pin Self>,
+        ) -> __FooProjectionRef<'pin, T, U> {
+            unsafe {
+                let Foo { pinned, unpinned } = self.get_ref();
+                __FooProjectionRef {
+                    pinned: ::core::pin::Pin::new_unchecked(pinned),
+                    unpinned,
+                }
+            }
+        }
+    }
+    #[allow(single_use_lifetimes)]
+    impl<'pin, T, U> ::core::marker::Unpin for Foo<T, U> where
+        ::pin_project::__private::Wrapper<'pin, Self>: ::pin_project::UnsafeUnpin
+    {
+    }
+    trait FooMustNotImplDrop {}
+    #[allow(clippy::drop_bounds)]
+    impl<T: ::core::ops::Drop> FooMustNotImplDrop for T {}
+    #[allow(single_use_lifetimes)]
+    impl<T, U> FooMustNotImplDrop for Foo<T, U> {}
+    #[allow(single_use_lifetimes)]
+    impl<T, U> ::pin_project::__private::PinnedDrop for Foo<T, U> {
+        unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
+    }
+    #[allow(single_use_lifetimes)]
+    #[deny(safe_packed_borrows)]
+    fn __assert_not_repr_packed<T, U>(val: &Foo<T, U>) {
+        &val.pinned;
+        &val.unpinned;
+    }
+};
+unsafe impl<T: Unpin, U> UnsafeUnpin for Foo<T, U> {}
+fn main() {}

--- a/tests/expand/tests/struct/unsafe_unpin.rs
+++ b/tests/expand/tests/struct/unsafe_unpin.rs
@@ -1,0 +1,12 @@
+use pin_project::{pin_project, UnsafeUnpin};
+
+#[pin_project(UnsafeUnpin)]
+pub struct Foo<T, U> {
+    #[pin]
+    pinned: T,
+    unpinned: U,
+}
+
+unsafe impl<T: Unpin, U> UnsafeUnpin for Foo<T, U> {}
+
+fn main() {}


### PR DESCRIPTION
Similar to ui tests, but instead of checking the compiler output, this checks the code generated by proc-macro.

Refs: https://github.com/eupn/macrotest