### PR TITLE
Allow naming the projected types

### DIFF
--- a/examples/enum-default-expanded.rs
+++ b/examples/enum-default-expanded.rs
@@ -5,7 +5,7 @@
 //
 // use pin_project::pin_project;
 //
-// #[pin_project]
+// #[pin_project(project = EnumProj)]
 // enum Enum<T, U> {
 //     Pinned(#[pin] T),
 //     Unpinned(U),
@@ -24,11 +24,10 @@ enum Enum<T, U> {
     Unpinned(U),
 }
 
-#[doc(hidden)]
 #[allow(clippy::mut_mut)] // This lint warns `&mut &mut <ty>`.
 #[allow(dead_code)] // This lint warns unused fields/variants.
 #[allow(single_use_lifetimes)]
-enum __EnumProjection<'pin, T, U>
+enum EnumProj<'pin, T, U>
 where
     Enum<T, U>: 'pin,
 {
@@ -53,13 +52,13 @@ const __SCOPE_Enum: () = {
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
             self: ::pin_project::__reexport::pin::Pin<&'pin mut Self>,
-        ) -> __EnumProjection<'pin, T, U> {
+        ) -> EnumProj<'pin, T, U> {
             unsafe {
                 match self.get_unchecked_mut() {
-                    Enum::Pinned(_0) => __EnumProjection::Pinned(
-                        ::pin_project::__reexport::pin::Pin::new_unchecked(_0),
-                    ),
-                    Enum::Unpinned(_0) => __EnumProjection::Unpinned(_0),
+                    Enum::Pinned(_0) => {
+                        EnumProj::Pinned(::pin_project::__reexport::pin::Pin::new_unchecked(_0))
+                    }
+                    Enum::Unpinned(_0) => EnumProj::Unpinned(_0),
                 }
             }
         }

--- a/examples/enum-default.rs
+++ b/examples/enum-default.rs
@@ -4,7 +4,7 @@
 
 use pin_project::pin_project;
 
-#[pin_project]
+#[pin_project(project = EnumProj)]
 enum Enum<T, U> {
     Pinned(#[pin] T),
     Unpinned(U),

--- a/tests/expand/tests/expand/naming-enum.expanded.rs
+++ b/tests/expand/tests/expand/naming-enum.expanded.rs
@@ -1,0 +1,155 @@
+use pin_project::pin_project;
+# [ pin ( __private ( Replace , project = Proj , project_ref = ProjRef , project_replace = ProjOwn ) ) ]
+enum Enum<T, U> {
+    Struct {
+        #[pin]
+        pinned: T,
+        unpinned: U,
+    },
+    Tuple(#[pin] T, U),
+    Unit,
+}
+#[allow(clippy::mut_mut)]
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+enum Proj<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Struct {
+        pinned: ::pin_project::__reexport::pin::Pin<&'pin mut (T)>,
+        unpinned: &'pin mut (U),
+    },
+    Tuple(
+        ::pin_project::__reexport::pin::Pin<&'pin mut (T)>,
+        &'pin mut (U),
+    ),
+    Unit,
+}
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+enum ProjRef<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Struct {
+        pinned: ::pin_project::__reexport::pin::Pin<&'pin (T)>,
+        unpinned: &'pin (U),
+    },
+    Tuple(::pin_project::__reexport::pin::Pin<&'pin (T)>, &'pin (U)),
+    Unit,
+}
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+enum ProjOwn<T, U> {
+    Struct {
+        pinned: ::pin_project::__reexport::marker::PhantomData<T>,
+        unpinned: U,
+    },
+    Tuple(::pin_project::__reexport::marker::PhantomData<T>, U),
+    Unit,
+}
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+#[allow(single_use_lifetimes)]
+const __SCOPE_Enum: () = {
+    impl<T, U> Enum<T, U> {
+        fn project<'pin>(
+            self: ::pin_project::__reexport::pin::Pin<&'pin mut Self>,
+        ) -> Proj<'pin, T, U> {
+            unsafe {
+                match self.get_unchecked_mut() {
+                    Enum::Struct { pinned, unpinned } => Proj::Struct {
+                        pinned: ::pin_project::__reexport::pin::Pin::new_unchecked(pinned),
+                        unpinned,
+                    },
+                    Enum::Tuple(_0, _1) => {
+                        Proj::Tuple(::pin_project::__reexport::pin::Pin::new_unchecked(_0), _1)
+                    }
+                    Enum::Unit => Proj::Unit,
+                }
+            }
+        }
+        fn project_ref<'pin>(
+            self: ::pin_project::__reexport::pin::Pin<&'pin Self>,
+        ) -> ProjRef<'pin, T, U> {
+            unsafe {
+                match self.get_ref() {
+                    Enum::Struct { pinned, unpinned } => ProjRef::Struct {
+                        pinned: ::pin_project::__reexport::pin::Pin::new_unchecked(pinned),
+                        unpinned,
+                    },
+                    Enum::Tuple(_0, _1) => {
+                        ProjRef::Tuple(::pin_project::__reexport::pin::Pin::new_unchecked(_0), _1)
+                    }
+                    Enum::Unit => ProjRef::Unit,
+                }
+            }
+        }
+        fn project_replace(
+            self: ::pin_project::__reexport::pin::Pin<&mut Self>,
+            __replacement: Self,
+        ) -> ProjOwn<T, U> {
+            unsafe {
+                let __self_ptr: *mut Self = self.get_unchecked_mut();
+                match &mut *__self_ptr {
+                    Enum::Struct { pinned, unpinned } => {
+                        let __result = ProjOwn::Struct {
+                            pinned: ::pin_project::__reexport::marker::PhantomData,
+                            unpinned: ::pin_project::__reexport::ptr::read(unpinned),
+                        };
+                        let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                            target: __self_ptr,
+                            value: ::pin_project::__reexport::mem::ManuallyDrop::new(__replacement),
+                        };
+                        {
+                            let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned);
+                        }
+                        __result
+                    }
+                    Enum::Tuple(_0, _1) => {
+                        let __result = ProjOwn::Tuple(
+                            ::pin_project::__reexport::marker::PhantomData,
+                            ::pin_project::__reexport::ptr::read(_1),
+                        );
+                        let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                            target: __self_ptr,
+                            value: ::pin_project::__reexport::mem::ManuallyDrop::new(__replacement),
+                        };
+                        {
+                            let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(_0);
+                        }
+                        __result
+                    }
+                    Enum::Unit => {
+                        let __result = ProjOwn::Unit;
+                        let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                            target: __self_ptr,
+                            value: ::pin_project::__reexport::mem::ManuallyDrop::new(__replacement),
+                        };
+                        {}
+                        __result
+                    }
+                }
+            }
+        }
+    }
+    struct __Enum<'pin, T, U> {
+        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T, U)>,
+        __field0: T,
+        __field1: T,
+    }
+    impl<'pin, T, U> ::pin_project::__reexport::marker::Unpin for Enum<T, U> where
+        __Enum<'pin, T, U>: ::pin_project::__reexport::marker::Unpin
+    {
+    }
+    unsafe impl<T, U> ::pin_project::UnsafeUnpin for Enum<T, U> {}
+    trait EnumMustNotImplDrop {}
+    #[allow(clippy::drop_bounds)]
+    impl<T: ::pin_project::__reexport::ops::Drop> EnumMustNotImplDrop for T {}
+    impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
+    impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
+        unsafe fn drop(self: ::pin_project::__reexport::pin::Pin<&mut Self>) {}
+    }
+};
+fn main() {}

--- a/tests/expand/tests/expand/naming-enum.rs
+++ b/tests/expand/tests/expand/naming-enum.rs
@@ -1,0 +1,14 @@
+use pin_project::pin_project;
+
+#[pin_project(Replace, project = Proj, project_ref = ProjRef, project_replace = ProjOwn)]
+enum Enum<T, U> {
+    Struct {
+        #[pin]
+        pinned: T,
+        unpinned: U,
+    },
+    Tuple(#[pin] T, U),
+    Unit,
+}
+
+fn main() {}

--- a/tests/expand/tests/expand/naming-struct.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct.expanded.rs
@@ -1,0 +1,104 @@
+use pin_project::pin_project;
+# [ pin ( __private ( Replace , project = Proj , project_ref = ProjRef , project_replace = ProjOwn ) ) ]
+struct Struct<T, U> {
+    #[pin]
+    pinned: T,
+    unpinned: U,
+}
+#[allow(clippy::mut_mut)]
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+struct Proj<'pin, T, U>
+where
+    Struct<T, U>: 'pin,
+{
+    pinned: ::pin_project::__reexport::pin::Pin<&'pin mut (T)>,
+    unpinned: &'pin mut (U),
+}
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+struct ProjRef<'pin, T, U>
+where
+    Struct<T, U>: 'pin,
+{
+    pinned: ::pin_project::__reexport::pin::Pin<&'pin (T)>,
+    unpinned: &'pin (U),
+}
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+struct ProjOwn<T, U> {
+    pinned: ::pin_project::__reexport::marker::PhantomData<T>,
+    unpinned: U,
+}
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+#[allow(single_use_lifetimes)]
+const __SCOPE_Struct: () = {
+    impl<T, U> Struct<T, U> {
+        fn project<'pin>(
+            self: ::pin_project::__reexport::pin::Pin<&'pin mut Self>,
+        ) -> Proj<'pin, T, U> {
+            unsafe {
+                let Self { pinned, unpinned } = self.get_unchecked_mut();
+                Proj {
+                    pinned: ::pin_project::__reexport::pin::Pin::new_unchecked(pinned),
+                    unpinned,
+                }
+            }
+        }
+        fn project_ref<'pin>(
+            self: ::pin_project::__reexport::pin::Pin<&'pin Self>,
+        ) -> ProjRef<'pin, T, U> {
+            unsafe {
+                let Self { pinned, unpinned } = self.get_ref();
+                ProjRef {
+                    pinned: ::pin_project::__reexport::pin::Pin::new_unchecked(pinned),
+                    unpinned,
+                }
+            }
+        }
+        fn project_replace(
+            self: ::pin_project::__reexport::pin::Pin<&mut Self>,
+            __replacement: Self,
+        ) -> ProjOwn<T, U> {
+            unsafe {
+                let __self_ptr: *mut Self = self.get_unchecked_mut();
+                let Self { pinned, unpinned } = &mut *__self_ptr;
+                let __result = ProjOwn {
+                    pinned: ::pin_project::__reexport::marker::PhantomData,
+                    unpinned: ::pin_project::__reexport::ptr::read(unpinned),
+                };
+                let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                    target: __self_ptr,
+                    value: ::pin_project::__reexport::mem::ManuallyDrop::new(__replacement),
+                };
+                {
+                    let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned);
+                }
+                __result
+            }
+        }
+    }
+    struct __Struct<'pin, T, U> {
+        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T, U)>,
+        __field0: T,
+    }
+    impl<'pin, T, U> ::pin_project::__reexport::marker::Unpin for Struct<T, U> where
+        __Struct<'pin, T, U>: ::pin_project::__reexport::marker::Unpin
+    {
+    }
+    unsafe impl<T, U> ::pin_project::UnsafeUnpin for Struct<T, U> {}
+    trait StructMustNotImplDrop {}
+    #[allow(clippy::drop_bounds)]
+    impl<T: ::pin_project::__reexport::ops::Drop> StructMustNotImplDrop for T {}
+    impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
+    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: ::pin_project::__reexport::pin::Pin<&mut Self>) {}
+    }
+    #[deny(safe_packed_borrows)]
+    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
+        &val.pinned;
+        &val.unpinned;
+    }
+};
+fn main() {}

--- a/tests/expand/tests/expand/naming-struct.rs
+++ b/tests/expand/tests/expand/naming-struct.rs
@@ -1,0 +1,10 @@
+use pin_project::pin_project;
+
+#[pin_project(Replace, project = Proj, project_ref = ProjRef, project_replace = ProjOwn)]
+struct Struct<T, U> {
+    #[pin]
+    pinned: T,
+    unpinned: U,
+}
+
+fn main() {}

--- a/tests/expand/tests/expand/naming-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct.expanded.rs
@@ -1,0 +1,86 @@
+use pin_project::pin_project;
+# [ pin ( __private ( Replace , project = Proj , project_ref = ProjRef , project_replace = ProjOwn ) ) ]
+struct TupleStruct<T, U>(#[pin] T, U);
+#[allow(clippy::mut_mut)]
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+struct Proj<'pin, T, U>(
+    ::pin_project::__reexport::pin::Pin<&'pin mut (T)>,
+    &'pin mut (U),
+)
+where
+    TupleStruct<T, U>: 'pin;
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+struct ProjRef<'pin, T, U>(::pin_project::__reexport::pin::Pin<&'pin (T)>, &'pin (U))
+where
+    TupleStruct<T, U>: 'pin;
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+struct ProjOwn<T, U>(::pin_project::__reexport::marker::PhantomData<T>, U);
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+#[allow(single_use_lifetimes)]
+const __SCOPE_TupleStruct: () = {
+    impl<T, U> TupleStruct<T, U> {
+        fn project<'pin>(
+            self: ::pin_project::__reexport::pin::Pin<&'pin mut Self>,
+        ) -> Proj<'pin, T, U> {
+            unsafe {
+                let Self(_0, _1) = self.get_unchecked_mut();
+                Proj(::pin_project::__reexport::pin::Pin::new_unchecked(_0), _1)
+            }
+        }
+        fn project_ref<'pin>(
+            self: ::pin_project::__reexport::pin::Pin<&'pin Self>,
+        ) -> ProjRef<'pin, T, U> {
+            unsafe {
+                let Self(_0, _1) = self.get_ref();
+                ProjRef(::pin_project::__reexport::pin::Pin::new_unchecked(_0), _1)
+            }
+        }
+        fn project_replace(
+            self: ::pin_project::__reexport::pin::Pin<&mut Self>,
+            __replacement: Self,
+        ) -> ProjOwn<T, U> {
+            unsafe {
+                let __self_ptr: *mut Self = self.get_unchecked_mut();
+                let Self(_0, _1) = &mut *__self_ptr;
+                let __result = ProjOwn(
+                    ::pin_project::__reexport::marker::PhantomData,
+                    ::pin_project::__reexport::ptr::read(_1),
+                );
+                let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                    target: __self_ptr,
+                    value: ::pin_project::__reexport::mem::ManuallyDrop::new(__replacement),
+                };
+                {
+                    let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(_0);
+                }
+                __result
+            }
+        }
+    }
+    struct __TupleStruct<'pin, T, U> {
+        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T, U)>,
+        __field0: T,
+    }
+    impl<'pin, T, U> ::pin_project::__reexport::marker::Unpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: ::pin_project::__reexport::marker::Unpin
+    {
+    }
+    unsafe impl<T, U> ::pin_project::UnsafeUnpin for TupleStruct<T, U> {}
+    trait TupleStructMustNotImplDrop {}
+    #[allow(clippy::drop_bounds)]
+    impl<T: ::pin_project::__reexport::ops::Drop> TupleStructMustNotImplDrop for T {}
+    impl<T, U> TupleStructMustNotImplDrop for TupleStruct<T, U> {}
+    impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
+        unsafe fn drop(self: ::pin_project::__reexport::pin::Pin<&mut Self>) {}
+    }
+    #[deny(safe_packed_borrows)]
+    fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
+        &val.0;
+        &val.1;
+    }
+};
+fn main() {}

--- a/tests/expand/tests/expand/naming-tuple_struct.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct.rs
@@ -1,0 +1,6 @@
+use pin_project::pin_project;
+
+#[pin_project(Replace, project = Proj, project_ref = ProjRef, project_replace = ProjOwn)]
+struct TupleStruct<T, U>(#[pin] T, U);
+
+fn main() {}

--- a/tests/ui/pin_project/conflict-naming.rs
+++ b/tests/ui/pin_project/conflict-naming.rs
@@ -1,0 +1,6 @@
+use pin_project::pin_project;
+
+#[pin_project(project = A, project_ref = A)] //~ ERROR E0428,E0308
+struct Struct(#[pin] ());
+
+fn main() {}

--- a/tests/ui/pin_project/conflict-naming.stderr
+++ b/tests/ui/pin_project/conflict-naming.stderr
@@ -1,0 +1,21 @@
+error[E0428]: the name `A` is defined multiple times
+ --> $DIR/conflict-naming.rs:3:1
+  |
+3 | #[pin_project(project = A, project_ref = A)] //~ ERROR E0428,E0308
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | |
+  | `A` redefined here
+  | previous definition of the type `A` here
+  |
+  = note: `A` must be defined only once in the type namespace of this module
+  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> $DIR/conflict-naming.rs:3:1
+  |
+3 | #[pin_project(project = A, project_ref = A)] //~ ERROR E0428,E0308
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+  |
+  = note: expected mutable reference `&mut ()`
+                     found reference `&()`
+  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/pin_project/invalid.rs
+++ b/tests/ui/pin_project/invalid.rs
@@ -118,6 +118,18 @@ mod pin_project_argument {
     #[pin_project(PinnedDrop, UnsafeUnpin, PinnedDrop, UnsafeUnpin)] //~ ERROR duplicate `PinnedDrop` argument
     struct Duplicate4(#[pin] ());
 
+    #[pin_project(project = A, project = B)] //~ ERROR duplicate `project` argument
+    struct DuplicateProject(#[pin] ());
+
+    #[pin_project(project_ref = A, project_ref = B)] //~ ERROR duplicate `project_ref` argument
+    struct DuplicateProjectRef(#[pin] ());
+
+    #[pin_project(project_replace = A, project_replace = B)] //~ ERROR duplicate `project_replace` argument
+    struct DuplicateProjectReplace(#[pin] ());
+
+    #[pin_project(project_replace = A)] //~ ERROR `project_replace` argument can only be used together with `Replace` argument
+    struct ProjectReplaceWithoutReplace(#[pin] ());
+
     #[pin_project(PinnedDrop, Replace)] //~ ERROR arguments `PinnedDrop` and `Replace` are mutually exclusive
     struct PinnedDropWithReplace1(#[pin] ());
 
@@ -135,6 +147,24 @@ mod pin_project_argument {
 
     #[pin_project(Unpin)] //~ ERROR unexpected argument
     struct NotUnpin2(#[pin] ());
+
+    #[pin_project(project)] //~ ERROR expected `=`
+    struct Project1(#[pin] ());
+
+    #[pin_project(project = )] //~ ERROR unexpected end of input, expected identifier
+    struct Project2(#[pin] ());
+
+    #[pin_project(project_ref)] //~ ERROR expected `=`
+    struct ProjectRef1(#[pin] ());
+
+    #[pin_project(project_ref = )] //~ ERROR unexpected end of input, expected identifier
+    struct ProjectRef2(#[pin] ());
+
+    #[pin_project(project_replace)] //~ ERROR expected `=`
+    struct ProjectReplace1(#[pin] ());
+
+    #[pin_project(project_replace = )] //~ ERROR unexpected end of input, expected identifier
+    struct ProjectReplace2(#[pin] ());
 }
 
 mod pin_project_attribute {

--- a/tests/ui/pin_project/invalid.stderr
+++ b/tests/ui/pin_project/invalid.stderr
@@ -118,111 +118,183 @@ error: duplicate `PinnedDrop` argument
 118 |     #[pin_project(PinnedDrop, UnsafeUnpin, PinnedDrop, UnsafeUnpin)] //~ ERROR duplicate `PinnedDrop` argument
     |                                            ^^^^^^^^^^
 
-error: arguments `PinnedDrop` and `Replace` are mutually exclusive
-   --> $DIR/invalid.rs:121:19
+error: duplicate `project` argument
+   --> $DIR/invalid.rs:121:32
     |
-121 |     #[pin_project(PinnedDrop, Replace)] //~ ERROR arguments `PinnedDrop` and `Replace` are mutually exclusive
+121 |     #[pin_project(project = A, project = B)] //~ ERROR duplicate `project` argument
+    |                                ^^^^^^^
+
+error: duplicate `project_ref` argument
+   --> $DIR/invalid.rs:124:36
+    |
+124 |     #[pin_project(project_ref = A, project_ref = B)] //~ ERROR duplicate `project_ref` argument
+    |                                    ^^^^^^^^^^^
+
+error: duplicate `project_replace` argument
+   --> $DIR/invalid.rs:127:40
+    |
+127 |     #[pin_project(project_replace = A, project_replace = B)] //~ ERROR duplicate `project_replace` argument
+    |                                        ^^^^^^^^^^^^^^^
+
+error: `project_replace` argument can only be used together with `Replace` argument
+   --> $DIR/invalid.rs:130:19
+    |
+130 |     #[pin_project(project_replace = A)] //~ ERROR `project_replace` argument can only be used together with `Replace` argument
+    |                   ^^^^^^^^^^^^^^^
+
+error: arguments `PinnedDrop` and `Replace` are mutually exclusive
+   --> $DIR/invalid.rs:133:19
+    |
+133 |     #[pin_project(PinnedDrop, Replace)] //~ ERROR arguments `PinnedDrop` and `Replace` are mutually exclusive
     |                   ^^^^^^^^^^
 
 error: arguments `PinnedDrop` and `Replace` are mutually exclusive
-   --> $DIR/invalid.rs:124:41
+   --> $DIR/invalid.rs:136:41
     |
-124 |     #[pin_project(Replace, UnsafeUnpin, PinnedDrop)] //~ ERROR arguments `PinnedDrop` and `Replace` are mutually exclusive
+136 |     #[pin_project(Replace, UnsafeUnpin, PinnedDrop)] //~ ERROR arguments `PinnedDrop` and `Replace` are mutually exclusive
     |                                         ^^^^^^^^^^
 
 error: arguments `UnsafeUnpin` and `!Unpin` are mutually exclusive
-   --> $DIR/invalid.rs:127:19
+   --> $DIR/invalid.rs:139:19
     |
-127 |     #[pin_project(UnsafeUnpin, !Unpin)] //~ ERROR arguments `UnsafeUnpin` and `!Unpin` are mutually exclusive
+139 |     #[pin_project(UnsafeUnpin, !Unpin)] //~ ERROR arguments `UnsafeUnpin` and `!Unpin` are mutually exclusive
     |                   ^^^^^^^^^^^
 
 error: arguments `UnsafeUnpin` and `!Unpin` are mutually exclusive
-   --> $DIR/invalid.rs:130:39
+   --> $DIR/invalid.rs:142:39
     |
-130 |     #[pin_project(!Unpin, PinnedDrop, UnsafeUnpin)] //~ ERROR arguments `UnsafeUnpin` and `!Unpin` are mutually exclusive
+142 |     #[pin_project(!Unpin, PinnedDrop, UnsafeUnpin)] //~ ERROR arguments `UnsafeUnpin` and `!Unpin` are mutually exclusive
     |                                       ^^^^^^^^^^^
 
 error: unexpected end of input, expected `Unpin`
-   --> $DIR/invalid.rs:133:5
+   --> $DIR/invalid.rs:145:5
     |
-133 |     #[pin_project(!)] //~ ERROR unexpected end of input, expected `Unpin`
+145 |     #[pin_project(!)] //~ ERROR unexpected end of input, expected `Unpin`
     |     ^^^^^^^^^^^^^^^^^
     |
     = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected argument: Unpin
-   --> $DIR/invalid.rs:136:19
+   --> $DIR/invalid.rs:148:19
     |
-136 |     #[pin_project(Unpin)] //~ ERROR unexpected argument
+148 |     #[pin_project(Unpin)] //~ ERROR unexpected argument
     |                   ^^^^^
 
-error: duplicate #[pin_project] attribute
-   --> $DIR/invalid.rs:144:5
+error: expected `=`
+   --> $DIR/invalid.rs:151:5
     |
-144 |     #[pin_project] //~ ERROR duplicate #[pin_project] attribute
+151 |     #[pin_project(project)] //~ ERROR expected `=`
+    |     ^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unexpected end of input, expected identifier
+   --> $DIR/invalid.rs:154:5
+    |
+154 |     #[pin_project(project = )] //~ ERROR unexpected end of input, expected identifier
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected `=`
+   --> $DIR/invalid.rs:157:5
+    |
+157 |     #[pin_project(project_ref)] //~ ERROR expected `=`
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unexpected end of input, expected identifier
+   --> $DIR/invalid.rs:160:5
+    |
+160 |     #[pin_project(project_ref = )] //~ ERROR unexpected end of input, expected identifier
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected `=`
+   --> $DIR/invalid.rs:163:5
+    |
+163 |     #[pin_project(project_replace)] //~ ERROR expected `=`
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unexpected end of input, expected identifier
+   --> $DIR/invalid.rs:166:5
+    |
+166 |     #[pin_project(project_replace = )] //~ ERROR unexpected end of input, expected identifier
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: duplicate #[pin_project] attribute
+   --> $DIR/invalid.rs:174:5
+    |
+174 |     #[pin_project] //~ ERROR duplicate #[pin_project] attribute
     |     ^^^^^^^^^^^^^^
 
 error: #[pin_project] attribute may not be used on structs with zero fields
-   --> $DIR/invalid.rs:152:19
+   --> $DIR/invalid.rs:182:19
     |
-152 |     struct Struct {} //~ ERROR may not be used on structs with zero fields
+182 |     struct Struct {} //~ ERROR may not be used on structs with zero fields
     |                   ^^
 
 error: #[pin_project] attribute may not be used on structs with zero fields
-   --> $DIR/invalid.rs:155:23
+   --> $DIR/invalid.rs:185:23
     |
-155 |     struct TupleStruct(); //~ ERROR may not be used on structs with zero fields
+185 |     struct TupleStruct(); //~ ERROR may not be used on structs with zero fields
     |                       ^^
 
 error: #[pin_project] attribute may not be used on structs with zero fields
-   --> $DIR/invalid.rs:158:12
+   --> $DIR/invalid.rs:188:12
     |
-158 |     struct UnitStruct; //~ ERROR may not be used on structs with zero fields
+188 |     struct UnitStruct; //~ ERROR may not be used on structs with zero fields
     |            ^^^^^^^^^^
 
 error: #[pin_project] attribute may not be used on enums without variants
-   --> $DIR/invalid.rs:161:20
+   --> $DIR/invalid.rs:191:20
     |
-161 |     enum EnumEmpty {} //~ ERROR may not be used on enums without variants
+191 |     enum EnumEmpty {} //~ ERROR may not be used on enums without variants
     |                    ^^
 
 error: #[pin_project] attribute may not be used on enums with discriminants
-   --> $DIR/invalid.rs:165:13
+   --> $DIR/invalid.rs:195:13
     |
-165 |         V = 2, //~ ERROR may not be used on enums with discriminants
+195 |         V = 2, //~ ERROR may not be used on enums with discriminants
     |             ^
 
 error: #[pin_project] attribute may not be used on enums with zero fields
-   --> $DIR/invalid.rs:170:9
+   --> $DIR/invalid.rs:200:9
     |
-170 | /         Unit, //~ ERROR may not be used on enums with zero fields
-171 | |         Tuple(),
-172 | |         Struct {},
+200 | /         Unit, //~ ERROR may not be used on enums with zero fields
+201 | |         Tuple(),
+202 | |         Struct {},
     | |__________________^
 
 error: #[pin_project] attribute may only be used on structs or enums
-   --> $DIR/invalid.rs:176:5
+   --> $DIR/invalid.rs:206:5
     |
-176 | /     union Union {
-177 | |         //~^ ERROR may only be used on structs or enums
-178 | |         f: (),
-179 | |     }
+206 | /     union Union {
+207 | |         //~^ ERROR may only be used on structs or enums
+208 | |         f: (),
+209 | |     }
     | |_____^
 
 error: #[pin_project] attribute may not be used on #[repr(packed)] types
-   --> $DIR/invalid.rs:187:12
+   --> $DIR/invalid.rs:217:12
     |
-187 |     #[repr(packed)]
+217 |     #[repr(packed)]
     |            ^^^^^^
 
 error: #[pin_project] attribute may not be used on #[repr(packed)] types
-   --> $DIR/invalid.rs:191:12
+   --> $DIR/invalid.rs:221:12
     |
-191 |     #[repr(packed)]
+221 |     #[repr(packed)]
     |            ^^^^^^
 
 error: #[pin_project] attribute may not be used on #[repr(packed)] types
-   --> $DIR/invalid.rs:195:12
+   --> $DIR/invalid.rs:225:12
     |
-195 |     #[repr(packed)]
+225 |     #[repr(packed)]
     |            ^^^^^^

--- a/tests/ui/pin_project/visibility.rs
+++ b/tests/ui/pin_project/visibility.rs
@@ -49,4 +49,34 @@ pub mod pub_crate_use {
     };
 }
 
+mod pub_renamed {
+    use pin_project::pin_project;
+
+    #[pin_project(project = DProj, project_ref = DProjRef)]
+    pub struct Default(());
+
+    #[pin_project(Replace, project = RProj, project_ref = RProjRef, project_replace = RProjOwn)]
+    pub struct Replace(());
+}
+pub mod pub_renamed_use {
+    #[rustfmt::skip]
+    pub use crate::pub_renamed::DProj; //~ ERROR E0365
+    #[rustfmt::skip]
+    pub use crate::pub_renamed::DProjRef; //~ ERROR E0365
+    #[rustfmt::skip]
+    pub use crate::pub_renamed::RProj; //~ ERROR E0365
+    #[rustfmt::skip]
+    pub use crate::pub_renamed::RProjOwn; //~ ERROR E0365
+    #[rustfmt::skip]
+    pub use crate::pub_renamed::RProjRef; //~ ERROR E0365
+
+    // Confirm that the visibility of the original type is not changed.
+    pub use crate::pub_renamed::{Default, Replace};
+}
+pub mod pub_renamed_use2 {
+    // Ok
+    #[allow(unused_imports)]
+    pub(crate) use crate::pub_renamed::{DProj, DProjRef, RProj, RProjOwn, RProjRef};
+}
+
 fn main() {}

--- a/tests/ui/pin_project/visibility.stderr
+++ b/tests/ui/pin_project/visibility.stderr
@@ -37,3 +37,43 @@ error[E0365]: `__ReplaceProjectionRef` is private, and cannot be re-exported
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ re-export of private `__ReplaceProjectionRef`
    |
    = note: consider declaring type or module `__ReplaceProjectionRef` with `pub`
+
+error[E0365]: `DProj` is private, and cannot be re-exported
+  --> $DIR/visibility.rs:63:13
+   |
+63 |     pub use crate::pub_renamed::DProj; //~ ERROR E0365
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ re-export of private `DProj`
+   |
+   = note: consider declaring type or module `DProj` with `pub`
+
+error[E0365]: `DProjRef` is private, and cannot be re-exported
+  --> $DIR/visibility.rs:65:13
+   |
+65 |     pub use crate::pub_renamed::DProjRef; //~ ERROR E0365
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ re-export of private `DProjRef`
+   |
+   = note: consider declaring type or module `DProjRef` with `pub`
+
+error[E0365]: `RProj` is private, and cannot be re-exported
+  --> $DIR/visibility.rs:67:13
+   |
+67 |     pub use crate::pub_renamed::RProj; //~ ERROR E0365
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ re-export of private `RProj`
+   |
+   = note: consider declaring type or module `RProj` with `pub`
+
+error[E0365]: `RProjOwn` is private, and cannot be re-exported
+  --> $DIR/visibility.rs:69:13
+   |
+69 |     pub use crate::pub_renamed::RProjOwn; //~ ERROR E0365
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ re-export of private `RProjOwn`
+   |
+   = note: consider declaring type or module `RProjOwn` with `pub`
+
+error[E0365]: `RProjRef` is private, and cannot be re-exported
+  --> $DIR/visibility.rs:71:13
+   |
+71 |     pub use crate::pub_renamed::RProjRef; //~ ERROR E0365
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ re-export of private `RProjRef`
+   |
+   = note: consider declaring type or module `RProjRef` with `pub`


### PR DESCRIPTION
By passing an argument with the same name as the method to the attribute, you can name the projection type returned from the method:

```rust
#[pin_project(
    Replace,
    project = StructProj,
    project_ref = StructProjRef,
    project_replace = StructProjOwn,
)]
struct Struct<T> {
    #[pin]
    field: T,
}

let mut x = Struct { field: 0 };
let StructProj { field } = Pin::new(&mut x).project();
let StructProjRef { field } = Pin::new(&x).project_ref();
let StructProjOwn { field } = Pin::new(&mut x).project_replace(Struct { field: 1 });
```

cc #43
Closes #124

TODO: 
  * [x] add tests
  * [x] write docs 
  * [x] separate unrelated changes; done in #214
  * [x] msrv (`unrestricted_attribute_tokens` requires 1.34); done in #219 
