### PR TITLE
Add ui test for conditional drop impl

### DIFF
--- a/tests/ui/pinned_drop/conditional-drop-impl.rs
+++ b/tests/ui/pinned_drop/conditional-drop-impl.rs
@@ -1,0 +1,26 @@
+use pin_project::{pin_project, pinned_drop};
+use std::pin::Pin;
+
+// In `Drop` impl, the implementor must specify the same requirement as type definition.
+
+struct DropImpl<T> {
+    field: T,
+}
+
+impl<T: Unpin> Drop for DropImpl<T> {
+    //~^ ERROR E0367
+    fn drop(&mut self) {}
+}
+
+#[pin_project(PinnedDrop)] //~ ERROR E0277
+struct PinnedDropImpl<T> {
+    #[pin]
+    field: T,
+}
+
+#[pinned_drop]
+impl<T: Unpin> PinnedDrop for PinnedDropImpl<T> {
+    fn drop(self: Pin<&mut Self>) {}
+}
+
+fn main() {}

--- a/tests/ui/pinned_drop/conditional-drop-impl.stderr
+++ b/tests/ui/pinned_drop/conditional-drop-impl.stderr
@@ -1,0 +1,26 @@
+error[E0367]: `Drop` impl requires `T: std::marker::Unpin` but the struct it is implemented for does not
+  --> $DIR/conditional-drop-impl.rs:10:9
+   |
+10 | impl<T: Unpin> Drop for DropImpl<T> {
+   |         ^^^^^
+   |
+note: the implementor must specify the same requirement
+  --> $DIR/conditional-drop-impl.rs:6:1
+   |
+6  | / struct DropImpl<T> {
+7  | |     field: T,
+8  | | }
+   | |_^
+
+error[E0277]: `T` cannot be unpinned
+  --> $DIR/conditional-drop-impl.rs:15:15
+   |
+15 | #[pin_project(PinnedDrop)] //~ ERROR E0277
+   |               ^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `T`
+   |
+   = note: required because of the requirements on the impl of `pin_project::__private::PinnedDrop` for `PinnedDropImpl<T>`
+   = note: required by `pin_project::__private::PinnedDrop::drop`
+help: consider restricting type parameter `T`
+   |
+16 | struct PinnedDropImpl<T: std::marker::Unpin> {
+   |                        ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
In `Drop` impl, the implementor must specify the same requirement as type definition. 
We cannot make `PinnedDrop` generate the same error message, but it seems rustc print out a useful help message.

`Drop`:
```txt
error[E0367]: `Drop` impl requires `T: std::marker::Unpin` but the struct it is implemented for does not
  --> $DIR/conditional-drop-impl.rs:10:9
   |
10 | impl<T: Unpin> Drop for DropImpl<T> {
   |         ^^^^^
   |
note: the implementor must specify the same requirement
  --> $DIR/conditional-drop-impl.rs:6:1
   |
6  | / struct DropImpl<T> {
7  | |     field: T,
8  | | }
   | |_^
```

`PinnedDrop`:
```txt
error[E0277]: `T` cannot be unpinned
  --> $DIR/conditional-drop-impl.rs:15:15
   |
15 | #[pin_project(PinnedDrop)] //~ ERROR E0277
   |               ^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `T`
   |
   = note: required because of the requirements on the impl of `pin_project::__private::PinnedDrop` for `PinnedDropImpl<T>`
   = note: required by `pin_project::__private::PinnedDrop::drop`
help: consider restricting type parameter `T`
   |
16 | struct PinnedDropImpl<T: std::marker::Unpin> {
   |    
```