### PR TITLE
Do not expose unnamed projected types

### DIFF
--- a/examples/enum-default-expanded.rs
+++ b/examples/enum-default-expanded.rs
@@ -35,23 +35,23 @@ where
     Pinned(::pin_project::__private::Pin<&'pin mut (T)>),
     Unpinned(&'pin mut (U)),
 }
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-enum __EnumProjectionRef<'pin, T, U>
-where
-    Enum<T, U>: 'pin,
-{
-    Pinned(::pin_project::__private::Pin<&'pin (T)>),
-    Unpinned(&'pin (U)),
-}
 
 #[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    enum __EnumProjectionRef<'pin, T, U>
+    where
+        Enum<T, U>: 'pin,
+    {
+        Pinned(::pin_project::__private::Pin<&'pin (T)>),
+        Unpinned(&'pin (U)),
+    }
+
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/examples/not_unpin-expanded.rs
+++ b/examples/not_unpin-expanded.rs
@@ -30,34 +30,32 @@ pub struct Struct<T, U> {
 }
 
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-pub(crate) struct __StructProjection<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-    unpinned: &'pin mut (U),
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-pub(crate) struct __StructProjectionRef<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin (T)>,
-    unpinned: &'pin (U),
-}
-
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    pub(crate) struct __StructProjection<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned: &'pin mut (U),
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    pub(crate) struct __StructProjectionRef<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin (T)>,
+        unpinned: &'pin (U),
+    }
+
     impl<T, U> Struct<T, U> {
         pub(crate) fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/examples/pinned_drop-expanded.rs
+++ b/examples/pinned_drop-expanded.rs
@@ -34,34 +34,32 @@ pub struct Struct<'a, T> {
 }
 
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-pub(crate) struct __StructProjection<'pin, 'a, T>
-where
-    Struct<'a, T>: 'pin,
-{
-    was_dropped: &'pin mut (&'a mut bool),
-    field: ::pin_project::__private::Pin<&'pin mut (T)>,
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-pub(crate) struct __StructProjectionRef<'pin, 'a, T>
-where
-    Struct<'a, T>: 'pin,
-{
-    was_dropped: &'pin (&'a mut bool),
-    field: ::pin_project::__private::Pin<&'pin (T)>,
-}
-
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    pub(crate) struct __StructProjection<'pin, 'a, T>
+    where
+        Struct<'a, T>: 'pin,
+    {
+        was_dropped: &'pin mut (&'a mut bool),
+        field: ::pin_project::__private::Pin<&'pin mut (T)>,
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    pub(crate) struct __StructProjectionRef<'pin, 'a, T>
+    where
+        Struct<'a, T>: 'pin,
+    {
+        was_dropped: &'pin (&'a mut bool),
+        field: ::pin_project::__private::Pin<&'pin (T)>,
+    }
+
     impl<'a, T> Struct<'a, T> {
         pub(crate) fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/examples/project_replace-expanded.rs
+++ b/examples/project_replace-expanded.rs
@@ -27,42 +27,39 @@ struct Struct<T, U> {
 }
 
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __StructProjection<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-    unpinned: &'pin mut (U),
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __StructProjectionRef<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin (T)>,
-    unpinned: &'pin (U),
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(unreachable_pub)]
-#[allow(single_use_lifetimes)]
-struct __StructProjectionOwned<T, U> {
-    pinned: ::pin_project::__private::PhantomData<T>,
-    unpinned: U,
-}
-
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __StructProjection<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned: &'pin mut (U),
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __StructProjectionRef<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin (T)>,
+        unpinned: &'pin (U),
+    }
+    #[allow(dead_code)]
+    #[allow(unreachable_pub)]
+    #[allow(single_use_lifetimes)]
+    struct __StructProjectionOwned<T, U> {
+        pinned: ::pin_project::__private::PhantomData<T>,
+        unpinned: U,
+    }
+
     impl<T, U> Struct<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/examples/struct-default-expanded.rs
+++ b/examples/struct-default-expanded.rs
@@ -27,34 +27,32 @@ struct Struct<T, U> {
 }
 
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __StructProjection<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-    unpinned: &'pin mut (U),
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __StructProjectionRef<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin (T)>,
-    unpinned: &'pin (U),
-}
-
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __StructProjection<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned: &'pin mut (U),
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __StructProjectionRef<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin (T)>,
+        unpinned: &'pin (U),
+    }
+
     impl<T, U> Struct<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/examples/unsafe_unpin-expanded.rs
+++ b/examples/unsafe_unpin-expanded.rs
@@ -29,34 +29,32 @@ pub struct Struct<T, U> {
 }
 
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-pub(crate) struct __StructProjection<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-    unpinned: &'pin mut (U),
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-pub(crate) struct __StructProjectionRef<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin (T)>,
-    unpinned: &'pin (U),
-}
-
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    pub(crate) struct __StructProjection<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned: &'pin mut (U),
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    pub(crate) struct __StructProjectionRef<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin (T)>,
+        unpinned: &'pin (U),
+    }
+
     impl<T, U> Struct<T, U> {
         pub(crate) fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/default-enum.expanded.rs
+++ b/tests/expand/tests/expand/default-enum.expanded.rs
@@ -10,41 +10,39 @@ enum Enum<T, U> {
     Unit,
 }
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-enum __EnumProjection<'pin, T, U>
-where
-    Enum<T, U>: 'pin,
-{
-    Struct {
-        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-        unpinned: &'pin mut (U),
-    },
-    Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
-    Unit,
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-enum __EnumProjectionRef<'pin, T, U>
-where
-    Enum<T, U>: 'pin,
-{
-    Struct {
-        pinned: ::pin_project::__private::Pin<&'pin (T)>,
-        unpinned: &'pin (U),
-    },
-    Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
-    Unit,
-}
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    enum __EnumProjection<'pin, T, U>
+    where
+        Enum<T, U>: 'pin,
+    {
+        Struct {
+            pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+            unpinned: &'pin mut (U),
+        },
+        Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
+        Unit,
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    enum __EnumProjectionRef<'pin, T, U>
+    where
+        Enum<T, U>: 'pin,
+    {
+        Struct {
+            pinned: ::pin_project::__private::Pin<&'pin (T)>,
+            unpinned: &'pin (U),
+        },
+        Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
+        Unit,
+    }
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/default-struct.expanded.rs
+++ b/tests/expand/tests/expand/default-struct.expanded.rs
@@ -6,33 +6,31 @@ struct Struct<T, U> {
     unpinned: U,
 }
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __StructProjection<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-    unpinned: &'pin mut (U),
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __StructProjectionRef<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin (T)>,
-    unpinned: &'pin (U),
-}
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __StructProjection<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned: &'pin mut (U),
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __StructProjectionRef<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin (T)>,
+        unpinned: &'pin (U),
+    }
     impl<T, U> Struct<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/default-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/default-tuple_struct.expanded.rs
@@ -2,28 +2,29 @@ use pin_project::pin_project;
 #[pin(__private())]
 struct TupleStruct<T, U>(#[pin] T, U);
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __TupleStructProjection<'pin, T, U>(
-    ::pin_project::__private::Pin<&'pin mut (T)>,
-    &'pin mut (U),
-)
-where
-    TupleStruct<T, U>: 'pin;
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __TupleStructProjectionRef<'pin, T, U>(::pin_project::__private::Pin<&'pin (T)>, &'pin (U))
-where
-    TupleStruct<T, U>: 'pin;
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __TupleStructProjection<'pin, T, U>(
+        ::pin_project::__private::Pin<&'pin mut (T)>,
+        &'pin mut (U),
+    )
+    where
+        TupleStruct<T, U>: 'pin;
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __TupleStructProjectionRef<'pin, T, U>(
+        ::pin_project::__private::Pin<&'pin (T)>,
+        &'pin (U),
+    )
+    where
+        TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/not_unpin-enum.expanded.rs
+++ b/tests/expand/tests/expand/not_unpin-enum.expanded.rs
@@ -10,41 +10,39 @@ enum Enum<T, U> {
     Unit,
 }
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-enum __EnumProjection<'pin, T, U>
-where
-    Enum<T, U>: 'pin,
-{
-    Struct {
-        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-        unpinned: &'pin mut (U),
-    },
-    Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
-    Unit,
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-enum __EnumProjectionRef<'pin, T, U>
-where
-    Enum<T, U>: 'pin,
-{
-    Struct {
-        pinned: ::pin_project::__private::Pin<&'pin (T)>,
-        unpinned: &'pin (U),
-    },
-    Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
-    Unit,
-}
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    enum __EnumProjection<'pin, T, U>
+    where
+        Enum<T, U>: 'pin,
+    {
+        Struct {
+            pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+            unpinned: &'pin mut (U),
+        },
+        Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
+        Unit,
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    enum __EnumProjectionRef<'pin, T, U>
+    where
+        Enum<T, U>: 'pin,
+    {
+        Struct {
+            pinned: ::pin_project::__private::Pin<&'pin (T)>,
+            unpinned: &'pin (U),
+        },
+        Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
+        Unit,
+    }
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/not_unpin-struct.expanded.rs
+++ b/tests/expand/tests/expand/not_unpin-struct.expanded.rs
@@ -6,33 +6,31 @@ struct Struct<T, U> {
     unpinned: U,
 }
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __StructProjection<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-    unpinned: &'pin mut (U),
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __StructProjectionRef<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin (T)>,
-    unpinned: &'pin (U),
-}
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __StructProjection<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned: &'pin mut (U),
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __StructProjectionRef<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin (T)>,
+        unpinned: &'pin (U),
+    }
     impl<T, U> Struct<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/not_unpin-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/not_unpin-tuple_struct.expanded.rs
@@ -2,28 +2,29 @@ use pin_project::pin_project;
 # [pin (__private (! Unpin))]
 struct TupleStruct<T, U>(#[pin] T, U);
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __TupleStructProjection<'pin, T, U>(
-    ::pin_project::__private::Pin<&'pin mut (T)>,
-    &'pin mut (U),
-)
-where
-    TupleStruct<T, U>: 'pin;
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __TupleStructProjectionRef<'pin, T, U>(::pin_project::__private::Pin<&'pin (T)>, &'pin (U))
-where
-    TupleStruct<T, U>: 'pin;
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __TupleStructProjection<'pin, T, U>(
+        ::pin_project::__private::Pin<&'pin mut (T)>,
+        &'pin mut (U),
+    )
+    where
+        TupleStruct<T, U>: 'pin;
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __TupleStructProjectionRef<'pin, T, U>(
+        ::pin_project::__private::Pin<&'pin (T)>,
+        &'pin (U),
+    )
+    where
+        TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/pinned_drop-enum.expanded.rs
+++ b/tests/expand/tests/expand/pinned_drop-enum.expanded.rs
@@ -11,41 +11,39 @@ enum Enum<T, U> {
     Unit,
 }
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-enum __EnumProjection<'pin, T, U>
-where
-    Enum<T, U>: 'pin,
-{
-    Struct {
-        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-        unpinned: &'pin mut (U),
-    },
-    Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
-    Unit,
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-enum __EnumProjectionRef<'pin, T, U>
-where
-    Enum<T, U>: 'pin,
-{
-    Struct {
-        pinned: ::pin_project::__private::Pin<&'pin (T)>,
-        unpinned: &'pin (U),
-    },
-    Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
-    Unit,
-}
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    enum __EnumProjection<'pin, T, U>
+    where
+        Enum<T, U>: 'pin,
+    {
+        Struct {
+            pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+            unpinned: &'pin mut (U),
+        },
+        Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
+        Unit,
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    enum __EnumProjectionRef<'pin, T, U>
+    where
+        Enum<T, U>: 'pin,
+    {
+        Struct {
+            pinned: ::pin_project::__private::Pin<&'pin (T)>,
+            unpinned: &'pin (U),
+        },
+        Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
+        Unit,
+    }
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/pinned_drop-struct.expanded.rs
+++ b/tests/expand/tests/expand/pinned_drop-struct.expanded.rs
@@ -7,33 +7,31 @@ struct Struct<T, U> {
     unpinned: U,
 }
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __StructProjection<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-    unpinned: &'pin mut (U),
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __StructProjectionRef<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin (T)>,
-    unpinned: &'pin (U),
-}
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __StructProjection<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned: &'pin mut (U),
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __StructProjectionRef<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin (T)>,
+        unpinned: &'pin (U),
+    }
     impl<T, U> Struct<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/pinned_drop-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/pinned_drop-tuple_struct.expanded.rs
@@ -3,28 +3,29 @@ use std::pin::Pin;
 #[pin(__private(PinnedDrop))]
 struct TupleStruct<T, U>(#[pin] T, U);
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __TupleStructProjection<'pin, T, U>(
-    ::pin_project::__private::Pin<&'pin mut (T)>,
-    &'pin mut (U),
-)
-where
-    TupleStruct<T, U>: 'pin;
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __TupleStructProjectionRef<'pin, T, U>(::pin_project::__private::Pin<&'pin (T)>, &'pin (U))
-where
-    TupleStruct<T, U>: 'pin;
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __TupleStructProjection<'pin, T, U>(
+        ::pin_project::__private::Pin<&'pin mut (T)>,
+        &'pin mut (U),
+    )
+    where
+        TupleStruct<T, U>: 'pin;
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __TupleStructProjectionRef<'pin, T, U>(
+        ::pin_project::__private::Pin<&'pin (T)>,
+        &'pin (U),
+    )
+    where
+        TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/project_replace-enum.expanded.rs
+++ b/tests/expand/tests/expand/project_replace-enum.expanded.rs
@@ -10,53 +10,50 @@ enum Enum<T, U> {
     Unit,
 }
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-enum __EnumProjection<'pin, T, U>
-where
-    Enum<T, U>: 'pin,
-{
-    Struct {
-        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-        unpinned: &'pin mut (U),
-    },
-    Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
-    Unit,
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-enum __EnumProjectionRef<'pin, T, U>
-where
-    Enum<T, U>: 'pin,
-{
-    Struct {
-        pinned: ::pin_project::__private::Pin<&'pin (T)>,
-        unpinned: &'pin (U),
-    },
-    Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
-    Unit,
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(unreachable_pub)]
-enum __EnumProjectionOwned<T, U> {
-    Struct {
-        pinned: ::pin_project::__private::PhantomData<T>,
-        unpinned: U,
-    },
-    Tuple(::pin_project::__private::PhantomData<T>, U),
-    Unit,
-}
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    enum __EnumProjection<'pin, T, U>
+    where
+        Enum<T, U>: 'pin,
+    {
+        Struct {
+            pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+            unpinned: &'pin mut (U),
+        },
+        Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
+        Unit,
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    enum __EnumProjectionRef<'pin, T, U>
+    where
+        Enum<T, U>: 'pin,
+    {
+        Struct {
+            pinned: ::pin_project::__private::Pin<&'pin (T)>,
+            unpinned: &'pin (U),
+        },
+        Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
+        Unit,
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
+    enum __EnumProjectionOwned<T, U> {
+        Struct {
+            pinned: ::pin_project::__private::PhantomData<T>,
+            unpinned: U,
+        },
+        Tuple(::pin_project::__private::PhantomData<T>, U),
+        Unit,
+    }
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/project_replace-struct.expanded.rs
+++ b/tests/expand/tests/expand/project_replace-struct.expanded.rs
@@ -6,41 +6,38 @@ struct Struct<T, U> {
     unpinned: U,
 }
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __StructProjection<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-    unpinned: &'pin mut (U),
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __StructProjectionRef<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin (T)>,
-    unpinned: &'pin (U),
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(unreachable_pub)]
-struct __StructProjectionOwned<T, U> {
-    pinned: ::pin_project::__private::PhantomData<T>,
-    unpinned: U,
-}
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __StructProjection<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned: &'pin mut (U),
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __StructProjectionRef<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin (T)>,
+        unpinned: &'pin (U),
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
+    struct __StructProjectionOwned<T, U> {
+        pinned: ::pin_project::__private::PhantomData<T>,
+        unpinned: U,
+    }
     impl<T, U> Struct<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/project_replace-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/project_replace-tuple_struct.expanded.rs
@@ -2,33 +2,33 @@ use pin_project::pin_project;
 #[pin(__private(project_replace))]
 struct TupleStruct<T, U>(#[pin] T, U);
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __TupleStructProjection<'pin, T, U>(
-    ::pin_project::__private::Pin<&'pin mut (T)>,
-    &'pin mut (U),
-)
-where
-    TupleStruct<T, U>: 'pin;
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __TupleStructProjectionRef<'pin, T, U>(::pin_project::__private::Pin<&'pin (T)>, &'pin (U))
-where
-    TupleStruct<T, U>: 'pin;
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(unreachable_pub)]
-struct __TupleStructProjectionOwned<T, U>(::pin_project::__private::PhantomData<T>, U);
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __TupleStructProjection<'pin, T, U>(
+        ::pin_project::__private::Pin<&'pin mut (T)>,
+        &'pin mut (U),
+    )
+    where
+        TupleStruct<T, U>: 'pin;
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __TupleStructProjectionRef<'pin, T, U>(
+        ::pin_project::__private::Pin<&'pin (T)>,
+        &'pin (U),
+    )
+    where
+        TupleStruct<T, U>: 'pin;
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
+    struct __TupleStructProjectionOwned<T, U>(::pin_project::__private::PhantomData<T>, U);
     impl<T, U> TupleStruct<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/pub-enum.expanded.rs
+++ b/tests/expand/tests/expand/pub-enum.expanded.rs
@@ -10,41 +10,39 @@ pub enum Enum<T, U> {
     Unit,
 }
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-pub(crate) enum __EnumProjection<'pin, T, U>
-where
-    Enum<T, U>: 'pin,
-{
-    Struct {
-        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-        unpinned: &'pin mut (U),
-    },
-    Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
-    Unit,
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-pub(crate) enum __EnumProjectionRef<'pin, T, U>
-where
-    Enum<T, U>: 'pin,
-{
-    Struct {
-        pinned: ::pin_project::__private::Pin<&'pin (T)>,
-        unpinned: &'pin (U),
-    },
-    Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
-    Unit,
-}
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    pub(crate) enum __EnumProjection<'pin, T, U>
+    where
+        Enum<T, U>: 'pin,
+    {
+        Struct {
+            pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+            unpinned: &'pin mut (U),
+        },
+        Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
+        Unit,
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    pub(crate) enum __EnumProjectionRef<'pin, T, U>
+    where
+        Enum<T, U>: 'pin,
+    {
+        Struct {
+            pinned: ::pin_project::__private::Pin<&'pin (T)>,
+            unpinned: &'pin (U),
+        },
+        Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
+        Unit,
+    }
     impl<T, U> Enum<T, U> {
         pub(crate) fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/pub-struct.expanded.rs
+++ b/tests/expand/tests/expand/pub-struct.expanded.rs
@@ -6,33 +6,31 @@ pub struct Struct<T, U> {
     pub unpinned: U,
 }
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-pub(crate) struct __StructProjection<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pub pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-    pub unpinned: &'pin mut (U),
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-pub(crate) struct __StructProjectionRef<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pub pinned: ::pin_project::__private::Pin<&'pin (T)>,
-    pub unpinned: &'pin (U),
-}
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    pub(crate) struct __StructProjection<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pub pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        pub unpinned: &'pin mut (U),
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    pub(crate) struct __StructProjectionRef<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pub pinned: ::pin_project::__private::Pin<&'pin (T)>,
+        pub unpinned: &'pin (U),
+    }
     impl<T, U> Struct<T, U> {
         pub(crate) fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/pub-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/pub-tuple_struct.expanded.rs
@@ -2,31 +2,29 @@ use pin_project::pin_project;
 #[pin(__private())]
 pub struct TupleStruct<T, U>(#[pin] pub T, pub U);
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-pub(crate) struct __TupleStructProjection<'pin, T, U>(
-    pub ::pin_project::__private::Pin<&'pin mut (T)>,
-    pub &'pin mut (U),
-)
-where
-    TupleStruct<T, U>: 'pin;
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-pub(crate) struct __TupleStructProjectionRef<'pin, T, U>(
-    pub ::pin_project::__private::Pin<&'pin (T)>,
-    pub &'pin (U),
-)
-where
-    TupleStruct<T, U>: 'pin;
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    pub(crate) struct __TupleStructProjection<'pin, T, U>(
+        pub ::pin_project::__private::Pin<&'pin mut (T)>,
+        pub &'pin mut (U),
+    )
+    where
+        TupleStruct<T, U>: 'pin;
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    pub(crate) struct __TupleStructProjectionRef<'pin, T, U>(
+        pub ::pin_project::__private::Pin<&'pin (T)>,
+        pub &'pin (U),
+    )
+    where
+        TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
         pub(crate) fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/unsafe_unpin-enum.expanded.rs
+++ b/tests/expand/tests/expand/unsafe_unpin-enum.expanded.rs
@@ -10,41 +10,39 @@ enum Enum<T, U> {
     Unit,
 }
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-enum __EnumProjection<'pin, T, U>
-where
-    Enum<T, U>: 'pin,
-{
-    Struct {
-        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-        unpinned: &'pin mut (U),
-    },
-    Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
-    Unit,
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-enum __EnumProjectionRef<'pin, T, U>
-where
-    Enum<T, U>: 'pin,
-{
-    Struct {
-        pinned: ::pin_project::__private::Pin<&'pin (T)>,
-        unpinned: &'pin (U),
-    },
-    Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
-    Unit,
-}
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    enum __EnumProjection<'pin, T, U>
+    where
+        Enum<T, U>: 'pin,
+    {
+        Struct {
+            pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+            unpinned: &'pin mut (U),
+        },
+        Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
+        Unit,
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    enum __EnumProjectionRef<'pin, T, U>
+    where
+        Enum<T, U>: 'pin,
+    {
+        Struct {
+            pinned: ::pin_project::__private::Pin<&'pin (T)>,
+            unpinned: &'pin (U),
+        },
+        Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
+        Unit,
+    }
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/unsafe_unpin-struct.expanded.rs
+++ b/tests/expand/tests/expand/unsafe_unpin-struct.expanded.rs
@@ -6,33 +6,31 @@ struct Struct<T, U> {
     unpinned: U,
 }
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __StructProjection<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-    unpinned: &'pin mut (U),
-}
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __StructProjectionRef<'pin, T, U>
-where
-    Struct<T, U>: 'pin,
-{
-    pinned: ::pin_project::__private::Pin<&'pin (T)>,
-    unpinned: &'pin (U),
-}
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __StructProjection<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned: &'pin mut (U),
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __StructProjectionRef<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin (T)>,
+        unpinned: &'pin (U),
+    }
     impl<T, U> Struct<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/expand/tests/expand/unsafe_unpin-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/unsafe_unpin-tuple_struct.expanded.rs
@@ -2,28 +2,29 @@ use pin_project::{pin_project, UnsafeUnpin};
 #[pin(__private(UnsafeUnpin))]
 struct TupleStruct<T, U>(#[pin] T, U);
 #[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __TupleStructProjection<'pin, T, U>(
-    ::pin_project::__private::Pin<&'pin mut (T)>,
-    &'pin mut (U),
-)
-where
-    TupleStruct<T, U>: 'pin;
-#[doc(hidden)]
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::type_repetition_in_bounds)]
-struct __TupleStructProjectionRef<'pin, T, U>(::pin_project::__private::Pin<&'pin (T)>, &'pin (U))
-where
-    TupleStruct<T, U>: 'pin;
-#[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __TupleStructProjection<'pin, T, U>(
+        ::pin_project::__private::Pin<&'pin mut (T)>,
+        &'pin mut (U),
+    )
+    where
+        TupleStruct<T, U>: 'pin;
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __TupleStructProjectionRef<'pin, T, U>(
+        ::pin_project::__private::Pin<&'pin (T)>,
+        &'pin (U),
+    )
+    where
+        TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,

--- a/tests/ui/pin_project/import_unnamed.rs
+++ b/tests/ui/pin_project/import_unnamed.rs
@@ -1,0 +1,30 @@
+/// Only named projected types can be imported.
+/// See visibility.rs for named projected types.
+
+mod pub_ {
+    use pin_project::pin_project;
+
+    #[pin_project]
+    pub struct Default(());
+
+    #[pin_project(project_replace)]
+    pub struct Replace(());
+}
+#[allow(unused_imports)]
+pub mod use_ {
+    #[rustfmt::skip]
+    use crate::pub_::__DefaultProjection; //~ ERROR E0432
+    #[rustfmt::skip]
+    use crate::pub_::__DefaultProjectionRef; //~ ERROR E0432
+    #[rustfmt::skip]
+    use crate::pub_::__ReplaceProjection; //~ ERROR E0432
+    #[rustfmt::skip]
+    use crate::pub_::__ReplaceProjectionOwned; //~ ERROR E0432
+    #[rustfmt::skip]
+    use crate::pub_::__ReplaceProjectionRef; //~ ERROR E0432
+
+    // Confirm that the visibility of the original type is not changed.
+    pub use crate::pub_::{Default, Replace};
+}
+
+fn main() {}

--- a/tests/ui/pin_project/import_unnamed.stderr
+++ b/tests/ui/pin_project/import_unnamed.stderr
@@ -1,0 +1,29 @@
+error[E0432]: unresolved import `crate::pub_::__DefaultProjection`
+  --> $DIR/import_unnamed.rs:16:9
+   |
+16 |     use crate::pub_::__DefaultProjection; //~ ERROR E0432
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `__DefaultProjection` in `pub_`
+
+error[E0432]: unresolved import `crate::pub_::__DefaultProjectionRef`
+  --> $DIR/import_unnamed.rs:18:9
+   |
+18 |     use crate::pub_::__DefaultProjectionRef; //~ ERROR E0432
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `__DefaultProjectionRef` in `pub_`
+
+error[E0432]: unresolved import `crate::pub_::__ReplaceProjection`
+  --> $DIR/import_unnamed.rs:20:9
+   |
+20 |     use crate::pub_::__ReplaceProjection; //~ ERROR E0432
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `__ReplaceProjection` in `pub_`
+
+error[E0432]: unresolved import `crate::pub_::__ReplaceProjectionOwned`
+  --> $DIR/import_unnamed.rs:22:9
+   |
+22 |     use crate::pub_::__ReplaceProjectionOwned; //~ ERROR E0432
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `__ReplaceProjectionOwned` in `pub_`
+
+error[E0432]: unresolved import `crate::pub_::__ReplaceProjectionRef`
+  --> $DIR/import_unnamed.rs:24:9
+   |
+24 |     use crate::pub_::__ReplaceProjectionRef; //~ ERROR E0432
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `__ReplaceProjectionRef` in `pub_`

--- a/tests/ui/pin_project/visibility.rs
+++ b/tests/ui/pin_project/visibility.rs
@@ -1,55 +1,7 @@
+/// Only named projected types can be imported.
+/// See import_unnamed.rs for unnamed projected types.
+
 mod pub_ {
-    use pin_project::pin_project;
-
-    #[pin_project]
-    pub struct Default(());
-
-    #[pin_project(project_replace)]
-    pub struct Replace(());
-}
-pub mod pub_use {
-    #[rustfmt::skip]
-    pub use crate::pub_::__DefaultProjection; //~ ERROR E0365
-    #[rustfmt::skip]
-    pub use crate::pub_::__DefaultProjectionRef; //~ ERROR E0365
-    #[rustfmt::skip]
-    pub use crate::pub_::__ReplaceProjection; //~ ERROR E0365
-    #[rustfmt::skip]
-    pub use crate::pub_::__ReplaceProjectionOwned; //~ ERROR E0365
-    #[rustfmt::skip]
-    pub use crate::pub_::__ReplaceProjectionRef; //~ ERROR E0365
-
-    // Confirm that the visibility of the original type is not changed.
-    pub use crate::pub_::{Default, Replace};
-}
-pub mod pub_use2 {
-    // Ok
-    #[allow(unused_imports)]
-    pub(crate) use crate::pub_::{
-        __DefaultProjection, __DefaultProjectionRef, __ReplaceProjection, __ReplaceProjectionOwned,
-        __ReplaceProjectionRef,
-    };
-}
-
-mod pub_crate {
-    use pin_project::pin_project;
-
-    #[pin_project]
-    pub(crate) struct Default(());
-
-    #[pin_project(project_replace)]
-    pub(crate) struct Replace(());
-}
-pub mod pub_crate_use {
-    // Ok
-    #[allow(unused_imports)]
-    pub(crate) use crate::pub_crate::{
-        __DefaultProjection, __DefaultProjectionRef, __ReplaceProjection, __ReplaceProjectionOwned,
-        __ReplaceProjectionRef,
-    };
-}
-
-mod pub_renamed {
     use pin_project::pin_project;
 
     #[pin_project(project = DProj, project_ref = DProjRef)]
@@ -58,25 +10,40 @@ mod pub_renamed {
     #[pin_project(project = RProj, project_ref = RProjRef, project_replace = RProjOwn)]
     pub struct Replace(());
 }
-pub mod pub_renamed_use {
+pub mod pub_use {
     #[rustfmt::skip]
-    pub use crate::pub_renamed::DProj; //~ ERROR E0365
+    pub use crate::pub_::DProj; //~ ERROR E0365
     #[rustfmt::skip]
-    pub use crate::pub_renamed::DProjRef; //~ ERROR E0365
+    pub use crate::pub_::DProjRef; //~ ERROR E0365
     #[rustfmt::skip]
-    pub use crate::pub_renamed::RProj; //~ ERROR E0365
+    pub use crate::pub_::RProj; //~ ERROR E0365
     #[rustfmt::skip]
-    pub use crate::pub_renamed::RProjOwn; //~ ERROR E0365
+    pub use crate::pub_::RProjOwn; //~ ERROR E0365
     #[rustfmt::skip]
-    pub use crate::pub_renamed::RProjRef; //~ ERROR E0365
+    pub use crate::pub_::RProjRef; //~ ERROR E0365
 
     // Confirm that the visibility of the original type is not changed.
-    pub use crate::pub_renamed::{Default, Replace};
+    pub use crate::pub_::{Default, Replace};
 }
-pub mod pub_renamed_use2 {
+pub mod pub_use2 {
     // Ok
     #[allow(unused_imports)]
-    pub(crate) use crate::pub_renamed::{DProj, DProjRef, RProj, RProjOwn, RProjRef};
+    pub(crate) use crate::pub_::{DProj, DProjRef, RProj, RProjOwn, RProjRef};
+}
+
+mod pub_crate {
+    use pin_project::pin_project;
+
+    #[pin_project(project = DProj, project_ref = DProjRef)]
+    pub(crate) struct Default(());
+
+    #[pin_project(project = RProj, project_ref = RProjRef, project_replace = RProjOwn)]
+    pub(crate) struct Replace(());
+}
+pub mod pub_crate_use {
+    // Ok
+    #[allow(unused_imports)]
+    pub(crate) use crate::pub_crate::{DProj, DProjRef, RProj, RProjOwn, RProjRef};
 }
 
 fn main() {}

--- a/tests/ui/pin_project/visibility.stderr
+++ b/tests/ui/pin_project/visibility.stderr
@@ -1,79 +1,39 @@
-error[E0365]: `__DefaultProjection` is private, and cannot be re-exported
-  --> $DIR/visibility.rs:12:13
-   |
-12 |     pub use crate::pub_::__DefaultProjection; //~ ERROR E0365
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ re-export of private `__DefaultProjection`
-   |
-   = note: consider declaring type or module `__DefaultProjection` with `pub`
-
-error[E0365]: `__DefaultProjectionRef` is private, and cannot be re-exported
-  --> $DIR/visibility.rs:14:13
-   |
-14 |     pub use crate::pub_::__DefaultProjectionRef; //~ ERROR E0365
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ re-export of private `__DefaultProjectionRef`
-   |
-   = note: consider declaring type or module `__DefaultProjectionRef` with `pub`
-
-error[E0365]: `__ReplaceProjection` is private, and cannot be re-exported
-  --> $DIR/visibility.rs:16:13
-   |
-16 |     pub use crate::pub_::__ReplaceProjection; //~ ERROR E0365
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ re-export of private `__ReplaceProjection`
-   |
-   = note: consider declaring type or module `__ReplaceProjection` with `pub`
-
-error[E0365]: `__ReplaceProjectionOwned` is private, and cannot be re-exported
-  --> $DIR/visibility.rs:18:13
-   |
-18 |     pub use crate::pub_::__ReplaceProjectionOwned; //~ ERROR E0365
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ re-export of private `__ReplaceProjectionOwned`
-   |
-   = note: consider declaring type or module `__ReplaceProjectionOwned` with `pub`
-
-error[E0365]: `__ReplaceProjectionRef` is private, and cannot be re-exported
-  --> $DIR/visibility.rs:20:13
-   |
-20 |     pub use crate::pub_::__ReplaceProjectionRef; //~ ERROR E0365
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ re-export of private `__ReplaceProjectionRef`
-   |
-   = note: consider declaring type or module `__ReplaceProjectionRef` with `pub`
-
 error[E0365]: `DProj` is private, and cannot be re-exported
-  --> $DIR/visibility.rs:63:13
+  --> $DIR/visibility.rs:15:13
    |
-63 |     pub use crate::pub_renamed::DProj; //~ ERROR E0365
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ re-export of private `DProj`
+15 |     pub use crate::pub_::DProj; //~ ERROR E0365
+   |             ^^^^^^^^^^^^^^^^^^ re-export of private `DProj`
    |
    = note: consider declaring type or module `DProj` with `pub`
 
 error[E0365]: `DProjRef` is private, and cannot be re-exported
-  --> $DIR/visibility.rs:65:13
+  --> $DIR/visibility.rs:17:13
    |
-65 |     pub use crate::pub_renamed::DProjRef; //~ ERROR E0365
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ re-export of private `DProjRef`
+17 |     pub use crate::pub_::DProjRef; //~ ERROR E0365
+   |             ^^^^^^^^^^^^^^^^^^^^^ re-export of private `DProjRef`
    |
    = note: consider declaring type or module `DProjRef` with `pub`
 
 error[E0365]: `RProj` is private, and cannot be re-exported
-  --> $DIR/visibility.rs:67:13
+  --> $DIR/visibility.rs:19:13
    |
-67 |     pub use crate::pub_renamed::RProj; //~ ERROR E0365
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ re-export of private `RProj`
+19 |     pub use crate::pub_::RProj; //~ ERROR E0365
+   |             ^^^^^^^^^^^^^^^^^^ re-export of private `RProj`
    |
    = note: consider declaring type or module `RProj` with `pub`
 
 error[E0365]: `RProjOwn` is private, and cannot be re-exported
-  --> $DIR/visibility.rs:69:13
+  --> $DIR/visibility.rs:21:13
    |
-69 |     pub use crate::pub_renamed::RProjOwn; //~ ERROR E0365
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ re-export of private `RProjOwn`
+21 |     pub use crate::pub_::RProjOwn; //~ ERROR E0365
+   |             ^^^^^^^^^^^^^^^^^^^^^ re-export of private `RProjOwn`
    |
    = note: consider declaring type or module `RProjOwn` with `pub`
 
 error[E0365]: `RProjRef` is private, and cannot be re-exported
-  --> $DIR/visibility.rs:71:13
+  --> $DIR/visibility.rs:23:13
    |
-71 |     pub use crate::pub_renamed::RProjRef; //~ ERROR E0365
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ re-export of private `RProjRef`
+23 |     pub use crate::pub_::RProjRef; //~ ERROR E0365
+   |             ^^^^^^^^^^^^^^^^^^^^^ re-export of private `RProjRef`
    |
    = note: consider declaring type or module `RProjRef` with `pub`


### PR DESCRIPTION
Defines projected types in inside `const _: () = {}` when the users don't name it;

cc #264