### PR TITLE
Prevent user call `__drop_inner`

### DIFF
--- a/examples/pinned_drop-expanded.rs
+++ b/examples/pinned_drop-expanded.rs
@@ -142,6 +142,9 @@ impl<T> ::pin_project::__private::PinnedDrop for Struct<'_, T> {
     unsafe fn drop(self: Pin<&mut Self>) {
         #[allow(clippy::needless_pass_by_value)]
         fn __drop_inner<T>(__self: Pin<&mut Struct<'_, T>>) {
+            // A dummy `__drop_inner` function to prevent users call outer `__drop_inner`.
+            fn __drop_inner() {}
+
             **__self.project().was_dropped = true;
         }
         __drop_inner(self);

--- a/tests/expand/tests/expand/pinned_drop-enum.expanded.rs
+++ b/tests/expand/tests/expand/pinned_drop-enum.expanded.rs
@@ -105,6 +105,7 @@ impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
     unsafe fn drop(self: Pin<&mut Self>) {
         #[allow(clippy::needless_pass_by_value)]
         fn __drop_inner<T, U>(__self: Pin<&mut Enum<T, U>>) {
+            fn __drop_inner() {}
             let _this = __self;
         }
         __drop_inner(self);

--- a/tests/expand/tests/expand/pinned_drop-struct.expanded.rs
+++ b/tests/expand/tests/expand/pinned_drop-struct.expanded.rs
@@ -82,6 +82,7 @@ impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
     unsafe fn drop(self: Pin<&mut Self>) {
         #[allow(clippy::needless_pass_by_value)]
         fn __drop_inner<T, U>(__self: Pin<&mut Struct<T, U>>) {
+            fn __drop_inner() {}
             let _this = __self;
         }
         __drop_inner(self);

--- a/tests/expand/tests/expand/pinned_drop-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/pinned_drop-tuple_struct.expanded.rs
@@ -73,6 +73,7 @@ impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
     unsafe fn drop(self: Pin<&mut Self>) {
         #[allow(clippy::needless_pass_by_value)]
         fn __drop_inner<T, U>(__self: Pin<&mut TupleStruct<T, U>>) {
+            fn __drop_inner() {}
             let _this = __self;
         }
         __drop_inner(self);

--- a/tests/ui/pinned_drop/call-drop-inner.rs
+++ b/tests/ui/pinned_drop/call-drop-inner.rs
@@ -1,0 +1,16 @@
+use pin_project::{pin_project, pinned_drop};
+use std::pin::Pin;
+
+#[pin_project(PinnedDrop)]
+struct Struct {
+    dropped: bool,
+}
+
+#[pinned_drop]
+impl PinnedDrop for Struct {
+    fn drop(mut self: Pin<&mut Self>) {
+        __drop_inner(__self);
+    }
+}
+
+fn main() {}

--- a/tests/ui/pinned_drop/call-drop-inner.stderr
+++ b/tests/ui/pinned_drop/call-drop-inner.stderr
@@ -1,0 +1,10 @@
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/call-drop-inner.rs:12:9
+   |
+9  | #[pinned_drop]
+   | -------------- defined here
+...
+12 |         __drop_inner(__self);
+   |         ^^^^^^^^^^^^ ------ supplied 1 argument
+   |         |
+   |         expected 0 arguments


### PR DESCRIPTION
This is an internal function, and the user should not be able to call this. Ideally, we should use a def-site span, but we can't do that, so add a dummy `__drop_inner` function at the beginning of `__drop_inner` function.

[playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=ee4d5e2621a61d510b63ab0d7a18bb98)
