### PR TITLE
Replace Option::as_ref().cloned() with Option::clone()

### DIFF
--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -909,8 +909,7 @@ impl<'a> Context<'a> {
                 }
             }
             UnpinImpl::Default => {
-                let mut full_where_clause =
-                    self.orig.generics.where_clause.as_ref().cloned().unwrap();
+                let mut full_where_clause = self.orig.generics.where_clause.clone().unwrap();
 
                 // Generate a field in our new struct for every
                 // pinned field in the original type.


### PR DESCRIPTION
`as_ref().cloned()` is redundant: https://doc.rust-lang.org/1.44.1/src/core/option.rs.html#1276-1292