### PR TITLE
Support overwriting the name of core crate

### DIFF
--- a/examples/enum-default-expanded.rs
+++ b/examples/enum-default-expanded.rs
@@ -29,7 +29,7 @@ enum __EnumProjection<'pin, T, U>
 where
     Enum<T, U>: 'pin,
 {
-    Pinned(::core::pin::Pin<&'pin mut (T)>),
+    Pinned(::pin_project::__reexport::pin::Pin<&'pin mut (T)>),
     Unpinned(&'pin mut (U)),
 }
 #[allow(dead_code)] // This lint warns unused fields/variants.
@@ -37,31 +37,33 @@ enum __EnumProjectionRef<'pin, T, U>
 where
     Enum<T, U>: 'pin,
 {
-    Pinned(::core::pin::Pin<&'pin (T)>),
+    Pinned(::pin_project::__reexport::pin::Pin<&'pin (T)>),
     Unpinned(&'pin (U)),
 }
 
 #[allow(non_upper_case_globals)]
 const __SCOPE_Enum: () = {
     impl<T, U> Enum<T, U> {
-        fn project<'pin>(self: ::core::pin::Pin<&'pin mut Self>) -> __EnumProjection<'pin, T, U> {
+        fn project<'pin>(
+            self: ::pin_project::__reexport::pin::Pin<&'pin mut Self>,
+        ) -> __EnumProjection<'pin, T, U> {
             unsafe {
                 match self.get_unchecked_mut() {
-                    Enum::Pinned(_0) => {
-                        __EnumProjection::Pinned(::core::pin::Pin::new_unchecked(_0))
-                    }
+                    Enum::Pinned(_0) => __EnumProjection::Pinned(
+                        ::pin_project::__reexport::pin::Pin::new_unchecked(_0),
+                    ),
                     Enum::Unpinned(_0) => __EnumProjection::Unpinned(_0),
                 }
             }
         }
         fn project_ref<'pin>(
-            self: ::core::pin::Pin<&'pin Self>,
+            self: ::pin_project::__reexport::pin::Pin<&'pin Self>,
         ) -> __EnumProjectionRef<'pin, T, U> {
             unsafe {
                 match self.get_ref() {
-                    Enum::Pinned(_0) => {
-                        __EnumProjectionRef::Pinned(::core::pin::Pin::new_unchecked(_0))
-                    }
+                    Enum::Pinned(_0) => __EnumProjectionRef::Pinned(
+                        ::pin_project::__reexport::pin::Pin::new_unchecked(_0),
+                    ),
                     Enum::Unpinned(_0) => __EnumProjectionRef::Unpinned(_0),
                 }
             }
@@ -76,20 +78,22 @@ const __SCOPE_Enum: () = {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T, U)>,
         __field0: T,
     }
-    impl<'pin, T, U> ::core::marker::Unpin for Enum<T, U> where __Enum<'pin, T, U>: ::core::marker::Unpin
-    {}
+    impl<'pin, T, U> ::pin_project::__reexport::marker::Unpin for Enum<T, U> where
+        __Enum<'pin, T, U>: ::pin_project::__reexport::marker::Unpin
+    {
+    }
 
     // Ensure that enum does not implement `Drop`.
     //
     // See ./struct-default-expanded.rs for details.
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds)]
-    impl<T: ::core::ops::Drop> EnumMustNotImplDrop for T {}
+    impl<T: ::pin_project::__reexport::ops::Drop> EnumMustNotImplDrop for T {}
     #[allow(single_use_lifetimes)]
     impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
     #[allow(single_use_lifetimes)]
     impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
-        unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
+        unsafe fn drop(self: ::pin_project::__reexport::pin::Pin<&mut Self>) {}
     }
 
     // We don't need to check for `#[repr(packed)]`,

--- a/examples/pinned_drop-expanded.rs
+++ b/examples/pinned_drop-expanded.rs
@@ -7,14 +7,14 @@
 // use std::pin::Pin;
 //
 // #[pin_project(PinnedDrop)]
-// pub struct Foo<'a, T> {
+// pub struct Struct<'a, T> {
 //     was_dropped: &'a mut bool,
 //     #[pin]
 //     field: T,
 // }
 //
 // #[pinned_drop]
-// fn drop_foo<T>(mut this: Pin<&mut Foo<'_, T>>) {
+// fn drop_Struct<T>(mut this: Pin<&mut Struct<'_, T>>) {
 //     **this.project().was_dropped = true;
 // }
 //
@@ -26,7 +26,7 @@
 use pin_project::{pin_project, pinned_drop};
 use std::pin::Pin;
 
-pub struct Foo<'a, T> {
+pub struct Struct<'a, T> {
     was_dropped: &'a mut bool,
     // #[pin]
     field: T,
@@ -34,49 +34,55 @@ pub struct Foo<'a, T> {
 
 #[allow(clippy::mut_mut)] // This lint warns `&mut &mut <ty>`.
 #[allow(dead_code)] // This lint warns unused fields/variants.
-pub(crate) struct __FooProjection<'pin, 'a, T>
+pub(crate) struct __StructProjection<'pin, 'a, T>
 where
-    Foo<'a, T>: 'pin,
+    Struct<'a, T>: 'pin,
 {
     was_dropped: &'pin mut (&'a mut bool),
-    field: ::core::pin::Pin<&'pin mut (T)>,
+    field: ::pin_project::__reexport::pin::Pin<&'pin mut (T)>,
 }
 #[allow(dead_code)] // This lint warns unused fields/variants.
-pub(crate) struct __FooProjectionRef<'pin, 'a, T>
+pub(crate) struct __StructProjectionRef<'pin, 'a, T>
 where
-    Foo<'a, T>: 'pin,
+    Struct<'a, T>: 'pin,
 {
     was_dropped: &'pin (&'a mut bool),
-    field: ::core::pin::Pin<&'pin (T)>,
+    field: ::pin_project::__reexport::pin::Pin<&'pin (T)>,
 }
 
 #[allow(non_upper_case_globals)]
-const __SCOPE_Foo: () = {
-    impl<'a, T> Foo<'a, T> {
+const __SCOPE_Struct: () = {
+    impl<'a, T> Struct<'a, T> {
         pub(crate) fn project<'pin>(
-            self: ::core::pin::Pin<&'pin mut Self>,
-        ) -> __FooProjection<'pin, 'a, T> {
+            self: ::pin_project::__reexport::pin::Pin<&'pin mut Self>,
+        ) -> __StructProjection<'pin, 'a, T> {
             unsafe {
                 let Self { was_dropped, field } = self.get_unchecked_mut();
-                __FooProjection { was_dropped, field: ::core::pin::Pin::new_unchecked(field) }
+                __StructProjection {
+                    was_dropped,
+                    field: ::pin_project::__reexport::pin::Pin::new_unchecked(field),
+                }
             }
         }
         pub(crate) fn project_ref<'pin>(
-            self: ::core::pin::Pin<&'pin Self>,
-        ) -> __FooProjectionRef<'pin, 'a, T> {
+            self: ::pin_project::__reexport::pin::Pin<&'pin Self>,
+        ) -> __StructProjectionRef<'pin, 'a, T> {
             unsafe {
                 let Self { was_dropped, field } = self.get_ref();
-                __FooProjectionRef { was_dropped, field: ::core::pin::Pin::new_unchecked(field) }
+                __StructProjectionRef {
+                    was_dropped,
+                    field: ::pin_project::__reexport::pin::Pin::new_unchecked(field),
+                }
             }
         }
     }
 
     #[allow(single_use_lifetimes)]
-    impl<'a, T> ::core::ops::Drop for Foo<'a, T> {
+    impl<'a, T> ::pin_project::__reexport::ops::Drop for Struct<'a, T> {
         fn drop(&mut self) {
             // Safety - we're in 'drop', so we know that 'self' will
             // never move again.
-            let pinned_self = unsafe { ::core::pin::Pin::new_unchecked(self) };
+            let pinned_self = unsafe { ::pin_project::__reexport::pin::Pin::new_unchecked(self) };
             // We call `pinned_drop` only once. Since `PinnedDrop::drop`
             // is an unsafe method and a private API, it is never called again in safe
             // code *unless the user uses a maliciously crafted macro*.
@@ -97,11 +103,11 @@ const __SCOPE_Foo: () = {
     //
     // Users can implement `Drop` safely using `#[pinned_drop]`.
     // **Do not call or implement this trait directly.**
-    impl<T> ::pin_project::__private::PinnedDrop for Foo<'_, T> {
+    impl<T> ::pin_project::__private::PinnedDrop for Struct<'_, T> {
         // Since calling it twice on the same object would be UB,
         // this method is unsafe.
         unsafe fn drop(self: Pin<&mut Self>) {
-            fn __drop_inner<T>(__self: Pin<&mut Foo<'_, T>>) {
+            fn __drop_inner<T>(__self: Pin<&mut Struct<'_, T>>) {
                 **__self.project().was_dropped = true;
             }
             __drop_inner(self);
@@ -112,13 +118,13 @@ const __SCOPE_Foo: () = {
     //
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/53.
     // for details.
-    pub struct __Foo<'pin, 'a, T> {
+    pub struct __Struct<'pin, 'a, T> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T)>,
         __field0: T,
         __lifetime0: &'a (),
     }
-    impl<'pin, 'a, T> ::core::marker::Unpin for Foo<'a, T> where
-        __Foo<'pin, 'a, T>: ::core::marker::Unpin
+    impl<'pin, 'a, T> ::pin_project::__reexport::marker::Unpin for Struct<'a, T> where
+        __Struct<'pin, 'a, T>: ::pin_project::__reexport::marker::Unpin
     {
     }
 
@@ -128,7 +134,7 @@ const __SCOPE_Foo: () = {
     // for details.
     #[allow(single_use_lifetimes)]
     #[deny(safe_packed_borrows)]
-    fn __assert_not_repr_packed<'a, T>(val: &Foo<'a, T>) {
+    fn __assert_not_repr_packed<'a, T>(val: &Struct<'a, T>) {
         &val.was_dropped;
         &val.field;
     }

--- a/examples/pinned_drop.rs
+++ b/examples/pinned_drop.rs
@@ -6,14 +6,14 @@ use pin_project::{pin_project, pinned_drop};
 use std::pin::Pin;
 
 #[pin_project(PinnedDrop)]
-pub struct Foo<'a, T> {
+pub struct Struct<'a, T> {
     was_dropped: &'a mut bool,
     #[pin]
     field: T,
 }
 
 #[pinned_drop]
-impl<T> PinnedDrop for Foo<'_, T> {
+impl<T> PinnedDrop for Struct<'_, T> {
     fn drop(self: Pin<&mut Self>) {
         **self.project().was_dropped = true;
     }

--- a/examples/struct-default-expanded.rs
+++ b/examples/struct-default-expanded.rs
@@ -31,7 +31,7 @@ struct __StructProjection<'pin, T, U>
 where
     Struct<T, U>: 'pin,
 {
-    pinned: ::core::pin::Pin<&'pin mut (T)>,
+    pinned: ::pin_project::__reexport::pin::Pin<&'pin mut (T)>,
     unpinned: &'pin mut (U),
 }
 #[allow(dead_code)] // This lint warns unused fields/variants.
@@ -39,25 +39,33 @@ struct __StructProjectionRef<'pin, T, U>
 where
     Struct<T, U>: 'pin,
 {
-    pinned: ::core::pin::Pin<&'pin (T)>,
+    pinned: ::pin_project::__reexport::pin::Pin<&'pin (T)>,
     unpinned: &'pin (U),
 }
 
 #[allow(non_upper_case_globals)]
 const __SCOPE_Struct: () = {
     impl<T, U> Struct<T, U> {
-        fn project<'pin>(self: ::core::pin::Pin<&'pin mut Self>) -> __StructProjection<'pin, T, U> {
+        fn project<'pin>(
+            self: ::pin_project::__reexport::pin::Pin<&'pin mut Self>,
+        ) -> __StructProjection<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_unchecked_mut();
-                __StructProjection { pinned: ::core::pin::Pin::new_unchecked(pinned), unpinned }
+                __StructProjection {
+                    pinned: ::pin_project::__reexport::pin::Pin::new_unchecked(pinned),
+                    unpinned,
+                }
             }
         }
         fn project_ref<'pin>(
-            self: ::core::pin::Pin<&'pin Self>,
+            self: ::pin_project::__reexport::pin::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_ref();
-                __StructProjectionRef { pinned: ::core::pin::Pin::new_unchecked(pinned), unpinned }
+                __StructProjectionRef {
+                    pinned: ::pin_project::__reexport::pin::Pin::new_unchecked(pinned),
+                    unpinned,
+                }
             }
         }
     }
@@ -92,8 +100,8 @@ const __SCOPE_Struct: () = {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T, U)>,
         __field0: T,
     }
-    impl<'pin, T, U> ::core::marker::Unpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::core::marker::Unpin
+    impl<'pin, T, U> ::pin_project::__reexport::marker::Unpin for Struct<T, U> where
+        __Struct<'pin, T, U>: ::pin_project::__reexport::marker::Unpin
     {
     }
 
@@ -104,14 +112,14 @@ const __SCOPE_Struct: () = {
     // the conflict with the second impl.
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds)]
-    impl<T: ::core::ops::Drop> StructMustNotImplDrop for T {}
+    impl<T: ::pin_project::__reexport::ops::Drop> StructMustNotImplDrop for T {}
     #[allow(single_use_lifetimes)]
     impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
     // A dummy impl of `PinnedDrop`, to ensure that users don't accidentally
     // write a non-functional `PinnedDrop` impls.
     #[allow(single_use_lifetimes)]
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
-        unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
+        unsafe fn drop(self: ::pin_project::__reexport::pin::Pin<&mut Self>) {}
     }
 
     // Ensure that it's impossible to use pin projections on a #[repr(packed)] struct.

--- a/examples/unsafe_unpin-expanded.rs
+++ b/examples/unsafe_unpin-expanded.rs
@@ -6,13 +6,13 @@
 // use pin_project::{pin_project, UnsafeUnpin};
 //
 // #[pin_project(UnsafeUnpin)]
-// pub struct Foo<T, U> {
+// pub struct Struct<T, U> {
 //     #[pin]
 //     pinned: T,
 //     unpinned: U,
 // }
 //
-// unsafe impl<T: Unpin, U> UnsafeUnpin for Foo<T, U> {}
+// unsafe impl<T: Unpin, U> UnsafeUnpin for Struct<T, U> {}
 //
 // fn main() {}
 // ```
@@ -21,7 +21,7 @@
 
 use pin_project::{pin_project, UnsafeUnpin};
 
-pub struct Foo<T, U> {
+pub struct Struct<T, U> {
     // #[pin]
     pinned: T,
     unpinned: U,
@@ -29,47 +29,53 @@ pub struct Foo<T, U> {
 
 #[allow(clippy::mut_mut)] // This lint warns `&mut &mut <ty>`.
 #[allow(dead_code)] // This lint warns unused fields/variants.
-pub(crate) struct __FooProjection<'pin, T, U>
+pub(crate) struct __StructProjection<'pin, T, U>
 where
-    Foo<T, U>: 'pin,
+    Struct<T, U>: 'pin,
 {
-    pinned: ::core::pin::Pin<&'pin mut (T)>,
+    pinned: ::pin_project::__reexport::pin::Pin<&'pin mut (T)>,
     unpinned: &'pin mut (U),
 }
 #[allow(dead_code)] // This lint warns unused fields/variants.
-pub(crate) struct __FooProjectionRef<'pin, T, U>
+pub(crate) struct __StructProjectionRef<'pin, T, U>
 where
-    Foo<T, U>: 'pin,
+    Struct<T, U>: 'pin,
 {
-    pinned: ::core::pin::Pin<&'pin (T)>,
+    pinned: ::pin_project::__reexport::pin::Pin<&'pin (T)>,
     unpinned: &'pin (U),
 }
 
 #[allow(non_upper_case_globals)]
-const __SCOPE_Foo: () = {
-    impl<T, U> Foo<T, U> {
+const __SCOPE_Struct: () = {
+    impl<T, U> Struct<T, U> {
         pub(crate) fn project<'pin>(
-            self: ::core::pin::Pin<&'pin mut Self>,
-        ) -> __FooProjection<'pin, T, U> {
+            self: ::pin_project::__reexport::pin::Pin<&'pin mut Self>,
+        ) -> __StructProjection<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_unchecked_mut();
-                __FooProjection { pinned: ::core::pin::Pin::new_unchecked(pinned), unpinned }
+                __StructProjection {
+                    pinned: ::pin_project::__reexport::pin::Pin::new_unchecked(pinned),
+                    unpinned,
+                }
             }
         }
         pub(crate) fn project_ref<'pin>(
-            self: ::core::pin::Pin<&'pin Self>,
-        ) -> __FooProjectionRef<'pin, T, U> {
+            self: ::pin_project::__reexport::pin::Pin<&'pin Self>,
+        ) -> __StructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_ref();
-                __FooProjectionRef { pinned: ::core::pin::Pin::new_unchecked(pinned), unpinned }
+                __StructProjectionRef {
+                    pinned: ::pin_project::__reexport::pin::Pin::new_unchecked(pinned),
+                    unpinned,
+                }
             }
         }
     }
 
-    unsafe impl<T: Unpin, U> UnsafeUnpin for Foo<T, U> {}
+    unsafe impl<T: Unpin, U> UnsafeUnpin for Struct<T, U> {}
 
     #[allow(single_use_lifetimes)]
-    impl<'pin, T, U> ::core::marker::Unpin for Foo<T, U> where
+    impl<'pin, T, U> ::pin_project::__reexport::marker::Unpin for Struct<T, U> where
         ::pin_project::__private::Wrapper<'pin, Self>: ::pin_project::UnsafeUnpin
     {
     }
@@ -77,14 +83,14 @@ const __SCOPE_Foo: () = {
     // Ensure that struct does not implement `Drop`.
     //
     // See ./struct-default-expanded.rs for details.
-    trait FooMustNotImplDrop {}
+    trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds)]
-    impl<T: ::core::ops::Drop> FooMustNotImplDrop for T {}
+    impl<T: ::pin_project::__reexport::ops::Drop> StructMustNotImplDrop for T {}
     #[allow(single_use_lifetimes)]
-    impl<T, U> FooMustNotImplDrop for Foo<T, U> {}
+    impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
     #[allow(single_use_lifetimes)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Foo<T, U> {
-        unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
+    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: ::pin_project::__reexport::pin::Pin<&mut Self>) {}
     }
 
     // Ensure that it's impossible to use pin projections on a #[repr(packed)] struct.
@@ -93,7 +99,7 @@ const __SCOPE_Foo: () = {
     // for details.
     #[allow(single_use_lifetimes)]
     #[deny(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &Foo<T, U>) {
+    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
         &val.pinned;
         &val.unpinned;
     }

--- a/examples/unsafe_unpin.rs
+++ b/examples/unsafe_unpin.rs
@@ -5,12 +5,12 @@
 use pin_project::{pin_project, UnsafeUnpin};
 
 #[pin_project(UnsafeUnpin)]
-pub struct Foo<T, U> {
+pub struct Struct<T, U> {
     #[pin]
     pinned: T,
     unpinned: U,
 }
 
-unsafe impl<T: Unpin, U> UnsafeUnpin for Foo<T, U> {}
+unsafe impl<T: Unpin, U> UnsafeUnpin for Struct<T, U> {}
 
 fn main() {}

--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -427,7 +427,7 @@ impl<'a> Context<'a> {
             // `self` with the replacement value without calling destructors.
             let __guard = ::pin_project::#private::UnsafeOverwriteGuard {
                 target: __self_ptr,
-                value: ::core::mem::ManuallyDrop::new(__replacement),
+                value: ::pin_project::__reexport::mem::ManuallyDrop::new(__replacement),
             };
 
             // Now create guards to drop all the pinned fields
@@ -562,7 +562,7 @@ impl<'a> Context<'a> {
                     // `self` with the replacement value without calling destructors.
                     let __guard = ::pin_project::#private::UnsafeOverwriteGuard {
                         target: __self_ptr,
-                        value: ::core::mem::ManuallyDrop::new(__replacement),
+                        value: ::pin_project::__reexport::mem::ManuallyDrop::new(__replacement),
                     };
 
                     // Now create guards to drop all the pinned fields
@@ -607,19 +607,19 @@ impl<'a> Context<'a> {
 
                 let lifetime = &self.proj.lifetime;
                 proj_fields.push(quote! {
-                    #vis #ident: ::core::pin::Pin<&#lifetime mut (#ty)>
+                    #vis #ident: ::pin_project::__reexport::pin::Pin<&#lifetime mut (#ty)>
                 });
                 proj_ref_fields.push(quote! {
-                    #vis #ident: ::core::pin::Pin<&#lifetime (#ty)>
+                    #vis #ident: ::pin_project::__reexport::pin::Pin<&#lifetime (#ty)>
                 });
                 proj_own_fields.push(quote! {
-                    #vis #ident: ::core::marker::PhantomData<#ty>
+                    #vis #ident: ::pin_project::__reexport::marker::PhantomData<#ty>
                 });
                 proj_body.push(quote! {
-                    #ident: ::core::pin::Pin::new_unchecked(#ident)
+                    #ident: ::pin_project::__reexport::pin::Pin::new_unchecked(#ident)
                 });
                 proj_move.push(quote! {
-                    #ident: ::core::marker::PhantomData
+                    #ident: ::pin_project::__reexport::marker::PhantomData
                 });
                 proj_drop.push(quote! {
                     let __guard = ::pin_project::#private::UnsafeDropInPlaceGuard(#ident);
@@ -639,7 +639,7 @@ impl<'a> Context<'a> {
                     #ident
                 });
                 proj_move.push(quote! {
-                    #ident: ::core::ptr::read(#ident)
+                    #ident: ::pin_project::__reexport::ptr::read(#ident)
                 });
             }
             proj_pat.push(ident);
@@ -684,19 +684,19 @@ impl<'a> Context<'a> {
 
                 let lifetime = &self.proj.lifetime;
                 proj_fields.push(quote! {
-                    #vis ::core::pin::Pin<&#lifetime mut (#ty)>
+                    #vis ::pin_project::__reexport::pin::Pin<&#lifetime mut (#ty)>
                 });
                 proj_ref_fields.push(quote! {
-                    #vis ::core::pin::Pin<&#lifetime (#ty)>
+                    #vis ::pin_project::__reexport::pin::Pin<&#lifetime (#ty)>
                 });
                 proj_own_fields.push(quote! {
-                    #vis ::core::marker::PhantomData<#ty>
+                    #vis ::pin_project::__reexport::marker::PhantomData<#ty>
                 });
                 proj_body.push(quote! {
-                    ::core::pin::Pin::new_unchecked(#id)
+                    ::pin_project::__reexport::pin::Pin::new_unchecked(#id)
                 });
                 proj_move.push(quote! {
-                    ::core::marker::PhantomData
+                    ::pin_project::__reexport::marker::PhantomData
                 });
                 proj_drop.push(quote! {
                     let __guard = ::pin_project::#private::UnsafeDropInPlaceGuard(#id);
@@ -716,7 +716,7 @@ impl<'a> Context<'a> {
                     #id
                 });
                 proj_move.push(quote! {
-                    ::core::ptr::read(#id)
+                    ::pin_project::__reexport::ptr::read(#id)
                 });
             }
             proj_pat.push(id);
@@ -762,7 +762,7 @@ impl<'a> Context<'a> {
 
             quote! {
                 #[allow(single_use_lifetimes)]
-                impl #impl_generics ::core::marker::Unpin for #orig_ident #ty_generics #where_clause {}
+                impl #impl_generics ::pin_project::__reexport::marker::Unpin for #orig_ident #ty_generics #where_clause {}
             }
         } else {
             let mut full_where_clause = self.orig.generics.where_clause.as_ref().cloned().unwrap();
@@ -825,7 +825,7 @@ impl<'a> Context<'a> {
             let (_, ty_generics, where_clause) = self.orig.generics.split_for_impl();
 
             full_where_clause.predicates.push(syn::parse_quote! {
-                #struct_ident #proj_ty_generics: ::core::marker::Unpin
+                #struct_ident #proj_ty_generics: ::pin_project::__reexport::marker::Unpin
             });
 
             let private = Ident::new(CURRENT_PRIVATE_MODULE, Span::call_site());
@@ -847,7 +847,7 @@ impl<'a> Context<'a> {
                     #(#lifetime_fields,)*
                 }
 
-                impl #impl_generics ::core::marker::Unpin for #orig_ident #ty_generics #full_where_clause {}
+                impl #impl_generics ::pin_project::__reexport::marker::Unpin for #orig_ident #ty_generics #full_where_clause {}
             }
         }
     }
@@ -869,11 +869,11 @@ impl<'a> Context<'a> {
 
             quote! {
                 #[allow(single_use_lifetimes)]
-                impl #impl_generics ::core::ops::Drop for #ident #ty_generics #where_clause {
+                impl #impl_generics ::pin_project::__reexport::ops::Drop for #ident #ty_generics #where_clause {
                     fn drop(&mut self) {
                         // Safety - we're in 'drop', so we know that 'self' will
                         // never move again.
-                        let pinned_self = unsafe { ::core::pin::Pin::new_unchecked(self) };
+                        let pinned_self = unsafe { ::pin_project::__reexport::pin::Pin::new_unchecked(self) };
                         // We call `pinned_drop` only once. Since `PinnedDrop::drop`
                         // is an unsafe method and a private API, it is never called again in safe
                         // code *unless the user uses a maliciously crafted macro*.
@@ -910,7 +910,7 @@ impl<'a> Context<'a> {
                 // This will result in a compilation error, which is exactly what we want.
                 trait #trait_ident {}
                 #[allow(clippy::drop_bounds)]
-                impl<T: ::core::ops::Drop> #trait_ident for T {}
+                impl<T: ::pin_project::__reexport::ops::Drop> #trait_ident for T {}
                 #[allow(single_use_lifetimes)]
                 impl #impl_generics #trait_ident for #ident #ty_generics #where_clause {}
 
@@ -926,7 +926,7 @@ impl<'a> Context<'a> {
                 // checks are run.
                 #[allow(single_use_lifetimes)]
                 impl #impl_generics ::pin_project::#private::PinnedDrop for #ident #ty_generics #where_clause {
-                    unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
+                    unsafe fn drop(self: ::pin_project::__reexport::pin::Pin<&mut Self>) {}
                 }
             }
         }
@@ -954,7 +954,7 @@ impl<'a> Context<'a> {
             // TODO: Use `_replace`'s span.
             quote! {
                 #vis fn project_replace(
-                    self: ::core::pin::Pin<&mut Self>,
+                    self: ::pin_project::__reexport::pin::Pin<&mut Self>,
                     __replacement: Self,
                 ) -> #proj_own_ident #orig_ty_generics {
                     unsafe {
@@ -967,14 +967,14 @@ impl<'a> Context<'a> {
         quote! {
             impl #impl_generics #orig_ident #ty_generics #where_clause {
                 #vis fn project<#lifetime>(
-                    self: ::core::pin::Pin<&#lifetime mut Self>,
+                    self: ::pin_project::__reexport::pin::Pin<&#lifetime mut Self>,
                 ) -> #proj_ident #proj_ty_generics {
                     unsafe {
                         #proj_body
                     }
                 }
                 #vis fn project_ref<#lifetime>(
-                    self: ::core::pin::Pin<&#lifetime Self>,
+                    self: ::pin_project::__reexport::pin::Pin<&#lifetime Self>,
                 ) -> #proj_ref_ident #proj_ty_generics {
                     unsafe {
                         #proj_ref_body

--- a/pin-project-internal/src/pinned_drop.rs
+++ b/pin-project-internal/src/pinned_drop.rs
@@ -23,7 +23,7 @@ pub(crate) fn attribute(args: &TokenStream, mut input: ItemImpl) -> TokenStream 
         // accidentally compile successfully.
         tokens.extend(quote! {
             impl #impl_generics ::pin_project::#private::PinnedDrop for #self_ty #where_clause {
-                unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
+                unsafe fn drop(self: ::pin_project::__reexport::pin::Pin<&mut Self>) {}
             }
         });
         tokens

--- a/pin-project-internal/src/utils.rs
+++ b/pin-project-internal/src/utils.rs
@@ -261,7 +261,7 @@ impl<'a> ReplaceReceiver<'a> {
             let span = path.segments[0].ident.span();
             let msg = "Self type of this impl is unsupported in expression position";
             let error = Error::new(span, msg).to_compile_error();
-            *path = parse_quote!(::core::marker::PhantomData::<#error>);
+            *path = parse_quote!(::pin_project::__reexport::marker::PhantomData::<#error>);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,3 +230,11 @@ pub mod __private {
         }
     }
 }
+
+// Not public API.
+// See tests/overwriting_core_crate.rs for more.
+#[doc(hidden)]
+pub mod __reexport {
+    #[doc(hidden)]
+    pub use core::{marker, mem, ops, pin, ptr};
+}

--- a/tests/expand/tests/enum/default.expanded.rs
+++ b/tests/expand/tests/enum/default.expanded.rs
@@ -10,7 +10,7 @@ enum __EnumProjection<'pin, T, U>
 where
     Enum<T, U>: 'pin,
 {
-    Pinned(::core::pin::Pin<&'pin mut (T)>),
+    Pinned(::pin_project::__reexport::pin::Pin<&'pin mut (T)>),
     Unpinned(&'pin mut (U)),
 }
 #[allow(dead_code)]
@@ -18,30 +18,32 @@ enum __EnumProjectionRef<'pin, T, U>
 where
     Enum<T, U>: 'pin,
 {
-    Pinned(::core::pin::Pin<&'pin (T)>),
+    Pinned(::pin_project::__reexport::pin::Pin<&'pin (T)>),
     Unpinned(&'pin (U)),
 }
 #[allow(non_upper_case_globals)]
 const __SCOPE_Enum: () = {
     impl<T, U> Enum<T, U> {
-        fn project<'pin>(self: ::core::pin::Pin<&'pin mut Self>) -> __EnumProjection<'pin, T, U> {
+        fn project<'pin>(
+            self: ::pin_project::__reexport::pin::Pin<&'pin mut Self>,
+        ) -> __EnumProjection<'pin, T, U> {
             unsafe {
                 match self.get_unchecked_mut() {
-                    Enum::Pinned(_0) => {
-                        __EnumProjection::Pinned(::core::pin::Pin::new_unchecked(_0))
-                    }
+                    Enum::Pinned(_0) => __EnumProjection::Pinned(
+                        ::pin_project::__reexport::pin::Pin::new_unchecked(_0),
+                    ),
                     Enum::Unpinned(_0) => __EnumProjection::Unpinned(_0),
                 }
             }
         }
         fn project_ref<'pin>(
-            self: ::core::pin::Pin<&'pin Self>,
+            self: ::pin_project::__reexport::pin::Pin<&'pin Self>,
         ) -> __EnumProjectionRef<'pin, T, U> {
             unsafe {
                 match self.get_ref() {
-                    Enum::Pinned(_0) => {
-                        __EnumProjectionRef::Pinned(::core::pin::Pin::new_unchecked(_0))
-                    }
+                    Enum::Pinned(_0) => __EnumProjectionRef::Pinned(
+                        ::pin_project::__reexport::pin::Pin::new_unchecked(_0),
+                    ),
                     Enum::Unpinned(_0) => __EnumProjectionRef::Unpinned(_0),
                 }
             }
@@ -51,16 +53,18 @@ const __SCOPE_Enum: () = {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T, U)>,
         __field0: T,
     }
-    impl<'pin, T, U> ::core::marker::Unpin for Enum<T, U> where __Enum<'pin, T, U>: ::core::marker::Unpin
-    {}
+    impl<'pin, T, U> ::pin_project::__reexport::marker::Unpin for Enum<T, U> where
+        __Enum<'pin, T, U>: ::pin_project::__reexport::marker::Unpin
+    {
+    }
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds)]
-    impl<T: ::core::ops::Drop> EnumMustNotImplDrop for T {}
+    impl<T: ::pin_project::__reexport::ops::Drop> EnumMustNotImplDrop for T {}
     #[allow(single_use_lifetimes)]
     impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
     #[allow(single_use_lifetimes)]
     impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
-        unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
+        unsafe fn drop(self: ::pin_project::__reexport::pin::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/tests/enum/project_replace.expanded.rs
+++ b/tests/expand/tests/enum/project_replace.expanded.rs
@@ -15,7 +15,7 @@ where
     Enum<T, U>: 'pin,
 {
     V {
-        pinned: ::core::pin::Pin<&'pin mut (T)>,
+        pinned: ::pin_project::__reexport::pin::Pin<&'pin mut (T)>,
         unpinned: &'pin mut (U),
     },
     None,
@@ -26,7 +26,7 @@ where
     Enum<T, U>: 'pin,
 {
     V {
-        pinned: ::core::pin::Pin<&'pin (T)>,
+        pinned: ::pin_project::__reexport::pin::Pin<&'pin (T)>,
         unpinned: &'pin (U),
     },
     None,
@@ -34,7 +34,7 @@ where
 #[allow(dead_code)]
 enum __EnumProjectionOwned<T, U> {
     V {
-        pinned: ::core::marker::PhantomData<T>,
+        pinned: ::pin_project::__reexport::marker::PhantomData<T>,
         unpinned: U,
     },
     None,
@@ -42,11 +42,13 @@ enum __EnumProjectionOwned<T, U> {
 #[allow(non_upper_case_globals)]
 const __SCOPE_Enum: () = {
     impl<T, U> Enum<T, U> {
-        fn project<'pin>(self: ::core::pin::Pin<&'pin mut Self>) -> __EnumProjection<'pin, T, U> {
+        fn project<'pin>(
+            self: ::pin_project::__reexport::pin::Pin<&'pin mut Self>,
+        ) -> __EnumProjection<'pin, T, U> {
             unsafe {
                 match self.get_unchecked_mut() {
                     Enum::V { pinned, unpinned } => __EnumProjection::V {
-                        pinned: ::core::pin::Pin::new_unchecked(pinned),
+                        pinned: ::pin_project::__reexport::pin::Pin::new_unchecked(pinned),
                         unpinned,
                     },
                     Enum::None => __EnumProjection::None,
@@ -54,12 +56,12 @@ const __SCOPE_Enum: () = {
             }
         }
         fn project_ref<'pin>(
-            self: ::core::pin::Pin<&'pin Self>,
+            self: ::pin_project::__reexport::pin::Pin<&'pin Self>,
         ) -> __EnumProjectionRef<'pin, T, U> {
             unsafe {
                 match self.get_ref() {
                     Enum::V { pinned, unpinned } => __EnumProjectionRef::V {
-                        pinned: ::core::pin::Pin::new_unchecked(pinned),
+                        pinned: ::pin_project::__reexport::pin::Pin::new_unchecked(pinned),
                         unpinned,
                     },
                     Enum::None => __EnumProjectionRef::None,
@@ -67,7 +69,7 @@ const __SCOPE_Enum: () = {
             }
         }
         fn project_replace(
-            self: ::core::pin::Pin<&mut Self>,
+            self: ::pin_project::__reexport::pin::Pin<&mut Self>,
             __replacement: Self,
         ) -> __EnumProjectionOwned<T, U> {
             unsafe {
@@ -75,12 +77,12 @@ const __SCOPE_Enum: () = {
                 match &mut *__self_ptr {
                     Enum::V { pinned, unpinned } => {
                         let __result = __EnumProjectionOwned::V {
-                            pinned: ::core::marker::PhantomData,
-                            unpinned: ::core::ptr::read(unpinned),
+                            pinned: ::pin_project::__reexport::marker::PhantomData,
+                            unpinned: ::pin_project::__reexport::ptr::read(unpinned),
                         };
                         let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
                             target: __self_ptr,
-                            value: ::core::mem::ManuallyDrop::new(__replacement),
+                            value: ::pin_project::__reexport::mem::ManuallyDrop::new(__replacement),
                         };
                         {
                             let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned);
@@ -91,7 +93,7 @@ const __SCOPE_Enum: () = {
                         let __result = __EnumProjectionOwned::None;
                         let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
                             target: __self_ptr,
-                            value: ::core::mem::ManuallyDrop::new(__replacement),
+                            value: ::pin_project::__reexport::mem::ManuallyDrop::new(__replacement),
                         };
                         {}
                         __result
@@ -104,16 +106,18 @@ const __SCOPE_Enum: () = {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T, U)>,
         __field0: T,
     }
-    impl<'pin, T, U> ::core::marker::Unpin for Enum<T, U> where __Enum<'pin, T, U>: ::core::marker::Unpin
-    {}
+    impl<'pin, T, U> ::pin_project::__reexport::marker::Unpin for Enum<T, U> where
+        __Enum<'pin, T, U>: ::pin_project::__reexport::marker::Unpin
+    {
+    }
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds)]
-    impl<T: ::core::ops::Drop> EnumMustNotImplDrop for T {}
+    impl<T: ::pin_project::__reexport::ops::Drop> EnumMustNotImplDrop for T {}
     #[allow(single_use_lifetimes)]
     impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
     #[allow(single_use_lifetimes)]
     impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
-        unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
+        unsafe fn drop(self: ::pin_project::__reexport::pin::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/tests/struct/default.expanded.rs
+++ b/tests/expand/tests/struct/default.expanded.rs
@@ -11,7 +11,7 @@ struct __StructProjection<'pin, T, U>
 where
     Struct<T, U>: 'pin,
 {
-    pinned: ::core::pin::Pin<&'pin mut (T)>,
+    pinned: ::pin_project::__reexport::pin::Pin<&'pin mut (T)>,
     unpinned: &'pin mut (U),
 }
 #[allow(dead_code)]
@@ -19,28 +19,30 @@ struct __StructProjectionRef<'pin, T, U>
 where
     Struct<T, U>: 'pin,
 {
-    pinned: ::core::pin::Pin<&'pin (T)>,
+    pinned: ::pin_project::__reexport::pin::Pin<&'pin (T)>,
     unpinned: &'pin (U),
 }
 #[allow(non_upper_case_globals)]
 const __SCOPE_Struct: () = {
     impl<T, U> Struct<T, U> {
-        fn project<'pin>(self: ::core::pin::Pin<&'pin mut Self>) -> __StructProjection<'pin, T, U> {
+        fn project<'pin>(
+            self: ::pin_project::__reexport::pin::Pin<&'pin mut Self>,
+        ) -> __StructProjection<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_unchecked_mut();
                 __StructProjection {
-                    pinned: ::core::pin::Pin::new_unchecked(pinned),
+                    pinned: ::pin_project::__reexport::pin::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         fn project_ref<'pin>(
-            self: ::core::pin::Pin<&'pin Self>,
+            self: ::pin_project::__reexport::pin::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_ref();
                 __StructProjectionRef {
-                    pinned: ::core::pin::Pin::new_unchecked(pinned),
+                    pinned: ::pin_project::__reexport::pin::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
@@ -50,18 +52,18 @@ const __SCOPE_Struct: () = {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T, U)>,
         __field0: T,
     }
-    impl<'pin, T, U> ::core::marker::Unpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::core::marker::Unpin
+    impl<'pin, T, U> ::pin_project::__reexport::marker::Unpin for Struct<T, U> where
+        __Struct<'pin, T, U>: ::pin_project::__reexport::marker::Unpin
     {
     }
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds)]
-    impl<T: ::core::ops::Drop> StructMustNotImplDrop for T {}
+    impl<T: ::pin_project::__reexport::ops::Drop> StructMustNotImplDrop for T {}
     #[allow(single_use_lifetimes)]
     impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
     #[allow(single_use_lifetimes)]
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
-        unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
+        unsafe fn drop(self: ::pin_project::__reexport::pin::Pin<&mut Self>) {}
     }
     #[allow(single_use_lifetimes)]
     #[deny(safe_packed_borrows)]

--- a/tests/expand/tests/struct/pinned_drop.expanded.rs
+++ b/tests/expand/tests/struct/pinned_drop.expanded.rs
@@ -1,67 +1,67 @@
 use pin_project::{pin_project, pinned_drop};
 use std::pin::Pin;
 #[pin(__private(PinnedDrop))]
-pub struct Foo<'a, T> {
+pub struct Struct<'a, T> {
     was_dropped: &'a mut bool,
     #[pin]
     field: T,
 }
 #[allow(clippy::mut_mut)]
 #[allow(dead_code)]
-pub(crate) struct __FooProjection<'pin, 'a, T>
+pub(crate) struct __StructProjection<'pin, 'a, T>
 where
-    Foo<'a, T>: 'pin,
+    Struct<'a, T>: 'pin,
 {
     was_dropped: &'pin mut (&'a mut bool),
-    field: ::core::pin::Pin<&'pin mut (T)>,
+    field: ::pin_project::__reexport::pin::Pin<&'pin mut (T)>,
 }
 #[allow(dead_code)]
-pub(crate) struct __FooProjectionRef<'pin, 'a, T>
+pub(crate) struct __StructProjectionRef<'pin, 'a, T>
 where
-    Foo<'a, T>: 'pin,
+    Struct<'a, T>: 'pin,
 {
     was_dropped: &'pin (&'a mut bool),
-    field: ::core::pin::Pin<&'pin (T)>,
+    field: ::pin_project::__reexport::pin::Pin<&'pin (T)>,
 }
 #[allow(non_upper_case_globals)]
-const __SCOPE_Foo: () = {
-    impl<'a, T> Foo<'a, T> {
+const __SCOPE_Struct: () = {
+    impl<'a, T> Struct<'a, T> {
         pub(crate) fn project<'pin>(
-            self: ::core::pin::Pin<&'pin mut Self>,
-        ) -> __FooProjection<'pin, 'a, T> {
+            self: ::pin_project::__reexport::pin::Pin<&'pin mut Self>,
+        ) -> __StructProjection<'pin, 'a, T> {
             unsafe {
                 let Self { was_dropped, field } = self.get_unchecked_mut();
-                __FooProjection {
+                __StructProjection {
                     was_dropped,
-                    field: ::core::pin::Pin::new_unchecked(field),
+                    field: ::pin_project::__reexport::pin::Pin::new_unchecked(field),
                 }
             }
         }
         pub(crate) fn project_ref<'pin>(
-            self: ::core::pin::Pin<&'pin Self>,
-        ) -> __FooProjectionRef<'pin, 'a, T> {
+            self: ::pin_project::__reexport::pin::Pin<&'pin Self>,
+        ) -> __StructProjectionRef<'pin, 'a, T> {
             unsafe {
                 let Self { was_dropped, field } = self.get_ref();
-                __FooProjectionRef {
+                __StructProjectionRef {
                     was_dropped,
-                    field: ::core::pin::Pin::new_unchecked(field),
+                    field: ::pin_project::__reexport::pin::Pin::new_unchecked(field),
                 }
             }
         }
     }
-    pub struct __Foo<'pin, 'a, T> {
+    pub struct __Struct<'pin, 'a, T> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T)>,
         __field0: T,
         __lifetime0: &'a (),
     }
-    impl<'pin, 'a, T> ::core::marker::Unpin for Foo<'a, T> where
-        __Foo<'pin, 'a, T>: ::core::marker::Unpin
+    impl<'pin, 'a, T> ::pin_project::__reexport::marker::Unpin for Struct<'a, T> where
+        __Struct<'pin, 'a, T>: ::pin_project::__reexport::marker::Unpin
     {
     }
     #[allow(single_use_lifetimes)]
-    impl<'a, T> ::core::ops::Drop for Foo<'a, T> {
+    impl<'a, T> ::pin_project::__reexport::ops::Drop for Struct<'a, T> {
         fn drop(&mut self) {
-            let pinned_self = unsafe { ::core::pin::Pin::new_unchecked(self) };
+            let pinned_self = unsafe { ::pin_project::__reexport::pin::Pin::new_unchecked(self) };
             unsafe {
                 ::pin_project::__private::PinnedDrop::drop(pinned_self);
             }
@@ -69,14 +69,14 @@ const __SCOPE_Foo: () = {
     }
     #[allow(single_use_lifetimes)]
     #[deny(safe_packed_borrows)]
-    fn __assert_not_repr_packed<'a, T>(val: &Foo<'a, T>) {
+    fn __assert_not_repr_packed<'a, T>(val: &Struct<'a, T>) {
         &val.was_dropped;
         &val.field;
     }
 };
-impl<T> ::pin_project::__private::PinnedDrop for Foo<'_, T> {
+impl<T> ::pin_project::__private::PinnedDrop for Struct<'_, T> {
     unsafe fn drop(self: Pin<&mut Self>) {
-        fn __drop_inner<T>(__self: Pin<&mut Foo<'_, T>>) {
+        fn __drop_inner<T>(__self: Pin<&mut Struct<'_, T>>) {
             **__self.project().was_dropped = true;
         }
         __drop_inner(self);

--- a/tests/expand/tests/struct/pinned_drop.rs
+++ b/tests/expand/tests/struct/pinned_drop.rs
@@ -2,14 +2,14 @@ use pin_project::{pin_project, pinned_drop};
 use std::pin::Pin;
 
 #[pin_project(PinnedDrop)]
-pub struct Foo<'a, T> {
+pub struct Struct<'a, T> {
     was_dropped: &'a mut bool,
     #[pin]
     field: T,
 }
 
 #[pinned_drop]
-impl<T> PinnedDrop for Foo<'_, T> {
+impl<T> PinnedDrop for Struct<'_, T> {
     fn drop(self: Pin<&mut Self>) {
         **self.project().was_dropped = true;
     }

--- a/tests/expand/tests/struct/project_replace.expanded.rs
+++ b/tests/expand/tests/struct/project_replace.expanded.rs
@@ -11,7 +11,7 @@ struct __StructProjection<'pin, T, U>
 where
     Struct<T, U>: 'pin,
 {
-    pinned: ::core::pin::Pin<&'pin mut (T)>,
+    pinned: ::pin_project::__reexport::pin::Pin<&'pin mut (T)>,
     unpinned: &'pin mut (U),
 }
 #[allow(dead_code)]
@@ -19,51 +19,53 @@ struct __StructProjectionRef<'pin, T, U>
 where
     Struct<T, U>: 'pin,
 {
-    pinned: ::core::pin::Pin<&'pin (T)>,
+    pinned: ::pin_project::__reexport::pin::Pin<&'pin (T)>,
     unpinned: &'pin (U),
 }
 #[allow(dead_code)]
 struct __StructProjectionOwned<T, U> {
-    pinned: ::core::marker::PhantomData<T>,
+    pinned: ::pin_project::__reexport::marker::PhantomData<T>,
     unpinned: U,
 }
 #[allow(non_upper_case_globals)]
 const __SCOPE_Struct: () = {
     impl<T, U> Struct<T, U> {
-        fn project<'pin>(self: ::core::pin::Pin<&'pin mut Self>) -> __StructProjection<'pin, T, U> {
+        fn project<'pin>(
+            self: ::pin_project::__reexport::pin::Pin<&'pin mut Self>,
+        ) -> __StructProjection<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_unchecked_mut();
                 __StructProjection {
-                    pinned: ::core::pin::Pin::new_unchecked(pinned),
+                    pinned: ::pin_project::__reexport::pin::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         fn project_ref<'pin>(
-            self: ::core::pin::Pin<&'pin Self>,
+            self: ::pin_project::__reexport::pin::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_ref();
                 __StructProjectionRef {
-                    pinned: ::core::pin::Pin::new_unchecked(pinned),
+                    pinned: ::pin_project::__reexport::pin::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         fn project_replace(
-            self: ::core::pin::Pin<&mut Self>,
+            self: ::pin_project::__reexport::pin::Pin<&mut Self>,
             __replacement: Self,
         ) -> __StructProjectionOwned<T, U> {
             unsafe {
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
                 let Self { pinned, unpinned } = &mut *__self_ptr;
                 let __result = __StructProjectionOwned {
-                    pinned: ::core::marker::PhantomData,
-                    unpinned: ::core::ptr::read(unpinned),
+                    pinned: ::pin_project::__reexport::marker::PhantomData,
+                    unpinned: ::pin_project::__reexport::ptr::read(unpinned),
                 };
                 let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
                     target: __self_ptr,
-                    value: ::core::mem::ManuallyDrop::new(__replacement),
+                    value: ::pin_project::__reexport::mem::ManuallyDrop::new(__replacement),
                 };
                 {
                     let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned);
@@ -76,18 +78,18 @@ const __SCOPE_Struct: () = {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T, U)>,
         __field0: T,
     }
-    impl<'pin, T, U> ::core::marker::Unpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::core::marker::Unpin
+    impl<'pin, T, U> ::pin_project::__reexport::marker::Unpin for Struct<T, U> where
+        __Struct<'pin, T, U>: ::pin_project::__reexport::marker::Unpin
     {
     }
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds)]
-    impl<T: ::core::ops::Drop> StructMustNotImplDrop for T {}
+    impl<T: ::pin_project::__reexport::ops::Drop> StructMustNotImplDrop for T {}
     #[allow(single_use_lifetimes)]
     impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
     #[allow(single_use_lifetimes)]
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
-        unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
+        unsafe fn drop(self: ::pin_project::__reexport::pin::Pin<&mut Self>) {}
     }
     #[allow(single_use_lifetimes)]
     #[deny(safe_packed_borrows)]

--- a/tests/expand/tests/struct/unsafe_unpin.expanded.rs
+++ b/tests/expand/tests/struct/unsafe_unpin.expanded.rs
@@ -1,73 +1,73 @@
 use pin_project::{pin_project, UnsafeUnpin};
 #[pin(__private(UnsafeUnpin))]
-pub struct Foo<T, U> {
+pub struct Struct<T, U> {
     #[pin]
     pinned: T,
     unpinned: U,
 }
 #[allow(clippy::mut_mut)]
 #[allow(dead_code)]
-pub(crate) struct __FooProjection<'pin, T, U>
+pub(crate) struct __StructProjection<'pin, T, U>
 where
-    Foo<T, U>: 'pin,
+    Struct<T, U>: 'pin,
 {
-    pinned: ::core::pin::Pin<&'pin mut (T)>,
+    pinned: ::pin_project::__reexport::pin::Pin<&'pin mut (T)>,
     unpinned: &'pin mut (U),
 }
 #[allow(dead_code)]
-pub(crate) struct __FooProjectionRef<'pin, T, U>
+pub(crate) struct __StructProjectionRef<'pin, T, U>
 where
-    Foo<T, U>: 'pin,
+    Struct<T, U>: 'pin,
 {
-    pinned: ::core::pin::Pin<&'pin (T)>,
+    pinned: ::pin_project::__reexport::pin::Pin<&'pin (T)>,
     unpinned: &'pin (U),
 }
 #[allow(non_upper_case_globals)]
-const __SCOPE_Foo: () = {
-    impl<T, U> Foo<T, U> {
+const __SCOPE_Struct: () = {
+    impl<T, U> Struct<T, U> {
         pub(crate) fn project<'pin>(
-            self: ::core::pin::Pin<&'pin mut Self>,
-        ) -> __FooProjection<'pin, T, U> {
+            self: ::pin_project::__reexport::pin::Pin<&'pin mut Self>,
+        ) -> __StructProjection<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_unchecked_mut();
-                __FooProjection {
-                    pinned: ::core::pin::Pin::new_unchecked(pinned),
+                __StructProjection {
+                    pinned: ::pin_project::__reexport::pin::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         pub(crate) fn project_ref<'pin>(
-            self: ::core::pin::Pin<&'pin Self>,
-        ) -> __FooProjectionRef<'pin, T, U> {
+            self: ::pin_project::__reexport::pin::Pin<&'pin Self>,
+        ) -> __StructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_ref();
-                __FooProjectionRef {
-                    pinned: ::core::pin::Pin::new_unchecked(pinned),
+                __StructProjectionRef {
+                    pinned: ::pin_project::__reexport::pin::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
     }
     #[allow(single_use_lifetimes)]
-    impl<'pin, T, U> ::core::marker::Unpin for Foo<T, U> where
+    impl<'pin, T, U> ::pin_project::__reexport::marker::Unpin for Struct<T, U> where
         ::pin_project::__private::Wrapper<'pin, Self>: ::pin_project::UnsafeUnpin
     {
     }
-    trait FooMustNotImplDrop {}
+    trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds)]
-    impl<T: ::core::ops::Drop> FooMustNotImplDrop for T {}
+    impl<T: ::pin_project::__reexport::ops::Drop> StructMustNotImplDrop for T {}
     #[allow(single_use_lifetimes)]
-    impl<T, U> FooMustNotImplDrop for Foo<T, U> {}
+    impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
     #[allow(single_use_lifetimes)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Foo<T, U> {
-        unsafe fn drop(self: ::core::pin::Pin<&mut Self>) {}
+    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: ::pin_project::__reexport::pin::Pin<&mut Self>) {}
     }
     #[allow(single_use_lifetimes)]
     #[deny(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &Foo<T, U>) {
+    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
         &val.pinned;
         &val.unpinned;
     }
 };
-unsafe impl<T: Unpin, U> UnsafeUnpin for Foo<T, U> {}
+unsafe impl<T: Unpin, U> UnsafeUnpin for Struct<T, U> {}
 fn main() {}

--- a/tests/expand/tests/struct/unsafe_unpin.rs
+++ b/tests/expand/tests/struct/unsafe_unpin.rs
@@ -1,12 +1,12 @@
 use pin_project::{pin_project, UnsafeUnpin};
 
 #[pin_project(UnsafeUnpin)]
-pub struct Foo<T, U> {
+pub struct Struct<T, U> {
     #[pin]
     pinned: T,
     unpinned: U,
 }
 
-unsafe impl<T: Unpin, U> UnsafeUnpin for Foo<T, U> {}
+unsafe impl<T: Unpin, U> UnsafeUnpin for Struct<T, U> {}
 
 fn main() {}

--- a/tests/overwriting_core_crate.rs
+++ b/tests/overwriting_core_crate.rs
@@ -1,0 +1,112 @@
+#![warn(rust_2018_idioms, single_use_lifetimes)]
+#![allow(dead_code)]
+
+// See https://github.com/rust-lang/pin-utils/pull/26#discussion_r344491597
+//
+// Note: If the proc-macro does not depend on its own items, it may be preferable not to
+//       support overwriting the name of core/std crate for compatibility with reexport.
+#[allow(unused_extern_crates)]
+extern crate pin_project as core;
+
+// Dummy module to check that the expansion refer to pin-project crate
+mod pin_project {}
+
+use ::pin_project::{pin_project, pinned_drop, UnsafeUnpin};
+use std::pin::Pin;
+
+#[pin_project]
+struct StructDefault<T, U> {
+    #[pin]
+    pinned: T,
+    unpinned: U,
+}
+
+#[pin_project(UnsafeUnpin)]
+struct StructUnsafeUnpin<T, U> {
+    #[pin]
+    pinned: T,
+    unpinned: U,
+}
+
+unsafe impl<T: Unpin, U> UnsafeUnpin for StructUnsafeUnpin<T, U> {}
+
+#[pin_project(PinnedDrop)]
+struct StructPinnedDrop<T, U> {
+    #[pin]
+    pinned: T,
+    unpinned: U,
+}
+
+#[pinned_drop]
+impl<T, U> PinnedDrop for StructPinnedDrop<T, U> {
+    fn drop(self: Pin<&mut Self>) {}
+}
+
+#[pin_project(Replace)]
+struct StructReplace<T, U> {
+    #[pin]
+    pinned: T,
+    unpinned: U,
+}
+
+#[pin_project]
+struct StructMutMut<'a, T, U> {
+    #[pin]
+    pinned: &'a mut T,
+    unpinned: &'a mut U,
+}
+
+#[pin_project]
+enum EnumDefault<T, U> {
+    Variant {
+        #[pin]
+        pinned: T,
+        unpinned: U,
+    },
+}
+
+#[pin_project(UnsafeUnpin)]
+enum EnumUnsafeUnpin<T, U> {
+    Variant {
+        #[pin]
+        pinned: T,
+        unpinned: U,
+    },
+}
+
+unsafe impl<T: Unpin, U> UnsafeUnpin for EnumUnsafeUnpin<T, U> {}
+
+#[pin_project(PinnedDrop)]
+enum EnumPinnedDrop<T, U> {
+    Variant {
+        #[pin]
+        pinned: T,
+        unpinned: U,
+    },
+}
+
+#[pinned_drop]
+impl<T, U> PinnedDrop for EnumPinnedDrop<T, U> {
+    fn drop(self: Pin<&mut Self>) {}
+}
+
+#[pin_project(Replace)]
+enum EnumReplace<T, U> {
+    Variant {
+        #[pin]
+        pinned: T,
+        unpinned: U,
+    },
+}
+
+#[pin_project]
+enum EnumMutMut<'a, T, U> {
+    Variant {
+        #[pin]
+        pinned: &'a mut T,
+        unpinned: &'a mut U,
+    },
+}
+
+#[test]
+fn test() {}


### PR DESCRIPTION
See https://github.com/rust-lang/pin-utils/pull/26#discussion_r344491597

Note: If the proc-macro does not depend on its own items, it may be preferable not to
      support overwriting the name of core/std crate for compatibility with reexport.