### PR TITLE
Propagate the span of Self keyword to QSelf

### DIFF
--- a/pin-project-internal/src/utils.rs
+++ b/pin-project-internal/src/utils.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Group, Spacing, Span, TokenStream, TokenTree};
-use quote::{format_ident, quote, ToTokens};
+use quote::{format_ident, quote, quote_spanned, ToTokens};
 use std::{iter::FromIterator, mem};
 use syn::{
     parse::{Parse, ParseBuffer, ParseStream},
@@ -227,12 +227,13 @@ impl ReplaceReceiver<'_> {
             return;
         }
 
+        let span = first.ident.span();
         *qself = Some(QSelf {
-            lt_token: token::Lt::default(),
-            ty: Box::new(self.self_ty(first.ident.span()).into()),
+            lt_token: token::Lt(span),
+            ty: Box::new(self.self_ty(span).into()),
             position: 0,
             as_token: None,
-            gt_token: token::Gt::default(),
+            gt_token: token::Gt(span),
         });
 
         path.leading_colon = Some(**path.segments.pairs().next().unwrap().punct().unwrap());
@@ -284,7 +285,8 @@ impl ReplaceReceiver<'_> {
                                 let next = iter.next().unwrap();
                                 match iter.peek() {
                                     Some(TokenTree::Punct(p)) if p.as_char() == ':' => {
-                                        out.extend(quote!(<#self_ty>))
+                                        let span = ident.span();
+                                        out.extend(quote_spanned!(span=> <#self_ty>))
                                     }
                                     _ => out.extend(quote!(#self_ty)),
                                 }

--- a/tests/ui/pinned_drop/self.rs
+++ b/tests/ui/pinned_drop/self.rs
@@ -38,6 +38,19 @@ pub mod self_span {
             let _: Self = Self; //~ ERROR E0423
         }
     }
+
+    #[pin_project(PinnedDrop)]
+    pub enum E {
+        V { x: () },
+    }
+
+    #[pinned_drop]
+    impl PinnedDrop for E {
+        fn drop(self: Pin<&mut Self>) {
+            let _: () = self; //~ ERROR E0308
+            let _: Self = Self::V; //~ ERROR E0533
+        }
+    }
 }
 
 fn main() {}

--- a/tests/ui/pinned_drop/self.stderr
+++ b/tests/ui/pinned_drop/self.stderr
@@ -43,3 +43,20 @@ error[E0308]: mismatched types
    |
    = note: expected unit type `()`
                  found struct `std::pin::Pin<&mut self_span::S>`
+
+error[E0308]: mismatched types
+  --> $DIR/self.rs:50:25
+   |
+50 |             let _: () = self; //~ ERROR E0308
+   |                    --   ^^^^ expected `()`, found struct `std::pin::Pin`
+   |                    |
+   |                    expected due to this
+   |
+   = note: expected unit type `()`
+                 found struct `std::pin::Pin<&mut self_span::E>`
+
+error[E0533]: expected unit struct, unit variant or constant, found struct variant `Self::V`
+  --> $DIR/self.rs:51:27
+   |
+51 |             let _: Self = Self::V; //~ ERROR E0533
+   |                           ^^^^^^^


### PR DESCRIPTION
A similar case to #235.

The following code:

```rust
use pin_project::{pin_project, pinned_drop};
use std::pin::Pin;

#[pin_project(PinnedDrop)]
pub enum E {
    V { x : () }
}

#[pinned_drop]
impl PinnedDrop for Struct {
    fn drop(self: Pin<&mut Self>) {
        let _: Self = Self::V;
    }
}
```

The error message points to call-site span:

```text
error[E0533]: expected unit struct, unit variant or constant, found struct variant `#[pinned_drop]`
  --> $DIR/self.rs:47:5
   |
47 |     #[pinned_drop]
   |     ^^^^^^^^^^^^^^
   |
```

This PR fixes span of `<` and `>` tokens of `QSelf` to make the error message to point to the correct span:

```text
error[E0533]: expected unit struct, unit variant or constant, found struct variant `Self::V`
  --> $DIR/self.rs:51:27
   |
51 |             let _: Self = Self::V;
   |                           ^^^^^^^
```