### PR TITLE
Allow `project_replace` argument to be used without `Replace`

### DIFF
--- a/examples/project_replace-expanded.rs
+++ b/examples/project_replace-expanded.rs
@@ -5,7 +5,7 @@
 //
 // use pin_project::pin_project;
 //
-// #[pin_project(Replace)]
+// #[pin_project(project_replace)]
 // struct Struct<T, U> {
 //     #[pin]
 //     pinned: T,

--- a/examples/project_replace.rs
+++ b/examples/project_replace.rs
@@ -4,7 +4,7 @@
 
 use pin_project::pin_project;
 
-#[pin_project(Replace)]
+#[pin_project(project_replace)]
 struct Struct<T, U> {
     #[pin]
     pinned: T,

--- a/pin-project-internal/src/lib.rs
+++ b/pin-project-internal/src/lib.rs
@@ -385,14 +385,39 @@ use crate::utils::ProjKind;
 /// This method is opt-in, because it is only supported for [`Sized`] types, and
 /// because it is incompatible with the [`#[pinned_drop]`][pinned-drop]
 /// attribute described above. It can be enabled by using
-/// `#[pin_project(Replace)]`.
+/// `#[pin_project(project_replace)]`.
 ///
 /// For example:
 ///
 /// ```rust
 /// use pin_project::pin_project;
+/// use std::{marker::PhantomData, pin::Pin};
 ///
-/// #[pin_project(Replace, project_replace = EnumProjOwn)]
+/// #[pin_project(project_replace)]
+/// struct Struct<T, U> {
+///     #[pin]
+///     pinned_field: T,
+///     unpinned_field: U,
+/// }
+///
+/// impl<T, U> Struct<T, U> {
+///     fn method(self: Pin<&mut Self>, other: Self) {
+///         let this = self.project_replace(other);
+///         let _: U = this.unpinned_field;
+///         let _: PhantomData<T> = this.pinned_field;
+///     }
+/// }
+/// ```
+///
+/// By passing the value to the `project_replace` argument, you can name the
+/// returned type of `project_replace()`. This is necessary whenever
+/// destructuring the return type of `project_replace()`, and work in exactly
+/// the same way as the `project` and `project_ref` arguments.
+///
+/// ```rust
+/// use pin_project::pin_project;
+///
+/// #[pin_project(project_replace = EnumProjOwn)]
 /// enum Enum<T, U> {
 ///     A {
 ///         #[pin]
@@ -409,10 +434,6 @@ use crate::utils::ProjKind;
 ///     EnumProjOwn::B => unreachable!(),
 /// }
 /// ```
-///
-/// The `project_replace` argument is necessary whenever destructuring
-/// the return type of `project_replace()`, and work in exactly the same way as
-/// the `project` and `project_ref` arguments.
 ///
 /// [`PhantomData`]: core::marker::PhantomData
 /// [`PhantomPinned`]: core::marker::PhantomPinned

--- a/tests/cfg.rs
+++ b/tests/cfg.rs
@@ -21,7 +21,7 @@ struct Any(PhantomPinned);
 fn cfg() {
     // structs
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct SameName {
         #[cfg(target_os = "linux")]
         #[pin]
@@ -41,7 +41,7 @@ fn cfg() {
     #[cfg(not(target_os = "linux"))]
     let _x = SameName { inner: Other };
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct DifferentName {
         #[cfg(target_os = "linux")]
         #[pin]
@@ -61,7 +61,7 @@ fn cfg() {
     #[cfg(not(target_os = "linux"))]
     let _x = DifferentName { o: Other };
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct TupleStruct(
         #[cfg(target_os = "linux")]
         #[pin]
@@ -83,7 +83,7 @@ fn cfg() {
 
     // enums
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     enum Variant {
         #[cfg(target_os = "linux")]
         Inner(#[pin] Linux),
@@ -110,7 +110,7 @@ fn cfg() {
     #[cfg(not(target_os = "linux"))]
     let _x = Variant::Other(Other);
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     enum Field {
         SameName {
             #[cfg(target_os = "linux")]
@@ -167,7 +167,7 @@ fn cfg() {
 
 #[test]
 fn cfg_attr() {
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct SameCfg {
         #[cfg(target_os = "linux")]
         #[cfg_attr(target_os = "linux", pin)]
@@ -193,7 +193,7 @@ fn cfg_attr() {
     #[cfg(not(target_os = "linux"))]
     let _: Pin<&mut Other> = x.inner;
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct DifferentCfg {
         #[cfg(target_os = "linux")]
         #[cfg_attr(target_os = "linux", pin)]
@@ -233,7 +233,7 @@ fn cfg_attr() {
 #[test]
 fn cfg_attr_any_packed() {
     // Since `cfg(any())` can never be true, it is okay for this to pass.
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     #[cfg_attr(any(), repr(packed))]
     struct Struct {
         #[pin]

--- a/tests/expand/tests/expand/naming-enum.expanded.rs
+++ b/tests/expand/tests/expand/naming-enum.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::pin_project;
-# [ pin ( __private ( Replace , project = Proj , project_ref = ProjRef , project_replace = ProjOwn ) ) ]
+# [ pin ( __private ( project = Proj , project_ref = ProjRef , project_replace = ProjOwn ) ) ]
 enum Enum<T, U> {
     Struct {
         #[pin]

--- a/tests/expand/tests/expand/naming-enum.rs
+++ b/tests/expand/tests/expand/naming-enum.rs
@@ -1,6 +1,6 @@
 use pin_project::pin_project;
 
-#[pin_project(Replace, project = Proj, project_ref = ProjRef, project_replace = ProjOwn)]
+#[pin_project(project = Proj, project_ref = ProjRef, project_replace = ProjOwn)]
 enum Enum<T, U> {
     Struct {
         #[pin]

--- a/tests/expand/tests/expand/naming-struct.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::pin_project;
-# [ pin ( __private ( Replace , project = Proj , project_ref = ProjRef , project_replace = ProjOwn ) ) ]
+# [ pin ( __private ( project = Proj , project_ref = ProjRef , project_replace = ProjOwn ) ) ]
 struct Struct<T, U> {
     #[pin]
     pinned: T,

--- a/tests/expand/tests/expand/naming-struct.rs
+++ b/tests/expand/tests/expand/naming-struct.rs
@@ -1,6 +1,6 @@
 use pin_project::pin_project;
 
-#[pin_project(Replace, project = Proj, project_ref = ProjRef, project_replace = ProjOwn)]
+#[pin_project(project = Proj, project_ref = ProjRef, project_replace = ProjOwn)]
 struct Struct<T, U> {
     #[pin]
     pinned: T,

--- a/tests/expand/tests/expand/naming-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::pin_project;
-# [ pin ( __private ( Replace , project = Proj , project_ref = ProjRef , project_replace = ProjOwn ) ) ]
+# [ pin ( __private ( project = Proj , project_ref = ProjRef , project_replace = ProjOwn ) ) ]
 struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(dead_code)]
 #[allow(single_use_lifetimes)]

--- a/tests/expand/tests/expand/naming-tuple_struct.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct.rs
@@ -1,6 +1,6 @@
 use pin_project::pin_project;
 
-#[pin_project(Replace, project = Proj, project_ref = ProjRef, project_replace = ProjOwn)]
+#[pin_project(project = Proj, project_ref = ProjRef, project_replace = ProjOwn)]
 struct TupleStruct<T, U>(#[pin] T, U);
 
 fn main() {}

--- a/tests/expand/tests/expand/project_replace-enum.expanded.rs
+++ b/tests/expand/tests/expand/project_replace-enum.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::pin_project;
-#[pin(__private(Replace))]
+#[pin(__private(project_replace))]
 enum Enum<T, U> {
     Struct {
         #[pin]

--- a/tests/expand/tests/expand/project_replace-enum.rs
+++ b/tests/expand/tests/expand/project_replace-enum.rs
@@ -1,6 +1,6 @@
 use pin_project::pin_project;
 
-#[pin_project(Replace)]
+#[pin_project(project_replace)]
 enum Enum<T, U> {
     Struct {
         #[pin]

--- a/tests/expand/tests/expand/project_replace-struct.expanded.rs
+++ b/tests/expand/tests/expand/project_replace-struct.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::pin_project;
-#[pin(__private(Replace))]
+#[pin(__private(project_replace))]
 struct Struct<T, U> {
     #[pin]
     pinned: T,

--- a/tests/expand/tests/expand/project_replace-struct.rs
+++ b/tests/expand/tests/expand/project_replace-struct.rs
@@ -1,6 +1,6 @@
 use pin_project::pin_project;
 
-#[pin_project(Replace)]
+#[pin_project(project_replace)]
 struct Struct<T, U> {
     #[pin]
     pinned: T,

--- a/tests/expand/tests/expand/project_replace-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/project_replace-tuple_struct.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::pin_project;
-#[pin(__private(Replace))]
+#[pin(__private(project_replace))]
 struct TupleStruct<T, U>(#[pin] T, U);
 #[doc(hidden)]
 #[allow(dead_code)]

--- a/tests/expand/tests/expand/project_replace-tuple_struct.rs
+++ b/tests/expand/tests/expand/project_replace-tuple_struct.rs
@@ -1,6 +1,6 @@
 use pin_project::pin_project;
 
-#[pin_project(Replace)]
+#[pin_project(project_replace)]
 struct TupleStruct<T, U>(#[pin] T, U);
 
 fn main() {}

--- a/tests/include/basic-safe-part.rs
+++ b/tests/include/basic-safe-part.rs
@@ -63,7 +63,7 @@ impl<T, U> PinnedDrop for PinnedDropEnum<T, U> {
     fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
 }
 
-#[::pin_project::pin_project(Replace)]
+#[::pin_project::pin_project(project_replace)]
 #[derive(Debug)]
 pub struct ReplaceStruct<T, U> {
     #[pin]
@@ -71,11 +71,11 @@ pub struct ReplaceStruct<T, U> {
     pub unpinned: U,
 }
 
-#[::pin_project::pin_project(Replace)]
+#[::pin_project::pin_project(project_replace)]
 #[derive(Debug)]
 pub struct ReplaceTupleStruct<T, U>(#[pin] pub T, pub U);
 
-#[::pin_project::pin_project(Replace)]
+#[::pin_project::pin_project(project_replace)]
 #[derive(Debug)]
 pub enum ReplaceEnum<T, U> {
     Struct {

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -51,17 +51,17 @@ pub mod forbid_unsafe {
 pub mod clippy {
     use pin_project::pin_project;
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct MutMutStruct<'a, T, U> {
         #[pin]
         pub pinned: &'a mut T,
         pub unpinned: &'a mut U,
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct MutMutTupleStruct<'a, T, U>(#[pin] &'a mut T, &'a mut U);
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub enum MutMutEnum<'a, T, U> {
         Struct {
             #[pin]
@@ -72,7 +72,7 @@ pub mod clippy {
         Unit,
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct TypeRepetitionInBoundsStruct<T, U>
     where
         Self: Sized,
@@ -82,12 +82,12 @@ pub mod clippy {
         pub unpinned: U,
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct TypeRepetitionInBoundsTupleStruct<T, U>(#[pin] T, U)
     where
         Self: Sized;
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub enum TypeRepetitionInBoundsEnum<T, U>
     where
         Self: Sized,
@@ -101,14 +101,14 @@ pub mod clippy {
         Unit,
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct UsedUnderscoreBindingStruct<T, U> {
         #[pin]
         pub _pinned: T,
         pub _unpinned: U,
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub enum UsedUnderscoreBindingEnum<T, U> {
         Struct {
             #[pin]

--- a/tests/pin_project.rs
+++ b/tests/pin_project.rs
@@ -53,7 +53,7 @@ fn projection() {
     assert_eq!(s.field1, 3);
     assert_eq!(s.field2, 4);
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct TupleStruct<T, U>(#[pin] T, U);
 
     let mut s = TupleStruct(1, 2);
@@ -65,7 +65,7 @@ fn projection() {
     let y: &mut i32 = s.1;
     assert_eq!(*y, 2);
 
-    #[pin_project(Replace, project = EnumProj)]
+    #[pin_project(project_replace, project = EnumProj)]
     #[derive(Eq, PartialEq, Debug)]
     enum Enum<A, B, C, D> {
         Variant1(#[pin] A, B),
@@ -127,7 +127,7 @@ fn projection() {
 
 #[test]
 fn enum_project_set() {
-    #[pin_project(Replace, project = EnumProj)]
+    #[pin_project(project_replace, project = EnumProj)]
     #[derive(Eq, PartialEq, Debug)]
     enum Enum {
         Variant1(#[pin] u8),
@@ -175,7 +175,7 @@ fn where_clause() {
 
 #[test]
 fn where_clause_and_associated_type_field() {
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct Struct1<I>
     where
         I: Iterator,
@@ -185,7 +185,7 @@ fn where_clause_and_associated_type_field() {
         field2: I::Item,
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct Struct2<I, J>
     where
         I: Iterator<Item = J>,
@@ -195,7 +195,7 @@ fn where_clause_and_associated_type_field() {
         field2: J,
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct Struct3<T>
     where
         T: 'static,
@@ -207,12 +207,12 @@ fn where_clause_and_associated_type_field() {
 
     impl<T> Static for Struct3<T> {}
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct TupleStruct<I>(#[pin] I, I::Item)
     where
         I: Iterator;
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     enum Enum<I>
     where
         I: Iterator,
@@ -224,7 +224,7 @@ fn where_clause_and_associated_type_field() {
 
 #[test]
 fn derive_copy() {
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     #[derive(Clone, Copy)]
     struct Struct<T> {
         val: T,
@@ -239,7 +239,7 @@ fn derive_copy() {
 fn move_out() {
     struct NotCopy;
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct Struct {
         val: NotCopy,
     }
@@ -247,7 +247,7 @@ fn move_out() {
     let x = Struct { val: NotCopy };
     let _val: NotCopy = x.val;
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     enum Enum {
         Variant(NotCopy),
     }
@@ -261,39 +261,39 @@ fn move_out() {
 
 #[test]
 fn trait_bounds_on_type_generics() {
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct Struct1<'a, T: ?Sized> {
         field: &'a mut T,
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct Struct2<'a, T: ::core::fmt::Debug> {
         field: &'a mut T,
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct Struct3<'a, T: core::fmt::Debug> {
         field: &'a mut T,
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct Struct4<'a, T: core::fmt::Debug + core::fmt::Display> {
         field: &'a mut T,
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct Struct5<'a, T: core::fmt::Debug + ?Sized> {
         field: &'a mut T,
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct Struct6<'a, T: core::fmt::Debug = [u8; 16]> {
         field: &'a mut T,
     }
 
     let _: Struct6<'_> = Struct6 { field: &mut [0u8; 16] };
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct Struct7<T: 'static> {
         field: T,
     }
@@ -302,16 +302,16 @@ fn trait_bounds_on_type_generics() {
 
     impl<T> Static for Struct7<T> {}
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct Struct8<'a, 'b: 'a> {
         field1: &'a u8,
         field2: &'b u8,
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct TupleStruct<'a, T: ?Sized>(&'a mut T);
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     enum Enum<'a, T: ?Sized> {
         Variant(&'a mut T),
     }
@@ -319,13 +319,13 @@ fn trait_bounds_on_type_generics() {
 
 #[test]
 fn overlapping_lifetime_names() {
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct Struct1<'pin, T> {
         #[pin]
         field: &'pin mut T,
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct Struct2<'pin, 'pin_, 'pin__> {
         #[pin]
         field: &'pin &'pin_ &'pin__ (),
@@ -334,7 +334,7 @@ fn overlapping_lifetime_names() {
     pub trait A<'a> {}
 
     #[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct HRTB<'pin___, T>
     where
         for<'pin> &'pin T: Unpin,
@@ -389,7 +389,7 @@ fn combine() {
 
 #[test]
 fn private_type_in_public_type() {
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct PublicStruct<T> {
         #[pin]
         inner: PrivateStruct<T>,
@@ -400,21 +400,21 @@ fn private_type_in_public_type() {
 
 #[test]
 fn lifetime_project() {
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct Struct1<T, U> {
         #[pin]
         pinned: T,
         unpinned: U,
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct Struct2<'a, T, U> {
         #[pin]
         pinned: &'a mut T,
         unpinned: U,
     }
 
-    #[pin_project(Replace, project = EnumProj, project_ref = EnumProjRef)]
+    #[pin_project(project_replace, project = EnumProj, project_ref = EnumProjRef)]
     enum Enum<T, U> {
         Variant {
             #[pin]
@@ -458,21 +458,21 @@ fn lifetime_project() {
 #[rustversion::since(1.36)] // https://github.com/rust-lang/rust/pull/61207
 #[test]
 fn lifetime_project_elided() {
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct Struct1<T, U> {
         #[pin]
         pinned: T,
         unpinned: U,
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct Struct2<'a, T, U> {
         #[pin]
         pinned: &'a mut T,
         unpinned: U,
     }
 
-    #[pin_project(Replace, project = EnumProj, project_ref = EnumProjRef)]
+    #[pin_project(project_replace, project = EnumProj, project_ref = EnumProjRef)]
     enum Enum<T, U> {
         Variant {
             #[pin]
@@ -516,7 +516,7 @@ fn lifetime_project_elided() {
 mod visibility {
     use pin_project::pin_project;
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub(crate) struct A {
         pub b: u8,
     }
@@ -534,7 +534,7 @@ fn visibility() {
 
 #[test]
 fn trivial_bounds() {
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct NoGenerics {
         #[pin]
         field: PhantomPinned,
@@ -712,7 +712,7 @@ fn dyn_type() {
 fn self_in_where_clause() {
     pub trait Trait1 {}
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct Struct1<T>
     where
         Self: Trait1,
@@ -726,7 +726,7 @@ fn self_in_where_clause() {
         type Assoc;
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct Struct2<T>
     where
         Self: Trait2<Assoc = Struct1<T>>,
@@ -752,7 +752,7 @@ fn no_infer_outlives() {
         type Y = Option<T>;
     }
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct Foo<A, B> {
         _x: <Example<A> as Bar<B>>::Y,
     }
@@ -765,7 +765,7 @@ fn no_infer_outlives() {
 fn project_replace_panic() {
     use std::panic;
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct S<T, U> {
         #[pin]
         pinned: T,

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -242,7 +242,7 @@ fn issue_206() {
 #[project]
 #[test]
 fn combine() {
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     enum Enum<A> {
         V1(#[pin] A),
         V2,
@@ -272,7 +272,7 @@ fn combine() {
 #[project_replace]
 #[test]
 fn combine_compat() {
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     enum Enum<A> {
         V1(#[pin] A),
         V2,

--- a/tests/project_ref.rs
+++ b/tests/project_ref.rs
@@ -149,7 +149,7 @@ fn project_impl() {
 #[project_ref]
 #[test]
 fn combine() {
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     enum Enum<A> {
         V1(#[pin] A),
         V2,

--- a/tests/project_replace.rs
+++ b/tests/project_replace.rs
@@ -7,7 +7,7 @@ use std::{marker::PhantomData, pin::Pin};
 #[project_replace] // Nightly does not need a dummy attribute to the function.
 #[test]
 fn project_replace_stmt_expr() {
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct Struct<T, U> {
         #[pin]
         field1: T,
@@ -27,7 +27,7 @@ fn project_replace_stmt_expr() {
 
     // tuple struct
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct TupleStruct<T, U>(#[pin] T, U);
 
     let mut s = TupleStruct(1, 2);
@@ -39,7 +39,7 @@ fn project_replace_stmt_expr() {
     let y: i32 = y;
     assert_eq!(y, 2);
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     enum Enum<A, B, C, D> {
         Variant1(#[pin] A, B),
         Variant2 {
@@ -73,7 +73,7 @@ fn project_replace_stmt_expr() {
 #[project_replace]
 #[test]
 fn combine() {
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     enum Enum<A> {
         V1(#[pin] A),
         V2,

--- a/tests/ui/pin_project/invalid.rs
+++ b/tests/ui/pin_project/invalid.rs
@@ -100,6 +100,9 @@ mod pin_project_argument {
     #[pin_project()] // Ok
     struct Unexpected4(#[pin] ());
 
+    #[pin_project(PinnedDrop PinnedDrop)] //~ ERROR expected `,`
+    struct Unexpected5(#[pin] ());
+
     #[pin_project(PinnedDrop, PinnedDrop)] //~ ERROR duplicate `PinnedDrop` argument
     struct DuplicatePinnedDrop(#[pin] ());
 
@@ -128,9 +131,15 @@ mod pin_project_argument {
     struct DuplicateProjectRef(#[pin] ());
 
     #[pin_project(project_replace = A, project_replace = B)] //~ ERROR duplicate `project_replace` argument
-    struct DuplicateProjectReplace(#[pin] ());
+    struct DuplicateProjectReplace1(#[pin] ());
 
-    #[pin_project(project_replace = A)] //~ ERROR `project_replace` argument can only be used together with `Replace` argument
+    #[pin_project(project_replace, project_replace = B)] //~ ERROR duplicate `project_replace` argument
+    struct DuplicateProjectReplace2(#[pin] ());
+
+    #[pin_project(project_replace = A, project_replace)] //~ ERROR duplicate `project_replace` argument
+    struct DuplicateProjectReplace3(#[pin] ());
+
+    #[pin_project(project_replace = A)] // Ok
     struct ProjectReplaceWithoutReplace(#[pin] ());
 
     #[pin_project(PinnedDrop, Replace)] //~ ERROR arguments `PinnedDrop` and `Replace` are mutually exclusive
@@ -138,6 +147,18 @@ mod pin_project_argument {
 
     #[pin_project(Replace, UnsafeUnpin, PinnedDrop)] //~ ERROR arguments `PinnedDrop` and `Replace` are mutually exclusive
     struct PinnedDropWithReplace2(#[pin] ());
+
+    #[pin_project(PinnedDrop, project_replace)] //~ ERROR arguments `PinnedDrop` and `project_replace` are mutually exclusive
+    struct PinnedDropWithProjectReplace1(#[pin] ());
+
+    #[pin_project(project_replace, UnsafeUnpin, PinnedDrop)] //~ ERROR arguments `PinnedDrop` and `project_replace` are mutually exclusive
+    struct PinnedDropWithProjectReplace2(#[pin] ());
+
+    #[pin_project(project_replace, Replace)] // Ok
+    struct ProjectReplaceWithReplace1(#[pin] ());
+
+    #[pin_project(project_replace = B, Replace)] // Ok
+    struct ProjectReplaceWithReplace2(#[pin] ());
 
     #[pin_project(UnsafeUnpin, !Unpin)] //~ ERROR arguments `UnsafeUnpin` and `!Unpin` are mutually exclusive
     struct UnsafeUnpinWithNotUnpin1(#[pin] ());
@@ -157,17 +178,26 @@ mod pin_project_argument {
     #[pin_project(project = )] //~ ERROR expected `project = <identifier>`, found `project =`
     struct Project2(#[pin] ());
 
+    #[pin_project(project = !)] //~ ERROR expected identifier
+    struct Project3(#[pin] ());
+
     #[pin_project(project_ref)] //~ ERROR expected `project_ref = <identifier>`, found `project_ref`
     struct ProjectRef1(#[pin] ());
 
     #[pin_project(project_ref = )] //~ ERROR expected `project_ref = <identifier>`, found `project_ref =`
     struct ProjectRef2(#[pin] ());
 
-    #[pin_project(project_replace)] //~ ERROR expected `project_replace = <identifier>`, found `project_replace`
+    #[pin_project(project_ref = !)] //~ ERROR expected identifier
+    struct ProjectRef3(#[pin] ());
+
+    #[pin_project(project_replace)] // Ok
     struct ProjectReplace1(#[pin] ());
 
     #[pin_project(project_replace = )] //~ ERROR expected `project_replace = <identifier>`, found `project_replace =`
     struct ProjectReplace2(#[pin] ());
+
+    #[pin_project(project_replace = !)] //~ ERROR expected identifier
+    struct ProjectReplace3(#[pin] ());
 }
 
 mod pin_project_attribute {

--- a/tests/ui/pin_project/invalid.stderr
+++ b/tests/ui/pin_project/invalid.stderr
@@ -82,211 +82,247 @@ error: expected identifier
 97 |     #[pin_project(,UnsafeUnpin)] //~ ERROR expected identifier
    |                   ^
 
-error: duplicate `PinnedDrop` argument
-   --> $DIR/invalid.rs:103:31
+error: expected `,`
+   --> $DIR/invalid.rs:103:30
     |
-103 |     #[pin_project(PinnedDrop, PinnedDrop)] //~ ERROR duplicate `PinnedDrop` argument
+103 |     #[pin_project(PinnedDrop PinnedDrop)] //~ ERROR expected `,`
+    |                              ^^^^^^^^^^
+
+error: duplicate `PinnedDrop` argument
+   --> $DIR/invalid.rs:106:31
+    |
+106 |     #[pin_project(PinnedDrop, PinnedDrop)] //~ ERROR duplicate `PinnedDrop` argument
     |                               ^^^^^^^^^^
 
 error: duplicate `Replace` argument
-   --> $DIR/invalid.rs:106:28
+   --> $DIR/invalid.rs:109:28
     |
-106 |     #[pin_project(Replace, Replace)] //~ ERROR duplicate `Replace` argument
+109 |     #[pin_project(Replace, Replace)] //~ ERROR duplicate `Replace` argument
     |                            ^^^^^^^
 
 error: duplicate `UnsafeUnpin` argument
-   --> $DIR/invalid.rs:109:32
+   --> $DIR/invalid.rs:112:32
     |
-109 |     #[pin_project(UnsafeUnpin, UnsafeUnpin)] //~ ERROR duplicate `UnsafeUnpin` argument
+112 |     #[pin_project(UnsafeUnpin, UnsafeUnpin)] //~ ERROR duplicate `UnsafeUnpin` argument
     |                                ^^^^^^^^^^^
 
 error: duplicate `!Unpin` argument
-   --> $DIR/invalid.rs:112:27
+   --> $DIR/invalid.rs:115:27
     |
-112 |     #[pin_project(!Unpin, !Unpin)] //~ ERROR duplicate `!Unpin` argument
+115 |     #[pin_project(!Unpin, !Unpin)] //~ ERROR duplicate `!Unpin` argument
     |                           ^^^^^^
 
 error: duplicate `UnsafeUnpin` argument
-   --> $DIR/invalid.rs:115:44
+   --> $DIR/invalid.rs:118:44
     |
-115 |     #[pin_project(PinnedDrop, UnsafeUnpin, UnsafeUnpin)] //~ ERROR duplicate `UnsafeUnpin` argument
+118 |     #[pin_project(PinnedDrop, UnsafeUnpin, UnsafeUnpin)] //~ ERROR duplicate `UnsafeUnpin` argument
     |                                            ^^^^^^^^^^^
 
 error: duplicate `PinnedDrop` argument
-   --> $DIR/invalid.rs:118:44
+   --> $DIR/invalid.rs:121:44
     |
-118 |     #[pin_project(PinnedDrop, UnsafeUnpin, PinnedDrop, UnsafeUnpin)] //~ ERROR duplicate `PinnedDrop` argument
+121 |     #[pin_project(PinnedDrop, UnsafeUnpin, PinnedDrop, UnsafeUnpin)] //~ ERROR duplicate `PinnedDrop` argument
     |                                            ^^^^^^^^^^
 
 error: duplicate `project` argument
-   --> $DIR/invalid.rs:121:32
+   --> $DIR/invalid.rs:124:32
     |
-121 |     #[pin_project(project = A, project = B)] //~ ERROR duplicate `project` argument
+124 |     #[pin_project(project = A, project = B)] //~ ERROR duplicate `project` argument
     |                                ^^^^^^^^^^^
 
 error: duplicate `project` argument
-   --> $DIR/invalid.rs:124:49
+   --> $DIR/invalid.rs:127:49
     |
-124 |     #[pin_project(project = A, project_ref = A, project = B)] //~ ERROR duplicate `project` argument
+127 |     #[pin_project(project = A, project_ref = A, project = B)] //~ ERROR duplicate `project` argument
     |                                                 ^^^^^^^^^^^
 
 error: duplicate `project_ref` argument
-   --> $DIR/invalid.rs:127:36
+   --> $DIR/invalid.rs:130:36
     |
-127 |     #[pin_project(project_ref = A, project_ref = B)] //~ ERROR duplicate `project_ref` argument
+130 |     #[pin_project(project_ref = A, project_ref = B)] //~ ERROR duplicate `project_ref` argument
     |                                    ^^^^^^^^^^^^^^^
 
 error: duplicate `project_replace` argument
-   --> $DIR/invalid.rs:130:40
+   --> $DIR/invalid.rs:133:40
     |
-130 |     #[pin_project(project_replace = A, project_replace = B)] //~ ERROR duplicate `project_replace` argument
+133 |     #[pin_project(project_replace = A, project_replace = B)] //~ ERROR duplicate `project_replace` argument
     |                                        ^^^^^^^^^^^^^^^^^^^
 
-error: `project_replace` argument can only be used together with `Replace` argument
-   --> $DIR/invalid.rs:133:19
+error: duplicate `project_replace` argument
+   --> $DIR/invalid.rs:136:36
     |
-133 |     #[pin_project(project_replace = A)] //~ ERROR `project_replace` argument can only be used together with `Replace` argument
-    |                   ^^^^^^^^^^^^^^^^^^^
+136 |     #[pin_project(project_replace, project_replace = B)] //~ ERROR duplicate `project_replace` argument
+    |                                    ^^^^^^^^^^^^^^^^^^^
+
+error: duplicate `project_replace` argument
+   --> $DIR/invalid.rs:139:40
+    |
+139 |     #[pin_project(project_replace = A, project_replace)] //~ ERROR duplicate `project_replace` argument
+    |                                        ^^^^^^^^^^^^^^^
 
 error: arguments `PinnedDrop` and `Replace` are mutually exclusive
-   --> $DIR/invalid.rs:136:19
+   --> $DIR/invalid.rs:145:19
     |
-136 |     #[pin_project(PinnedDrop, Replace)] //~ ERROR arguments `PinnedDrop` and `Replace` are mutually exclusive
+145 |     #[pin_project(PinnedDrop, Replace)] //~ ERROR arguments `PinnedDrop` and `Replace` are mutually exclusive
     |                   ^^^^^^^^^^
 
 error: arguments `PinnedDrop` and `Replace` are mutually exclusive
-   --> $DIR/invalid.rs:139:41
+   --> $DIR/invalid.rs:148:41
     |
-139 |     #[pin_project(Replace, UnsafeUnpin, PinnedDrop)] //~ ERROR arguments `PinnedDrop` and `Replace` are mutually exclusive
+148 |     #[pin_project(Replace, UnsafeUnpin, PinnedDrop)] //~ ERROR arguments `PinnedDrop` and `Replace` are mutually exclusive
     |                                         ^^^^^^^^^^
 
-error: arguments `UnsafeUnpin` and `!Unpin` are mutually exclusive
-   --> $DIR/invalid.rs:142:19
+error: arguments `PinnedDrop` and `project_replace` are mutually exclusive
+   --> $DIR/invalid.rs:151:19
     |
-142 |     #[pin_project(UnsafeUnpin, !Unpin)] //~ ERROR arguments `UnsafeUnpin` and `!Unpin` are mutually exclusive
+151 |     #[pin_project(PinnedDrop, project_replace)] //~ ERROR arguments `PinnedDrop` and `project_replace` are mutually exclusive
+    |                   ^^^^^^^^^^
+
+error: arguments `PinnedDrop` and `project_replace` are mutually exclusive
+   --> $DIR/invalid.rs:154:49
+    |
+154 |     #[pin_project(project_replace, UnsafeUnpin, PinnedDrop)] //~ ERROR arguments `PinnedDrop` and `project_replace` are mutually exclusive
+    |                                                 ^^^^^^^^^^
+
+error: arguments `UnsafeUnpin` and `!Unpin` are mutually exclusive
+   --> $DIR/invalid.rs:163:19
+    |
+163 |     #[pin_project(UnsafeUnpin, !Unpin)] //~ ERROR arguments `UnsafeUnpin` and `!Unpin` are mutually exclusive
     |                   ^^^^^^^^^^^
 
 error: arguments `UnsafeUnpin` and `!Unpin` are mutually exclusive
-   --> $DIR/invalid.rs:145:39
+   --> $DIR/invalid.rs:166:39
     |
-145 |     #[pin_project(!Unpin, PinnedDrop, UnsafeUnpin)] //~ ERROR arguments `UnsafeUnpin` and `!Unpin` are mutually exclusive
+166 |     #[pin_project(!Unpin, PinnedDrop, UnsafeUnpin)] //~ ERROR arguments `UnsafeUnpin` and `!Unpin` are mutually exclusive
     |                                       ^^^^^^^^^^^
 
 error: expected `!Unpin`, found `!`
-   --> $DIR/invalid.rs:148:19
+   --> $DIR/invalid.rs:169:19
     |
-148 |     #[pin_project(!)] //~ ERROR expected `!Unpin`, found `!`
+169 |     #[pin_project(!)] //~ ERROR expected `!Unpin`, found `!`
     |                   ^
 
 error: unexpected argument: Unpin
-   --> $DIR/invalid.rs:151:19
+   --> $DIR/invalid.rs:172:19
     |
-151 |     #[pin_project(Unpin)] //~ ERROR unexpected argument
+172 |     #[pin_project(Unpin)] //~ ERROR unexpected argument
     |                   ^^^^^
 
 error: expected `project = <identifier>`, found `project`
-   --> $DIR/invalid.rs:154:19
+   --> $DIR/invalid.rs:175:19
     |
-154 |     #[pin_project(project)] //~ ERROR expected `project = <identifier>`, found `project`
+175 |     #[pin_project(project)] //~ ERROR expected `project = <identifier>`, found `project`
     |                   ^^^^^^^
 
 error: expected `project = <identifier>`, found `project =`
-   --> $DIR/invalid.rs:157:19
+   --> $DIR/invalid.rs:178:19
     |
-157 |     #[pin_project(project = )] //~ ERROR expected `project = <identifier>`, found `project =`
+178 |     #[pin_project(project = )] //~ ERROR expected `project = <identifier>`, found `project =`
     |                   ^^^^^^^^^
 
-error: expected `project_ref = <identifier>`, found `project_ref`
-   --> $DIR/invalid.rs:160:19
+error: expected identifier
+   --> $DIR/invalid.rs:181:29
     |
-160 |     #[pin_project(project_ref)] //~ ERROR expected `project_ref = <identifier>`, found `project_ref`
+181 |     #[pin_project(project = !)] //~ ERROR expected identifier
+    |                             ^
+
+error: expected `project_ref = <identifier>`, found `project_ref`
+   --> $DIR/invalid.rs:184:19
+    |
+184 |     #[pin_project(project_ref)] //~ ERROR expected `project_ref = <identifier>`, found `project_ref`
     |                   ^^^^^^^^^^^
 
 error: expected `project_ref = <identifier>`, found `project_ref =`
-   --> $DIR/invalid.rs:163:19
+   --> $DIR/invalid.rs:187:19
     |
-163 |     #[pin_project(project_ref = )] //~ ERROR expected `project_ref = <identifier>`, found `project_ref =`
+187 |     #[pin_project(project_ref = )] //~ ERROR expected `project_ref = <identifier>`, found `project_ref =`
     |                   ^^^^^^^^^^^^^
 
-error: expected `project_replace = <identifier>`, found `project_replace`
-   --> $DIR/invalid.rs:166:19
+error: expected identifier
+   --> $DIR/invalid.rs:190:33
     |
-166 |     #[pin_project(project_replace)] //~ ERROR expected `project_replace = <identifier>`, found `project_replace`
-    |                   ^^^^^^^^^^^^^^^
+190 |     #[pin_project(project_ref = !)] //~ ERROR expected identifier
+    |                                 ^
 
 error: expected `project_replace = <identifier>`, found `project_replace =`
-   --> $DIR/invalid.rs:169:19
+   --> $DIR/invalid.rs:196:19
     |
-169 |     #[pin_project(project_replace = )] //~ ERROR expected `project_replace = <identifier>`, found `project_replace =`
+196 |     #[pin_project(project_replace = )] //~ ERROR expected `project_replace = <identifier>`, found `project_replace =`
     |                   ^^^^^^^^^^^^^^^^^
 
-error: duplicate #[pin_project] attribute
-   --> $DIR/invalid.rs:177:5
+error: expected identifier
+   --> $DIR/invalid.rs:199:37
     |
-177 |     #[pin_project] //~ ERROR duplicate #[pin_project] attribute
+199 |     #[pin_project(project_replace = !)] //~ ERROR expected identifier
+    |                                     ^
+
+error: duplicate #[pin_project] attribute
+   --> $DIR/invalid.rs:207:5
+    |
+207 |     #[pin_project] //~ ERROR duplicate #[pin_project] attribute
     |     ^^^^^^^^^^^^^^
 
 error: #[pin_project] attribute may not be used on structs with zero fields
-   --> $DIR/invalid.rs:185:19
+   --> $DIR/invalid.rs:215:19
     |
-185 |     struct Struct {} //~ ERROR may not be used on structs with zero fields
+215 |     struct Struct {} //~ ERROR may not be used on structs with zero fields
     |                   ^^
 
 error: #[pin_project] attribute may not be used on structs with zero fields
-   --> $DIR/invalid.rs:188:23
+   --> $DIR/invalid.rs:218:23
     |
-188 |     struct TupleStruct(); //~ ERROR may not be used on structs with zero fields
+218 |     struct TupleStruct(); //~ ERROR may not be used on structs with zero fields
     |                       ^^
 
 error: #[pin_project] attribute may not be used on structs with zero fields
-   --> $DIR/invalid.rs:191:12
+   --> $DIR/invalid.rs:221:12
     |
-191 |     struct UnitStruct; //~ ERROR may not be used on structs with zero fields
+221 |     struct UnitStruct; //~ ERROR may not be used on structs with zero fields
     |            ^^^^^^^^^^
 
 error: #[pin_project] attribute may not be used on enums without variants
-   --> $DIR/invalid.rs:194:20
+   --> $DIR/invalid.rs:224:20
     |
-194 |     enum EnumEmpty {} //~ ERROR may not be used on enums without variants
+224 |     enum EnumEmpty {} //~ ERROR may not be used on enums without variants
     |                    ^^
 
 error: #[pin_project] attribute may not be used on enums with discriminants
-   --> $DIR/invalid.rs:198:13
+   --> $DIR/invalid.rs:228:13
     |
-198 |         V = 2, //~ ERROR may not be used on enums with discriminants
+228 |         V = 2, //~ ERROR may not be used on enums with discriminants
     |             ^
 
 error: #[pin_project] attribute may not be used on enums with zero fields
-   --> $DIR/invalid.rs:203:9
+   --> $DIR/invalid.rs:233:9
     |
-203 | /         Unit, //~ ERROR may not be used on enums with zero fields
-204 | |         Tuple(),
-205 | |         Struct {},
+233 | /         Unit, //~ ERROR may not be used on enums with zero fields
+234 | |         Tuple(),
+235 | |         Struct {},
     | |__________________^
 
 error: #[pin_project] attribute may only be used on structs or enums
-   --> $DIR/invalid.rs:209:5
+   --> $DIR/invalid.rs:239:5
     |
-209 | /     union Union {
-210 | |         //~^ ERROR may only be used on structs or enums
-211 | |         f: (),
-212 | |     }
+239 | /     union Union {
+240 | |         //~^ ERROR may only be used on structs or enums
+241 | |         f: (),
+242 | |     }
     | |_____^
 
 error: #[pin_project] attribute may not be used on #[repr(packed)] types
-   --> $DIR/invalid.rs:220:12
+   --> $DIR/invalid.rs:250:12
     |
-220 |     #[repr(packed)]
+250 |     #[repr(packed)]
     |            ^^^^^^
 
 error: #[pin_project] attribute may not be used on #[repr(packed)] types
-   --> $DIR/invalid.rs:224:12
+   --> $DIR/invalid.rs:254:12
     |
-224 |     #[repr(packed)]
+254 |     #[repr(packed)]
     |            ^^^^^^
 
 error: #[pin_project] attribute may not be used on #[repr(packed)] types
-   --> $DIR/invalid.rs:228:12
+   --> $DIR/invalid.rs:258:12
     |
-228 |     #[repr(packed)]
+258 |     #[repr(packed)]
     |            ^^^^^^

--- a/tests/ui/pin_project/project_replace_unsized.rs
+++ b/tests/ui/pin_project/project_replace_unsized.rs
@@ -1,11 +1,11 @@
 use pin_project::pin_project;
 
-#[pin_project(Replace)] //~ ERROR E0277
+#[pin_project(project_replace)] //~ ERROR E0277
 struct Struct<T: ?Sized> {
     x: T,
 }
 
-#[pin_project(Replace)] //~ ERROR E0277
+#[pin_project(project_replace)] //~ ERROR E0277
 struct TupleStruct<T: ?Sized>(T);
 
 fn main() {}

--- a/tests/ui/pin_project/project_replace_unsized.stderr
+++ b/tests/ui/pin_project/project_replace_unsized.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `T` cannot be known at compilation time
  --> $DIR/project_replace_unsized.rs:3:15
   |
-3 | #[pin_project(Replace)] //~ ERROR E0277
-  |               ^^^^^^^ doesn't have a size known at compile-time
+3 | #[pin_project(project_replace)] //~ ERROR E0277
+  |               ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
 4 | struct Struct<T: ?Sized> {
   |               - this type parameter needs to be `std::marker::Sized`
   |
@@ -26,8 +26,8 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 error[E0277]: the size for values of type `T` cannot be known at compilation time
  --> $DIR/project_replace_unsized.rs:3:1
   |
-3 | #[pin_project(Replace)] //~ ERROR E0277
-  | ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+3 | #[pin_project(project_replace)] //~ ERROR E0277
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
 4 | struct Struct<T: ?Sized> {
   |               - this type parameter needs to be `std::marker::Sized`
   |
@@ -40,8 +40,8 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 error[E0277]: the size for values of type `T` cannot be known at compilation time
  --> $DIR/project_replace_unsized.rs:8:15
   |
-8 | #[pin_project(Replace)] //~ ERROR E0277
-  |               ^^^^^^^ doesn't have a size known at compile-time
+8 | #[pin_project(project_replace)] //~ ERROR E0277
+  |               ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
 9 | struct TupleStruct<T: ?Sized>(T);
   |                    - this type parameter needs to be `std::marker::Sized`
   |
@@ -54,8 +54,8 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 error[E0277]: the size for values of type `T` cannot be known at compilation time
    --> $DIR/project_replace_unsized.rs:8:1
     |
-8   | #[pin_project(Replace)] //~ ERROR E0277
-    | ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+8   | #[pin_project(project_replace)] //~ ERROR E0277
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
 9   | struct TupleStruct<T: ?Sized>(T);
     |                    - this type parameter needs to be `std::marker::Sized`
     |

--- a/tests/ui/pin_project/project_replace_unsized_locals.rs
+++ b/tests/ui/pin_project/project_replace_unsized_locals.rs
@@ -2,12 +2,12 @@
 
 use pin_project::pin_project;
 
-#[pin_project(Replace)] //~ ERROR E0277
+#[pin_project(project_replace)] //~ ERROR E0277
 struct Struct<T: ?Sized> {
     x: T,
 }
 
-#[pin_project(Replace)] //~ ERROR E0277
+#[pin_project(project_replace)] //~ ERROR E0277
 struct TupleStruct<T: ?Sized>(T);
 
 fn main() {}

--- a/tests/ui/pin_project/project_replace_unsized_locals.stderr
+++ b/tests/ui/pin_project/project_replace_unsized_locals.stderr
@@ -26,8 +26,8 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 error[E0277]: the size for values of type `T` cannot be known at compilation time
  --> $DIR/project_replace_unsized_locals.rs:5:1
   |
-5 | #[pin_project(Replace)] //~ ERROR E0277
-  | ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+5 | #[pin_project(project_replace)] //~ ERROR E0277
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
 6 | struct Struct<T: ?Sized> {
   |               - this type parameter needs to be `std::marker::Sized`
   |
@@ -54,8 +54,8 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 error[E0277]: the size for values of type `T` cannot be known at compilation time
    --> $DIR/project_replace_unsized_locals.rs:10:1
     |
-10  | #[pin_project(Replace)] //~ ERROR E0277
-    | ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+10  | #[pin_project(project_replace)] //~ ERROR E0277
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
 11  | struct TupleStruct<T: ?Sized>(T);
     |                    - this type parameter needs to be `std::marker::Sized`
     |

--- a/tests/ui/pin_project/visibility.rs
+++ b/tests/ui/pin_project/visibility.rs
@@ -4,7 +4,7 @@ mod pub_ {
     #[pin_project]
     pub struct Default(());
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub struct Replace(());
 }
 pub mod pub_use {
@@ -37,7 +37,7 @@ mod pub_crate {
     #[pin_project]
     pub(crate) struct Default(());
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     pub(crate) struct Replace(());
 }
 pub mod pub_crate_use {
@@ -55,7 +55,7 @@ mod pub_renamed {
     #[pin_project(project = DProj, project_ref = DProjRef)]
     pub struct Default(());
 
-    #[pin_project(Replace, project = RProj, project_ref = RProjRef, project_replace = RProjOwn)]
+    #[pin_project(project = RProj, project_ref = RProjRef, project_replace = RProjOwn)]
     pub struct Replace(());
 }
 pub mod pub_renamed_use {

--- a/tests/ui/project/invalid.rs
+++ b/tests/ui/project/invalid.rs
@@ -46,7 +46,7 @@ mod argument {
 mod attribute {
     use pin_project::{pin_project, project, project_ref, project_replace};
 
-    #[pin_project(Replace)]
+    #[pin_project(project_replace)]
     struct A(#[pin] ());
 
     #[project]


### PR DESCRIPTION
Currently, both `Replace` and `project_replace = <name>` arguments are required to name the return value of `project_replace()` method.

```rust
#[pin_project(Replace, project_replace = EnumProjOwn)]
enum Enum<T> {
    Variant(#[pin] T)
}
```

It is not ideal that we need to have both `Replace` and `project_replace = <name>` as `project_replace = <name>` implies that a `project_replace` method is generated.

This PR makes `project_replace` argument to use without `Replace` argument.

```diff
- #[pin_project(Replace, project_replace = EnumProjOwn)]
+ #[pin_project(project_replace = EnumProjOwn)]
  enum Enum<T> {
      Variant(#[pin] T)
  }
```

Also, makes `project_replace` argument an alias for `Replace` so that it can be used without a value.


```rust
#[pin_project(project_replace)]
enum Enum<T> {
    Variant(#[pin] T)
}
```

Related: https://github.com/rust-lang/futures-rs/pull/2176#discussion_r436234178 https://github.com/hyperium/hyper/pull/2220#discussion_r436234137