### PR TITLE
Add #[allow(clippy::needless_pass_by_value)] to drop_inner

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ pub mod __private {
 
     // It is safe to implement PinnedDrop::drop, but it is not safe to call it.
     // This is because destructors can be called multiple times (double dropping
-    // is unsound: rust-lang/rust#62360).
+    // is unsound: https://github.com/rust-lang/rust/pull/62360).
     //
     // Ideally, it would be desirable to be able to prohibit manual calls in the
     // same way as Drop::drop, but the library cannot. So, by using macros and

--- a/tests/clippy.rs
+++ b/tests/clippy.rs
@@ -30,7 +30,6 @@ pub struct StructPinnedDrop<T, U> {
 
 #[pinned_drop]
 impl<T, U> PinnedDrop for StructPinnedDrop<T, U> {
-    #[allow(clippy::needless_pass_by_value)] // FIXME: https://github.com/rust-lang/rust-clippy/issues/3031?
     fn drop(self: Pin<&mut Self>) {}
 }
 
@@ -79,7 +78,6 @@ pub enum EnumPinnedDrop<T, U> {
 
 #[pinned_drop]
 impl<T, U> PinnedDrop for EnumPinnedDrop<T, U> {
-    #[allow(clippy::needless_pass_by_value)] // FIXME: https://github.com/rust-lang/rust-clippy/issues/3031?
     fn drop(self: Pin<&mut Self>) {}
 }
 

--- a/tests/expand/tests/struct/pinned_drop.expanded.rs
+++ b/tests/expand/tests/struct/pinned_drop.expanded.rs
@@ -76,6 +76,7 @@ const __SCOPE_Struct: () = {
 };
 impl<T> ::pin_project::__private::PinnedDrop for Struct<'_, T> {
     unsafe fn drop(self: Pin<&mut Self>) {
+        #[allow(clippy::needless_pass_by_value)]
         fn __drop_inner<T>(__self: Pin<&mut Struct<'_, T>>) {
             **__self.project().was_dropped = true;
         }


### PR DESCRIPTION
This lint does not warn the receiver.