### PR TITLE
Preserve span of Self keyword

### DIFF
--- a/tests/ui/pinned_drop/self.rs
+++ b/tests/ui/pinned_drop/self.rs
@@ -1,10 +1,10 @@
-use pin_project::{pin_project, pinned_drop};
-use std::pin::Pin;
+pub mod self_in_macro_def {
+    use pin_project::{pin_project, pinned_drop};
+    use std::pin::Pin;
 
-fn self_in_macro_def() {
     #[pin_project(PinnedDrop)]
     pub struct Struct {
-        x: usize,
+        x: (),
     }
 
     #[pinned_drop]
@@ -12,15 +12,30 @@ fn self_in_macro_def() {
         fn drop(self: Pin<&mut Self>) {
             macro_rules! t {
                 () => {{
-                    let _ = self; //~ ERROR can't capture dynamic environment in a fn item
+                    let _ = self; //~ ERROR E0434
 
-                    fn f(self: ()) {
-                        //~^ ERROR `self` parameter is only allowed in associated functions
-                        let _ = self;
-                    }
+                    fn f(self: ()) {} //~ ERROR `self` parameter is only allowed in associated functions
                 }};
             }
             t!();
+        }
+    }
+}
+
+pub mod self_span {
+    use pin_project::{pin_project, pinned_drop};
+    use std::pin::Pin;
+
+    #[pin_project(PinnedDrop)]
+    pub struct Struct {
+        x: (),
+    }
+
+    #[pinned_drop]
+    impl PinnedDrop for Struct {
+        fn drop(self: Pin<&mut Self>) {
+            let _: () = self; //~ ERROR E0308
+            let _: Self = Self; //~ ERROR E0423
         }
     }
 }

--- a/tests/ui/pinned_drop/self.stderr
+++ b/tests/ui/pinned_drop/self.stderr
@@ -1,10 +1,10 @@
 error: `self` parameter is only allowed in associated functions
   --> $DIR/self.rs:17:26
    |
-17 |                     fn f(self: ()) {
+17 |                     fn f(self: ()) {} //~ ERROR `self` parameter is only allowed in associated functions
    |                          ^^^^ not semantically valid as function parameter
 ...
-23 |             t!();
+20 |             t!();
    |             ----- in this macro invocation
    |
    = note: associated functions are those in `impl` or `trait` definitions
@@ -13,11 +13,33 @@ error: `self` parameter is only allowed in associated functions
 error[E0434]: can't capture dynamic environment in a fn item
   --> $DIR/self.rs:15:29
    |
-15 |                     let _ = self; //~ ERROR can't capture dynamic environment in a fn item
+15 |                     let _ = self; //~ ERROR E0434
    |                             ^^^^
 ...
-23 |             t!();
+20 |             t!();
    |             ----- in this macro invocation
    |
    = help: use the `|| { ... }` closure form instead
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0423]: expected value, found struct `Struct`
+  --> $DIR/self.rs:38:27
+   |
+30 | /     pub struct Struct {
+31 | |         x: (),
+32 | |     }
+   | |_____- `Struct` defined here
+...
+38 |               let _: Self = Self; //~ ERROR E0423
+   |                             ^^^^ did you mean `Struct { /* fields */ }`?
+
+error[E0308]: mismatched types
+  --> $DIR/self.rs:37:25
+   |
+37 |             let _: () = self; //~ ERROR E0308
+   |                    --   ^^^^ expected `()`, found struct `std::pin::Pin`
+   |                    |
+   |                    expected due to this
+   |
+   = note: expected unit type `()`
+                 found struct `std::pin::Pin<&mut self_span::Struct>`


### PR DESCRIPTION
The following code:

```rust
use pin_project::{pin_project, pinned_drop};
use std::pin::Pin;

#[pin_project(PinnedDrop)]
pub struct Struct {
    x: (),
}

#[pinned_drop]
impl PinnedDrop for Struct {
    fn drop(self: Pin<&mut Self>) {
        let _: Self = Self;
    }
}
```

The error message points to wrong span:

```text
error[E0423]: expected value, found struct `Struct`
  --> src/lib.rs:10:21
   |
10 | impl PinnedDrop for Struct {
   |                     ^^^^^^ did you mean `(Struct { /* fields */ })`?
   |
```

This PR fixes span of Self keyword to make the error message to point to the correct span:

```text
error[E0423]: expected value, found struct `Struct`
  --> $DIR/self.rs:38:27
   |
30 | /     pub struct Struct {
31 | |         x: (),
32 | |     }
   | |_____- `Struct` defined here
...
38 |               let _: Self = Self; //~ ERROR E0423
   |                             ^^^^ did you mean `Struct { /* fields */ }`?
```