### PR TITLE
Deprecate project* attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+* [Deprecated `#[project]`, `#[project_ref]`, and `#[project_replace]` attributes due to some unfixable limitations.][244]
+
+  Consider naming the projected type by passing an argument with the same name as the method to the #[pin_project] attribute instead.
+
+  ```rust
+  use pin_project::pin_project;
+  use std::pin::Pin;
+
+  #[pin_project(project = EnumProj)]
+  enum Enum<T> {
+      Variant(#[pin] T),
+  }
+
+  fn func<T>(x: Pin<&mut Enum<T>>) {
+      match x.project() {
+          EnumProj::Variant(y) => {
+              let _: Pin<&mut T> = y;
+          }
+      }
+  }
+  ```
+
+  See [#225][225] for more details.
+
+[225]: https://github.com/taiki-e/pin-project/pull/225
+[244]: https://github.com/taiki-e/pin-project/pull/244
+
 ## [0.4.20] - 2020-06-07
 
 * [You can now use project_replace argument without Replace argument.][243]

--- a/pin-project-internal/build.rs
+++ b/pin-project-internal/build.rs
@@ -9,10 +9,16 @@ fn main() {
         None => return,
     };
 
-    // Underscore const names stabilized in Rust 1.37:
-    // https://github.com/rust-lang/rust/pull/61347/
+    // Underscore const names requires Rust 1.37:
+    // https://github.com/rust-lang/rust/pull/61347
     if minor >= 37 {
         println!("cargo:rustc-cfg=underscore_consts");
+    }
+
+    // #[deprecated] on proc-macro requires Rust 1.40:
+    // https://github.com/rust-lang/rust/pull/65666
+    if minor >= 40 {
+        println!("cargo:rustc-cfg=deprecated_proc_macro");
     }
 }
 

--- a/pin-project-internal/src/lib.rs
+++ b/pin-project-internal/src/lib.rs
@@ -546,6 +546,7 @@ pub fn pinned_drop(args: TokenStream, input: TokenStream) -> TokenStream {
 /// ## Examples
 ///
 /// ```rust
+/// # #![allow(deprecated)]
 /// use pin_project::{pin_project, project};
 /// use std::pin::Pin;
 ///
@@ -576,6 +577,7 @@ pub fn pinned_drop(args: TokenStream, input: TokenStream) -> TokenStream {
 /// ## Examples
 ///
 /// ```rust
+/// # #![allow(deprecated)]
 /// use pin_project::{pin_project, project};
 /// use std::pin::Pin;
 ///
@@ -616,6 +618,7 @@ pub fn pinned_drop(args: TokenStream, input: TokenStream) -> TokenStream {
 /// ## Examples
 ///
 /// ```rust
+/// # #![allow(deprecated)]
 /// use pin_project::{pin_project, project};
 /// use std::pin::Pin;
 ///
@@ -650,6 +653,7 @@ pub fn pinned_drop(args: TokenStream, input: TokenStream) -> TokenStream {
 /// ## Examples
 ///
 /// ```rust
+/// # #![allow(deprecated)]
 /// # mod dox {
 /// use pin_project::pin_project;
 ///
@@ -676,6 +680,16 @@ pub fn pinned_drop(args: TokenStream, input: TokenStream) -> TokenStream {
 /// }
 /// # }
 /// ```
+#[cfg_attr(
+    deprecated_proc_macro,
+    deprecated(
+        since = "0.4.21",
+        note = "consider naming projected type by passing `project` \
+                argument to #[pin_project] attribute instead, see release note \
+                <https://github.com/taiki-e/pin-project/releases/tag/v0.4.21> \
+                for details"
+    )
+)]
 #[proc_macro_attribute]
 pub fn project(args: TokenStream, input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input);
@@ -691,6 +705,16 @@ pub fn project(args: TokenStream, input: TokenStream) -> TokenStream {
 /// See [`#[project]`][`project`] attribute for more details.
 ///
 /// [`project`]: ./attr.project.html
+#[cfg_attr(
+    deprecated_proc_macro,
+    deprecated(
+        since = "0.4.21",
+        note = "consider naming projected type by passing `project_ref` \
+                argument to #[pin_project] attribute instead, see release note \
+                <https://github.com/taiki-e/pin-project/releases/tag/v0.4.21> \
+                for details"
+    )
+)]
 #[proc_macro_attribute]
 pub fn project_ref(args: TokenStream, input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input);
@@ -706,6 +730,16 @@ pub fn project_ref(args: TokenStream, input: TokenStream) -> TokenStream {
 /// See [`#[project]`][`project`] attribute for more details.
 ///
 /// [`project`]: ./attr.project.html
+#[cfg_attr(
+    deprecated_proc_macro,
+    deprecated(
+        since = "0.4.21",
+        note = "consider naming projected type by passing `project_replace` \
+                argument to #[pin_project] attribute instead, see release note \
+                <https://github.com/taiki-e/pin-project/releases/tag/v0.4.21> \
+                for details"
+    )
+)]
 #[proc_macro_attribute]
 pub fn project_replace(args: TokenStream, input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,12 +55,15 @@ pub use pin_project_internal::pin_project;
 #[doc(inline)]
 pub use pin_project_internal::pinned_drop;
 
+#[allow(deprecated)]
 #[doc(inline)]
 pub use pin_project_internal::project;
 
+#[allow(deprecated)]
 #[doc(inline)]
 pub use pin_project_internal::project_ref;
 
+#[allow(deprecated)]
 #[doc(inline)]
 pub use pin_project_internal::project_replace;
 

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms, single_use_lifetimes)]
 #![allow(dead_code)]
+#![allow(deprecated)]
 
 // Ceurrently, `#[attr] if true {}` doesn't even *parse* on MSRV,
 // which means that it will error even behind a `#[rustversion::since(..)]`

--- a/tests/project_ref.rs
+++ b/tests/project_ref.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms, single_use_lifetimes)]
 #![allow(dead_code)]
+#![allow(deprecated)]
 
 use pin_project::{pin_project, project_ref};
 use std::pin::Pin;

--- a/tests/project_replace.rs
+++ b/tests/project_replace.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms, single_use_lifetimes)]
 #![allow(dead_code)]
+#![allow(deprecated)]
 
 use pin_project::{pin_project, project_replace};
 use std::{marker::PhantomData, pin::Pin};

--- a/tests/ui/project/ambiguous-let.rs
+++ b/tests/ui/project/ambiguous-let.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use pin_project::{pin_project, project};
 
 #[pin_project]

--- a/tests/ui/project/ambiguous-let.stderr
+++ b/tests/ui/project/ambiguous-let.stderr
@@ -1,5 +1,5 @@
 error: Both initializer expression and pattern are replaceable, you need to split the initializer expression into separate let bindings to avoid ambiguity
-  --> $DIR/ambiguous-let.rs:16:9
+  --> $DIR/ambiguous-let.rs:18:9
    |
-16 |     let Struct(x) = match Pin::new(&mut foo).project() {
+18 |     let Struct(x) = match Pin::new(&mut foo).project() {
    |         ^^^^^^^^^

--- a/tests/ui/project/deprecated.rs
+++ b/tests/ui/project/deprecated.rs
@@ -1,0 +1,8 @@
+#![deny(deprecated)]
+
+use pin_project::{project, project_ref, project_replace};
+
+#[project]
+#[project_ref]
+#[project_replace]
+fn main() {}

--- a/tests/ui/project/deprecated.stderr
+++ b/tests/ui/project/deprecated.stderr
@@ -1,0 +1,23 @@
+error: use of deprecated item 'project': consider naming projected type by passing `project` argument to #[pin_project] attribute instead, see release note <https://github.com/taiki-e/pin-project/releases/tag/v0.4.21> for details
+ --> $DIR/deprecated.rs:5:3
+  |
+5 | #[project]
+  |   ^^^^^^^
+  |
+note: the lint level is defined here
+ --> $DIR/deprecated.rs:1:9
+  |
+1 | #![deny(deprecated)]
+  |         ^^^^^^^^^^
+
+error: use of deprecated item 'project_ref': consider naming projected type by passing `project_ref` argument to #[pin_project] attribute instead, see release note <https://github.com/taiki-e/pin-project/releases/tag/v0.4.21> for details
+ --> $DIR/deprecated.rs:6:3
+  |
+6 | #[project_ref]
+  |   ^^^^^^^^^^^
+
+error: use of deprecated item 'project_replace': consider naming projected type by passing `project_replace` argument to #[pin_project] attribute instead, see release note <https://github.com/taiki-e/pin-project/releases/tag/v0.4.21> for details
+ --> $DIR/deprecated.rs:7:3
+  |
+7 | #[project_replace]
+  |   ^^^^^^^^^^^^^^^

--- a/tests/ui/project/invalid.rs
+++ b/tests/ui/project/invalid.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 mod argument {
     use pin_project::{pin_project, project};
 

--- a/tests/ui/project/invalid.stderr
+++ b/tests/ui/project/invalid.stderr
@@ -1,155 +1,155 @@
 error: unexpected token: ()
-  --> $DIR/invalid.rs:10:18
+  --> $DIR/invalid.rs:12:18
    |
-10 |         #[project()] //~ ERROR unexpected token
+12 |         #[project()] //~ ERROR unexpected token
    |                  ^^
 
 error: unexpected token: (foo)
-  --> $DIR/invalid.rs:17:18
+  --> $DIR/invalid.rs:19:18
    |
-17 |         #[project(foo)] //~ ERROR unexpected token
+19 |         #[project(foo)] //~ ERROR unexpected token
    |                  ^^^^^
 
 error: unexpected token: ()
-  --> $DIR/invalid.rs:24:18
+  --> $DIR/invalid.rs:26:18
    |
-24 |         #[project()] //~ ERROR unexpected token
+26 |         #[project()] //~ ERROR unexpected token
    |                  ^^
 
 error: unexpected token: (foo)
-  --> $DIR/invalid.rs:33:18
+  --> $DIR/invalid.rs:35:18
    |
-33 |         #[project(foo)] //~ ERROR unexpected token
+35 |         #[project(foo)] //~ ERROR unexpected token
    |                  ^^^^^
 
 error: unexpected token: foo
-  --> $DIR/invalid.rs:42:15
+  --> $DIR/invalid.rs:44:15
    |
-42 |     #[project(foo)] //~ ERROR unexpected token
+44 |     #[project(foo)] //~ ERROR unexpected token
    |               ^^^
 
 error: duplicate #[project] attribute
-  --> $DIR/invalid.rs:56:9
+  --> $DIR/invalid.rs:58:9
    |
-56 |         #[project] //~ ERROR duplicate #[project] attribute
+58 |         #[project] //~ ERROR duplicate #[project] attribute
    |         ^^^^^^^^^^
 
 error: duplicate #[project_ref] attribute
-  --> $DIR/invalid.rs:64:9
+  --> $DIR/invalid.rs:66:9
    |
-64 |         #[project_ref] //~ ERROR duplicate #[project_ref] attribute
+66 |         #[project_ref] //~ ERROR duplicate #[project_ref] attribute
    |         ^^^^^^^^^^^^^^
 
 error: duplicate #[project_replace] attribute
-  --> $DIR/invalid.rs:72:9
+  --> $DIR/invalid.rs:74:9
    |
-72 |         #[project_replace] //~ ERROR duplicate #[project_replace] attribute
+74 |         #[project_replace] //~ ERROR duplicate #[project_replace] attribute
    |         ^^^^^^^^^^^^^^^^^^
 
 error: attributes `project` and `project_ref` are mutually exclusive
-  --> $DIR/invalid.rs:80:9
+  --> $DIR/invalid.rs:82:9
    |
-80 |         #[project_ref] //~ ERROR are mutually exclusive
+82 |         #[project_ref] //~ ERROR are mutually exclusive
    |         ^^^^^^^^^^^^^^
 
 error: attributes `project` and `project_replace` are mutually exclusive
-  --> $DIR/invalid.rs:88:9
+  --> $DIR/invalid.rs:90:9
    |
-88 |         #[project_replace] //~ ERROR are mutually exclusive
+90 |         #[project_replace] //~ ERROR are mutually exclusive
    |         ^^^^^^^^^^^^^^^^^^
 
 error: attributes `project_ref` and `project_replace` are mutually exclusive
-  --> $DIR/invalid.rs:96:9
+  --> $DIR/invalid.rs:98:9
    |
-96 |         #[project_replace] //~ ERROR are mutually exclusive
+98 |         #[project_replace] //~ ERROR are mutually exclusive
    |         ^^^^^^^^^^^^^^^^^^
 
 error: attributes `project` and `project_ref` are mutually exclusive
-   --> $DIR/invalid.rs:104:9
+   --> $DIR/invalid.rs:106:9
     |
-104 |         #[project_ref] //~ ERROR are mutually exclusive
+106 |         #[project_ref] //~ ERROR are mutually exclusive
     |         ^^^^^^^^^^^^^^
 
 error: attributes `project` and `project_replace` are mutually exclusive
-   --> $DIR/invalid.rs:112:9
+   --> $DIR/invalid.rs:114:9
     |
-112 |         #[project_replace] //~ ERROR are mutually exclusive
+114 |         #[project_replace] //~ ERROR are mutually exclusive
     |         ^^^^^^^^^^^^^^^^^^
 
 error: attributes `project_ref` and `project_replace` are mutually exclusive
-   --> $DIR/invalid.rs:120:9
+   --> $DIR/invalid.rs:122:9
     |
-120 |         #[project_replace] //~ ERROR are mutually exclusive
+122 |         #[project_replace] //~ ERROR are mutually exclusive
     |         ^^^^^^^^^^^^^^^^^^
 
 error: attributes `project` and `project_ref` are mutually exclusive
-   --> $DIR/invalid.rs:128:9
+   --> $DIR/invalid.rs:130:9
     |
-128 |         #[project_ref] //~ ERROR are mutually exclusive
+130 |         #[project_ref] //~ ERROR are mutually exclusive
     |         ^^^^^^^^^^^^^^
 
 error: attributes `project` and `project_replace` are mutually exclusive
-   --> $DIR/invalid.rs:136:9
+   --> $DIR/invalid.rs:138:9
     |
-136 |         #[project_replace] //~ ERROR are mutually exclusive
+138 |         #[project_replace] //~ ERROR are mutually exclusive
     |         ^^^^^^^^^^^^^^^^^^
 
 error: attributes `project_ref` and `project_replace` are mutually exclusive
-   --> $DIR/invalid.rs:144:9
+   --> $DIR/invalid.rs:146:9
     |
-144 |         #[project_replace] //~ ERROR are mutually exclusive
+146 |         #[project_replace] //~ ERROR are mutually exclusive
     |         ^^^^^^^^^^^^^^^^^^
 
 error: duplicate #[project] attribute
-   --> $DIR/invalid.rs:149:5
+   --> $DIR/invalid.rs:151:5
     |
-149 |     #[project] //~ ERROR duplicate #[project] attribute
+151 |     #[project] //~ ERROR duplicate #[project] attribute
     |     ^^^^^^^^^^
 
 error: duplicate #[project_ref] attribute
-   --> $DIR/invalid.rs:153:5
+   --> $DIR/invalid.rs:155:5
     |
-153 |     #[project_ref] //~ ERROR duplicate #[project_ref] attribute
+155 |     #[project_ref] //~ ERROR duplicate #[project_ref] attribute
     |     ^^^^^^^^^^^^^^
 
 error: duplicate #[project_replace] attribute
-   --> $DIR/invalid.rs:157:5
+   --> $DIR/invalid.rs:159:5
     |
-157 |     #[project_replace] //~ ERROR duplicate #[project_replace] attribute
+159 |     #[project_replace] //~ ERROR duplicate #[project_replace] attribute
     |     ^^^^^^^^^^^^^^^^^^
 
 error: duplicate #[project] attribute
-   --> $DIR/invalid.rs:161:5
+   --> $DIR/invalid.rs:163:5
     |
-161 |     #[project] //~ ERROR duplicate #[project] attribute
+163 |     #[project] //~ ERROR duplicate #[project] attribute
     |     ^^^^^^^^^^
 
 error: duplicate #[project_ref] attribute
-   --> $DIR/invalid.rs:165:5
+   --> $DIR/invalid.rs:167:5
     |
-165 |     #[project_ref] //~ ERROR duplicate #[project_ref] attribute
+167 |     #[project_ref] //~ ERROR duplicate #[project_ref] attribute
     |     ^^^^^^^^^^^^^^
 
 error: duplicate #[project_replace] attribute
-   --> $DIR/invalid.rs:169:5
+   --> $DIR/invalid.rs:171:5
     |
-169 |     #[project_replace] //~ ERROR duplicate #[project_replace] attribute
+171 |     #[project_replace] //~ ERROR duplicate #[project_replace] attribute
     |     ^^^^^^^^^^^^^^^^^^
 
 error: duplicate #[project] attribute
-   --> $DIR/invalid.rs:177:9
+   --> $DIR/invalid.rs:179:9
     |
-177 |         #[project] //~ ERROR duplicate #[project] attribute
+179 |         #[project] //~ ERROR duplicate #[project] attribute
     |         ^^^^^^^^^^
 
 error: duplicate #[project_ref] attribute
-   --> $DIR/invalid.rs:181:9
+   --> $DIR/invalid.rs:183:9
     |
-181 |         #[project_ref] //~ ERROR duplicate #[project_ref] attribute
+183 |         #[project_ref] //~ ERROR duplicate #[project_ref] attribute
     |         ^^^^^^^^^^^^^^
 
 error: duplicate #[project_replace] attribute
-   --> $DIR/invalid.rs:185:9
+   --> $DIR/invalid.rs:187:9
     |
-185 |         #[project_replace] //~ ERROR duplicate #[project_replace] attribute
+187 |         #[project_replace] //~ ERROR duplicate #[project_replace] attribute
     |         ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/project/type-mismatch.rs
+++ b/tests/ui/project/type-mismatch.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 #![feature(proc_macro_hygiene, stmt_expr_attributes)]
 
 use pin_project::{pin_project, project};

--- a/tests/ui/project/type-mismatch.stderr
+++ b/tests/ui/project/type-mismatch.stderr
@@ -1,22 +1,22 @@
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:35:9
+  --> $DIR/type-mismatch.rs:36:9
    |
-23 |     match &mut foo {
+24 |     match &mut foo {
    |           -------- this expression has type `&mut type_mismatch::__EnumProjection<'_, {integer}, {integer}, _, _>`
 ...
-35 |         None => {} //~ ERROR mismatched types
+36 |         None => {} //~ ERROR mismatched types
    |         ^^^^ expected enum `type_mismatch::__EnumProjection`, found enum `std::option::Option`
    |
    = note: expected enum `type_mismatch::__EnumProjection<'_, {integer}, {integer}, _, _>`
               found enum `std::option::Option<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:67:9
+  --> $DIR/type-mismatch.rs:68:9
    |
-55 |     match &mut foo {
+56 |     match &mut foo {
    |           -------- this expression has type `&mut type_mismatch_span_issue::__EnumProjection<'_, {integer}, {integer}, _, _>`
 ...
-67 |         None => {} //~ ERROR mismatched types
+68 |         None => {} //~ ERROR mismatched types
    |         ^^^^ expected enum `type_mismatch_span_issue::__EnumProjection`, found enum `std::option::Option`
    |
    = note: expected enum `type_mismatch_span_issue::__EnumProjection<'_, {integer}, {integer}, _, _>`

--- a/tests/ui/project/use-public.rs
+++ b/tests/ui/project/use-public.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use pin_project::pin_project;
 
 #[pin_project]

--- a/tests/ui/project/use-public.stderr
+++ b/tests/ui/project/use-public.stderr
@@ -1,7 +1,7 @@
 error[E0365]: `__AProjection` is private, and cannot be re-exported
-  --> $DIR/use-public.rs:12:13
+  --> $DIR/use-public.rs:14:13
    |
-12 |     pub use crate::A; //~ ERROR E0365
+14 |     pub use crate::A; //~ ERROR E0365
    |             ^^^^^^^^ re-export of private `__AProjection`
    |
    = note: consider declaring type or module `__AProjection` with `pub`

--- a/tests/ui/project/use.rs
+++ b/tests/ui/project/use.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use pin_project::pin_project;
 
 #[pin_project]

--- a/tests/ui/project/use.stderr
+++ b/tests/ui/project/use.stderr
@@ -1,11 +1,11 @@
 error: #[project] attribute may not be used on renamed imports
-  --> $DIR/use.rs:12:16
+  --> $DIR/use.rs:14:16
    |
-12 |     use crate::A as B; //~ ERROR #[project] attribute may not be used on renamed imports
+14 |     use crate::A as B; //~ ERROR #[project] attribute may not be used on renamed imports
    |                ^^^^^^
 
 error: #[project] attribute may not be used on glob imports
-  --> $DIR/use.rs:14:16
+  --> $DIR/use.rs:16:16
    |
-14 |     use crate::*; //~ ERROR #[project] attribute may not be used on glob imports
+16 |     use crate::*; //~ ERROR #[project] attribute may not be used on glob imports
    |                ^

--- a/tests/ui/unstable-features/run-pass/stmt_expr_attributes.rs
+++ b/tests/ui/unstable-features/run-pass/stmt_expr_attributes.rs
@@ -1,5 +1,6 @@
 // NB: If you change this test, change 'stmt_expr_attributes-feature-gate.rs' at the same time.
 
+#![allow(deprecated)]
 // proc_macro_hygiene
 // Tracking issue: https://github.com/rust-lang/rust/issues/54727
 #![feature(proc_macro_hygiene)]

--- a/tests/ui/unstable-features/stmt_expr_attributes-feature-gate.rs
+++ b/tests/ui/unstable-features/stmt_expr_attributes-feature-gate.rs
@@ -1,5 +1,7 @@
 // NB: If you change this test, change 'stmt_expr_attributes.rs' at the same time.
 
+#![allow(deprecated)]
+
 use pin_project::{pin_project, project};
 use std::pin::Pin;
 

--- a/tests/ui/unstable-features/stmt_expr_attributes-feature-gate.stderr
+++ b/tests/ui/unstable-features/stmt_expr_attributes-feature-gate.stderr
@@ -1,34 +1,34 @@
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/stmt_expr_attributes-feature-gate.rs:22:5
+  --> $DIR/stmt_expr_attributes-feature-gate.rs:24:5
    |
-22 |     #[project] //~ ERROR E0658
+24 |     #[project] //~ ERROR E0658
    |     ^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/stmt_expr_attributes-feature-gate.rs:38:14
+  --> $DIR/stmt_expr_attributes-feature-gate.rs:40:14
    |
-38 |     let () = #[project] //~ ERROR E0658
+40 |     let () = #[project] //~ ERROR E0658
    |              ^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: custom attributes cannot be applied to expressions
-  --> $DIR/stmt_expr_attributes-feature-gate.rs:22:5
+  --> $DIR/stmt_expr_attributes-feature-gate.rs:24:5
    |
-22 |     #[project] //~ ERROR E0658
+24 |     #[project] //~ ERROR E0658
    |     ^^^^^^^^^^
    |
    = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: custom attributes cannot be applied to expressions
-  --> $DIR/stmt_expr_attributes-feature-gate.rs:38:14
+  --> $DIR/stmt_expr_attributes-feature-gate.rs:40:14
    |
-38 |     let () = #[project] //~ ERROR E0658
+40 |     let () = #[project] //~ ERROR E0658
    |              ^^^^^^^^^^
    |
    = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information


### PR DESCRIPTION
This deprecates `#[project]`, `#[project_ref]`, and `#[project_replace]` attributes in favor of the naming of projected type.

Closes #225
