### PR TITLE
Hide generated items from --document-private-items

### DIFF
--- a/examples/enum-default-expanded.rs
+++ b/examples/enum-default-expanded.rs
@@ -41,6 +41,7 @@ where
     Unpinned(&'pin (U)),
 }
 
+#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 const __SCOPE_Enum: () = {
     impl<T, U> Enum<T, U> {

--- a/examples/pinned_drop-expanded.rs
+++ b/examples/pinned_drop-expanded.rs
@@ -50,6 +50,7 @@ where
     field: ::pin_project::__reexport::pin::Pin<&'pin (T)>,
 }
 
+#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 const __SCOPE_Struct: () = {
     impl<'a, T> Struct<'a, T> {

--- a/examples/struct-default-expanded.rs
+++ b/examples/struct-default-expanded.rs
@@ -43,6 +43,7 @@ where
     unpinned: &'pin (U),
 }
 
+#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 const __SCOPE_Struct: () = {
     impl<T, U> Struct<T, U> {

--- a/examples/unsafe_unpin-expanded.rs
+++ b/examples/unsafe_unpin-expanded.rs
@@ -45,6 +45,7 @@ where
     unpinned: &'pin (U),
 }
 
+#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 const __SCOPE_Struct: () = {
     impl<T, U> Struct<T, U> {
@@ -71,8 +72,6 @@ const __SCOPE_Struct: () = {
             }
         }
     }
-
-    unsafe impl<T: Unpin, U> UnsafeUnpin for Struct<T, U> {}
 
     #[allow(single_use_lifetimes)]
     impl<'pin, T, U> ::pin_project::__reexport::marker::Unpin for Struct<T, U> where
@@ -104,5 +103,7 @@ const __SCOPE_Struct: () = {
         &val.unpinned;
     }
 };
+
+unsafe impl<T: Unpin, U> UnsafeUnpin for Struct<T, U> {}
 
 fn main() {}

--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -42,6 +42,7 @@ pub(super) fn parse_derive(input: TokenStream) -> Result<TokenStream> {
                 // * https://github.com/rust-lang/rust/issues/63281
                 // * https://github.com/taiki-e/pin-project/pull/53#issuecomment-525906867
                 // * https://github.com/taiki-e/pin-project/pull/70
+                #[doc(hidden)]
                 #[allow(non_upper_case_globals)]
                 const #dummy_const: () = {
                     #proj_impl
@@ -66,6 +67,7 @@ pub(super) fn parse_derive(input: TokenStream) -> Result<TokenStream> {
 
             let dummy_const = format_ident!("__SCOPE_{}", ident);
             proj_items.extend(quote! {
+                #[doc(hidden)]
                 #[allow(non_upper_case_globals)]
                 const #dummy_const: () = {
                     #proj_impl
@@ -379,16 +381,18 @@ impl<'a> Context<'a> {
         };
 
         let mut proj_items = quote! {
+            #[doc(hidden)] // TODO: If the user gave it a name, it should appear in the document.
             #[allow(clippy::mut_mut)] // This lint warns `&mut &mut <ty>`.
             #[allow(dead_code)] // This lint warns unused fields/variants.
             #vis struct #proj_ident #proj_generics #where_clause_fields
+            #[doc(hidden)] // TODO: If the user gave it a name, it should appear in the document.
             #[allow(dead_code)] // This lint warns unused fields/variants.
             #vis struct #proj_ref_ident #proj_generics #where_clause_ref_fields
         };
-
         if self.replace.is_some() {
             // Currently, using quote_spanned here does not seem to have any effect on the diagnostics.
             proj_items.extend(quote! {
+                #[doc(hidden)] // TODO: If the user gave it a name, it should appear in the document.
                 #[allow(dead_code)] // This lint warns unused fields/variants.
                 #vis struct #proj_own_ident #orig_generics #where_clause_own_fields
             });
@@ -451,20 +455,22 @@ impl<'a> Context<'a> {
         let where_clause = &self.proj.where_clause;
 
         let mut proj_items = quote! {
+            #[doc(hidden)] // TODO: If the user gave it a name, it should appear in the document.
             #[allow(clippy::mut_mut)] // This lint warns `&mut &mut <ty>`.
             #[allow(dead_code)] // This lint warns unused fields/variants.
             #vis enum #proj_ident #proj_generics #where_clause {
                 #proj_variants
             }
+            #[doc(hidden)] // TODO: If the user gave it a name, it should appear in the document.
             #[allow(dead_code)] // This lint warns unused fields/variants.
             #vis enum #proj_ref_ident #proj_generics #where_clause {
                 #proj_ref_variants
             }
         };
-
         if self.replace.is_some() {
             // Currently, using quote_spanned here does not seem to have any effect on the diagnostics.
             proj_items.extend(quote! {
+                #[doc(hidden)] // TODO: If the user gave it a name, it should appear in the document.
                 #[allow(dead_code)] // This lint warns unused fields/variants.
                 #vis enum #proj_own_ident #orig_generics #orig_where_clause {
                     #proj_own_variants

--- a/tests/expand/tests/enum/default.expanded.rs
+++ b/tests/expand/tests/enum/default.expanded.rs
@@ -4,6 +4,7 @@ enum Enum<T, U> {
     Pinned(#[pin] T),
     Unpinned(U),
 }
+#[doc(hidden)]
 #[allow(clippy::mut_mut)]
 #[allow(dead_code)]
 enum __EnumProjection<'pin, T, U>
@@ -13,6 +14,7 @@ where
     Pinned(::pin_project::__reexport::pin::Pin<&'pin mut (T)>),
     Unpinned(&'pin mut (U)),
 }
+#[doc(hidden)]
 #[allow(dead_code)]
 enum __EnumProjectionRef<'pin, T, U>
 where
@@ -21,6 +23,7 @@ where
     Pinned(::pin_project::__reexport::pin::Pin<&'pin (T)>),
     Unpinned(&'pin (U)),
 }
+#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 const __SCOPE_Enum: () = {
     impl<T, U> Enum<T, U> {

--- a/tests/expand/tests/enum/project_replace.expanded.rs
+++ b/tests/expand/tests/enum/project_replace.expanded.rs
@@ -8,6 +8,7 @@ enum Enum<T, U> {
     },
     None,
 }
+#[doc(hidden)]
 #[allow(clippy::mut_mut)]
 #[allow(dead_code)]
 enum __EnumProjection<'pin, T, U>
@@ -20,6 +21,7 @@ where
     },
     None,
 }
+#[doc(hidden)]
 #[allow(dead_code)]
 enum __EnumProjectionRef<'pin, T, U>
 where
@@ -31,6 +33,7 @@ where
     },
     None,
 }
+#[doc(hidden)]
 #[allow(dead_code)]
 enum __EnumProjectionOwned<T, U> {
     V {
@@ -39,6 +42,7 @@ enum __EnumProjectionOwned<T, U> {
     },
     None,
 }
+#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 const __SCOPE_Enum: () = {
     impl<T, U> Enum<T, U> {

--- a/tests/expand/tests/struct/default.expanded.rs
+++ b/tests/expand/tests/struct/default.expanded.rs
@@ -5,6 +5,7 @@ struct Struct<T, U> {
     pinned: T,
     unpinned: U,
 }
+#[doc(hidden)]
 #[allow(clippy::mut_mut)]
 #[allow(dead_code)]
 struct __StructProjection<'pin, T, U>
@@ -14,6 +15,7 @@ where
     pinned: ::pin_project::__reexport::pin::Pin<&'pin mut (T)>,
     unpinned: &'pin mut (U),
 }
+#[doc(hidden)]
 #[allow(dead_code)]
 struct __StructProjectionRef<'pin, T, U>
 where
@@ -22,6 +24,7 @@ where
     pinned: ::pin_project::__reexport::pin::Pin<&'pin (T)>,
     unpinned: &'pin (U),
 }
+#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 const __SCOPE_Struct: () = {
     impl<T, U> Struct<T, U> {

--- a/tests/expand/tests/struct/pinned_drop.expanded.rs
+++ b/tests/expand/tests/struct/pinned_drop.expanded.rs
@@ -6,6 +6,7 @@ pub struct Struct<'a, T> {
     #[pin]
     field: T,
 }
+#[doc(hidden)]
 #[allow(clippy::mut_mut)]
 #[allow(dead_code)]
 pub(crate) struct __StructProjection<'pin, 'a, T>
@@ -15,6 +16,7 @@ where
     was_dropped: &'pin mut (&'a mut bool),
     field: ::pin_project::__reexport::pin::Pin<&'pin mut (T)>,
 }
+#[doc(hidden)]
 #[allow(dead_code)]
 pub(crate) struct __StructProjectionRef<'pin, 'a, T>
 where
@@ -23,6 +25,7 @@ where
     was_dropped: &'pin (&'a mut bool),
     field: ::pin_project::__reexport::pin::Pin<&'pin (T)>,
 }
+#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 const __SCOPE_Struct: () = {
     impl<'a, T> Struct<'a, T> {

--- a/tests/expand/tests/struct/project_replace.expanded.rs
+++ b/tests/expand/tests/struct/project_replace.expanded.rs
@@ -5,6 +5,7 @@ struct Struct<T, U> {
     pinned: T,
     unpinned: U,
 }
+#[doc(hidden)]
 #[allow(clippy::mut_mut)]
 #[allow(dead_code)]
 struct __StructProjection<'pin, T, U>
@@ -14,6 +15,7 @@ where
     pinned: ::pin_project::__reexport::pin::Pin<&'pin mut (T)>,
     unpinned: &'pin mut (U),
 }
+#[doc(hidden)]
 #[allow(dead_code)]
 struct __StructProjectionRef<'pin, T, U>
 where
@@ -22,11 +24,13 @@ where
     pinned: ::pin_project::__reexport::pin::Pin<&'pin (T)>,
     unpinned: &'pin (U),
 }
+#[doc(hidden)]
 #[allow(dead_code)]
 struct __StructProjectionOwned<T, U> {
     pinned: ::pin_project::__reexport::marker::PhantomData<T>,
     unpinned: U,
 }
+#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 const __SCOPE_Struct: () = {
     impl<T, U> Struct<T, U> {

--- a/tests/expand/tests/struct/unsafe_unpin.expanded.rs
+++ b/tests/expand/tests/struct/unsafe_unpin.expanded.rs
@@ -5,6 +5,7 @@ pub struct Struct<T, U> {
     pinned: T,
     unpinned: U,
 }
+#[doc(hidden)]
 #[allow(clippy::mut_mut)]
 #[allow(dead_code)]
 pub(crate) struct __StructProjection<'pin, T, U>
@@ -14,6 +15,7 @@ where
     pinned: ::pin_project::__reexport::pin::Pin<&'pin mut (T)>,
     unpinned: &'pin mut (U),
 }
+#[doc(hidden)]
 #[allow(dead_code)]
 pub(crate) struct __StructProjectionRef<'pin, T, U>
 where
@@ -22,6 +24,7 @@ where
     pinned: ::pin_project::__reexport::pin::Pin<&'pin (T)>,
     unpinned: &'pin (U),
 }
+#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 const __SCOPE_Struct: () = {
     impl<T, U> Struct<T, U> {


### PR DESCRIPTION
All of the generated items are private items, but it can be displayed in the document by using the `--document-private-items` flag.

Naming will be allowed by #202, so it would probably be preferable to only display it in the document if the user did a naming.

cc #124 #202
Related: https://github.com/taiki-e/pin-project/pull/192