### PR TITLE
Use Token macro instead of concrete token type names

### DIFF
--- a/pin-project-internal/src/pin_project/attribute.rs
+++ b/pin-project-internal/src/pin_project/attribute.rs
@@ -47,7 +47,7 @@ impl Parse for Input {
 
         let ahead = input.fork();
         let _: Visibility = ahead.parse()?;
-        if !ahead.peek(token::Struct) && !ahead.peek(token::Enum) {
+        if !ahead.peek(Token![struct]) && !ahead.peek(Token![enum]) {
             // If we check this only on proc-macro-derive, it may generate unhelpful error
             // messages. So it is preferable to be able to detect it here.
             Err(error!(

--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -223,7 +223,7 @@ impl Parse for Args {
             if input.is_empty() {
                 return Err(error!(name, "expected `{0} = <identifier>`, found `{0}`", name));
             }
-            let eq_token: token::Eq = input.parse()?;
+            let eq_token: Token![=] = input.parse()?;
             if input.is_empty() {
                 let span = quote!(#name #eq_token);
                 return Err(error!(span, "expected `{0} = <identifier>`, found `{0} =`", name));
@@ -248,8 +248,8 @@ impl Parse for Args {
         let mut project_replace_span = None;
 
         while !input.is_empty() {
-            if input.peek(token::Bang) {
-                let bang: token::Bang = input.parse()?;
+            if input.peek(Token![!]) {
+                let bang: Token![!] = input.parse()?;
                 if input.is_empty() {
                     return Err(error!(bang, "expected `!Unpin`, found `!`"));
                 }
@@ -278,7 +278,7 @@ impl Parse for Args {
                         project_ref = Some(parse_value(input, &token, project_ref.is_some())?.0);
                     }
                     "project_replace" => {
-                        if input.peek(token::Eq) {
+                        if input.peek(Token![=]) {
                             let (value, span) =
                                 parse_value(input, &token, project_replace_span.is_some())?;
                             project_replace_value = Some(value);
@@ -301,7 +301,7 @@ impl Parse for Args {
             if input.is_empty() {
                 break;
             }
-            let _: token::Comma = input.parse()?;
+            let _: Token![,] = input.parse()?;
         }
 
         if project.is_some() || project_ref.is_some() {
@@ -887,7 +887,7 @@ impl<'a> Context<'a> {
 
                 // For interoperability with `forbid(unsafe_code)`, `unsafe` token should be
                 // call-site span.
-                let unsafety = token::Unsafe::default();
+                let unsafety = <Token![unsafe]>::default();
                 quote_spanned! { span =>
                     impl #proj_impl_generics ::pin_project::__private::Unpin
                         for #orig_ident #ty_generics
@@ -1011,7 +1011,7 @@ impl<'a> Context<'a> {
         if let Some(span) = self.pinned_drop {
             // For interoperability with `forbid(unsafe_code)`, `unsafe` token should be
             // call-site span.
-            let unsafety = token::Unsafe::default();
+            let unsafety = <Token![unsafe]>::default();
             quote_spanned! { span =>
                 impl #impl_generics ::pin_project::__private::Drop for #ident #ty_generics
                 #where_clause
@@ -1101,7 +1101,7 @@ impl<'a> Context<'a> {
         let replace_impl = self.project_replace.span().map(|span| {
             // For interoperability with `forbid(unsafe_code)`, `unsafe` token should be
             // call-site span.
-            let unsafety = token::Unsafe::default();
+            let unsafety = <Token![unsafe]>::default();
             quote_spanned! { span =>
                 #vis fn project_replace(
                     self: ::pin_project::__private::Pin<&mut Self>,

--- a/pin-project-internal/src/pinned_drop.rs
+++ b/pin-project-internal/src/pinned_drop.rs
@@ -193,7 +193,7 @@ fn expand_item(item: &mut ItemImpl) {
     visitor.visit_block_mut(&mut drop_inner.block);
 
     // `fn drop(mut self: Pin<&mut Self>)` -> `unsafe fn drop(self: Pin<&mut Self>)`
-    method.sig.unsafety = Some(token::Unsafe::default());
+    method.sig.unsafety = Some(<Token![unsafe]>::default());
     let mut self_token = None;
     if let FnArg::Typed(arg) = &mut method.sig.inputs[0] {
         if let Pat::Ident(ident) = &mut *arg.pat {

--- a/pin-project-internal/src/utils.rs
+++ b/pin-project-internal/src/utils.rs
@@ -8,7 +8,7 @@ use syn::{
     *,
 };
 
-pub(crate) type Variants = Punctuated<Variant, token::Comma>;
+pub(crate) type Variants = Punctuated<Variant, Token![,]>;
 
 macro_rules! error {
     ($span:expr, $msg:expr) => {
@@ -94,15 +94,15 @@ pub(crate) fn insert_lifetime_and_bound(
     WherePredicate::Type(PredicateType {
         lifetimes: None,
         bounded_ty: orig_type,
-        colon_token: token::Colon::default(),
+        colon_token: <Token![:]>::default(),
         bounds: punct,
     })
 }
 
 /// Inserts a `lifetime` at position `0` of `generics.params`.
 pub(crate) fn insert_lifetime(generics: &mut Generics, lifetime: Lifetime) {
-    generics.lt_token.get_or_insert_with(token::Lt::default);
-    generics.gt_token.get_or_insert_with(token::Gt::default);
+    generics.lt_token.get_or_insert_with(<Token![<]>::default);
+    generics.gt_token.get_or_insert_with(<Token![>]>::default);
     generics.params.insert(0, LifetimeDef::new(lifetime).into());
 }
 
@@ -203,7 +203,7 @@ impl<'a> ParseBufferExt<'a> for ParseBuffer<'a> {
 // visitors
 
 // Replace `self`/`Self` with `__self`/`self_ty`.
-// Based on https://github.com/dtolnay/async-trait/blob/0.1.33/src/receiver.rs
+// Based on https://github.com/dtolnay/async-trait/blob/0.1.35/src/receiver.rs
 
 pub(crate) struct ReplaceReceiver<'a>(pub(crate) &'a TypePath);
 
@@ -229,11 +229,11 @@ impl ReplaceReceiver<'_> {
 
         let span = first.ident.span();
         *qself = Some(QSelf {
-            lt_token: token::Lt(span),
+            lt_token: Token![<](span),
             ty: Box::new(self.self_ty(span).into()),
             position: 0,
             as_token: None,
-            gt_token: token::Gt(span),
+            gt_token: Token![>](span),
         });
 
         path.leading_colon = Some(**path.segments.pairs().next().unwrap().punct().unwrap());
@@ -257,12 +257,12 @@ impl ReplaceReceiver<'_> {
         for segment in &mut path.segments {
             if let PathArguments::AngleBracketed(bracketed) = &mut segment.arguments {
                 if bracketed.colon2_token.is_none() && !bracketed.args.is_empty() {
-                    bracketed.colon2_token = Some(token::Colon2::default());
+                    bracketed.colon2_token = Some(<Token![::]>::default());
                 }
             }
         }
         if variant.segments.len() > 1 {
-            path.segments.push_punct(token::Colon2::default());
+            path.segments.push_punct(<Token![::]>::default());
             path.segments.extend(variant.segments.into_pairs().skip(1));
         }
     }

--- a/tests/ui/auxiliary/lib.rs
+++ b/tests/ui/auxiliary/lib.rs
@@ -3,7 +3,7 @@
 
 use proc_macro::TokenStream;
 use quote::{format_ident, ToTokens};
-use syn::{parse_quote, token, Field, Fields, ItemStruct, Visibility};
+use syn::{parse_quote, Field, Fields, ItemStruct, Token, Visibility};
 
 #[proc_macro_attribute]
 pub fn hidden_repr(args: TokenStream, input: TokenStream) -> TokenStream {
@@ -28,7 +28,7 @@ pub fn add_pinned_field(_: TokenStream, input: TokenStream) -> TokenStream {
         attrs: vec![parse_quote!(#[pin])],
         vis: Visibility::Inherited,
         ident: Some(format_ident!("__field")),
-        colon_token: Some(token::Colon::default()),
+        colon_token: Some(<Token![:]>::default()),
         ty: parse_quote!(::std::marker::PhantomPinned),
     });
 


### PR DESCRIPTION
https://docs.rs/syn/1.0.31/syn/token/index.html
> The type names in this module can be difficult to keep straight, so we prefer to use the `Token!` macro instead. This is a type-macro that expands to the token type of the given token.

