### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A crate for safe and ergonomic pin-projection.
 
 [Documentation][docs-url]
 
-[Examples](examples/README.md)
+[Examples][examples]
 
 ## Usage
 
@@ -33,7 +33,7 @@ The current pin-project requires Rust 1.34 or later.
 
 ## Examples
 
-[`pin_project`] attribute creates a projection type covering all the fields of struct or enum.
+[`#[pin_project]`][`pin_project`] attribute creates a projection type covering all the fields of struct or enum.
 
 ```rust
 use pin_project::pin_project;
@@ -47,7 +47,7 @@ struct Struct<T, U> {
 }
 
 impl<T, U> Struct<T, U> {
-    fn foo(self: Pin<&mut Self>) {
+    fn method(self: Pin<&mut Self>) {
         let this = self.project();
         let _: Pin<&mut T> = this.pinned; // Pinned reference to the field
         let _: &mut U = this.unpinned; // Normal reference to the field
@@ -55,13 +55,15 @@ impl<T, U> Struct<T, U> {
 }
 ```
 
-[Code like this will be generated](examples/struct-default-expanded.rs)
+[Code like this will be generated][struct-default-expanded]
 
 See [API documentation][docs-url] for more details.
 
-Also, there are examples and generated code of each feature in [examples](examples/README.md) directory.
+Also, there are examples and generated code of each feature in [examples] directory.
 
 [`pin_project`]: https://docs.rs/pin-project/0.4/pin_project/attr.pin_project.html
+[examples]: examples/README.md
+[struct-default-expanded]: examples/struct-default-expanded.rs
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Examples
 //!
-//! [`pin_project`] attribute creates a projection type covering all the fields of struct or enum.
+//! [`#[pin_project]`][`pin_project`] attribute creates a projection type covering all the fields of struct or enum.
 //!
 //! ```rust
 //! use pin_project::pin_project;
@@ -16,7 +16,7 @@
 //! }
 //!
 //! impl<T, U> Struct<T, U> {
-//!     fn foo(self: Pin<&mut Self>) {
+//!     fn method(self: Pin<&mut Self>) {
 //!         let this = self.project();
 //!         let _: Pin<&mut T> = this.pinned; // Pinned reference to the field
 //!         let _: &mut U = this.unpinned; // Normal reference to the field
@@ -24,13 +24,15 @@
 //! }
 //! ```
 //!
-//! [Code like this will be generated](https://github.com/taiki-e/pin-project/blob/master/examples/struct-default-expanded.rs)
+//! [Code like this will be generated][struct-default-expanded]
 //!
-//! See [`pin_project`] attribute for more details.
+//! See [`#[pin_project]`][`pin_project`] attribute for more details.
 //!
-//! Also, there are examples and generated code of each feature in [examples](https://github.com/taiki-e/pin-project/blob/master/examples/README.md) directory.
+//! Also, there are examples and generated code of each feature in [examples] directory.
 //!
 //! [`pin_project`]: attr.pin_project.html
+//! [examples]: https://github.com/taiki-e/pin-project/blob/master/examples/README.md
+//! [struct-default-expanded]: https://github.com/taiki-e/pin-project/blob/master/examples/struct-default-expanded.rs
 
 #![no_std]
 #![recursion_limit = "256"]
@@ -62,7 +64,7 @@ pub use pin_project_internal::project_replace;
 
 /// A trait used for custom implementations of [`Unpin`].
 /// This trait is used in conjunction with the `UnsafeUnpin`
-/// argument to [`pin_project`]
+/// argument to [`#[pin_project]`][`pin_project`]
 ///
 /// The Rust [`Unpin`] trait is safe to implement - by itself,
 /// implementing it cannot lead to undefined behavior. Undefined


### PR DESCRIPTION
* Reduced reference to #[project], which will be deprecated.
* Tweaked some explanations and examples.