### PR TITLE
Optimize code generation when used on enums

### DIFF
--- a/examples/enum-default-expanded.rs
+++ b/examples/enum-default-expanded.rs
@@ -41,16 +41,10 @@ where
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    enum __EnumProjectionRef<'pin, T, U>
-    where
-        Enum<T, U>: 'pin,
-    {
-        Pinned(::pin_project::__private::Pin<&'pin (T)>),
-        Unpinned(&'pin (U)),
-    }
+    // When `#[pin_project]` is used on enums, only named projection types and
+    // methods are generated because there is no way to access variants of
+    // projected types without naming it.
+    // (When `#[pin_project]` is used on structs, both methods are always generated.)
 
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
@@ -62,18 +56,6 @@ const _: () = {
                         EnumProj::Pinned(::pin_project::__private::Pin::new_unchecked(_0))
                     }
                     Enum::Unpinned(_0) => EnumProj::Unpinned(_0),
-                }
-            }
-        }
-        fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
-        ) -> __EnumProjectionRef<'pin, T, U> {
-            unsafe {
-                match self.get_ref() {
-                    Enum::Pinned(_0) => __EnumProjectionRef::Pinned(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                    ),
-                    Enum::Unpinned(_0) => __EnumProjectionRef::Unpinned(_0),
                 }
             }
         }

--- a/tests/cfg.rs
+++ b/tests/cfg.rs
@@ -83,7 +83,11 @@ fn cfg() {
 
     // enums
 
-    #[pin_project(project_replace)]
+    #[pin_project(
+        project = VariantProj,
+        project_ref = VariantProjRef,
+        project_replace = VariantProjOwn,
+    )]
     enum Variant {
         #[cfg(target_os = "linux")]
         Inner(#[pin] Linux),
@@ -110,7 +114,11 @@ fn cfg() {
     #[cfg(not(target_os = "linux"))]
     let _x = Variant::Other(Other);
 
-    #[pin_project(project_replace)]
+    #[pin_project(
+        project = FieldProj,
+        project_ref = FieldProjRef,
+        project_replace = FieldProjOwn,
+    )]
     enum Field {
         SameName {
             #[cfg(target_os = "linux")]

--- a/tests/expand/tests/expand/default-enum.expanded.rs
+++ b/tests/expand/tests/expand/default-enum.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::pin_project;
-#[pin(__private())]
+# [pin (__private (project = EnumProj , project_ref = EnumProjRef))]
 enum Enum<T, U> {
     Struct {
         #[pin]
@@ -9,72 +9,70 @@ enum Enum<T, U> {
     Tuple(#[pin] T, U),
     Unit,
 }
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::mut_mut)]
+#[allow(clippy::type_repetition_in_bounds)]
+enum EnumProj<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Struct {
+        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned: &'pin mut (U),
+    },
+    Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
+    Unit,
+}
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::type_repetition_in_bounds)]
+enum EnumProjRef<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Struct {
+        pinned: ::pin_project::__private::Pin<&'pin (T)>,
+        unpinned: &'pin (U),
+    },
+    Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
+    Unit,
+}
 #[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    enum __EnumProjection<'pin, T, U>
-    where
-        Enum<T, U>: 'pin,
-    {
-        Struct {
-            pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-            unpinned: &'pin mut (U),
-        },
-        Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
-        Unit,
-    }
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    enum __EnumProjectionRef<'pin, T, U>
-    where
-        Enum<T, U>: 'pin,
-    {
-        Struct {
-            pinned: ::pin_project::__private::Pin<&'pin (T)>,
-            unpinned: &'pin (U),
-        },
-        Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
-        Unit,
-    }
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,
-        ) -> __EnumProjection<'pin, T, U> {
+        ) -> EnumProj<'pin, T, U> {
             unsafe {
                 match self.get_unchecked_mut() {
-                    Enum::Struct { pinned, unpinned } => __EnumProjection::Struct {
+                    Enum::Struct { pinned, unpinned } => EnumProj::Struct {
                         pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
-                    Enum::Tuple(_0, _1) => __EnumProjection::Tuple(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                        _1,
-                    ),
-                    Enum::Unit => __EnumProjection::Unit,
+                    Enum::Tuple(_0, _1) => {
+                        EnumProj::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                    }
+                    Enum::Unit => EnumProj::Unit,
                 }
             }
         }
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
-        ) -> __EnumProjectionRef<'pin, T, U> {
+        ) -> EnumProjRef<'pin, T, U> {
             unsafe {
                 match self.get_ref() {
-                    Enum::Struct { pinned, unpinned } => __EnumProjectionRef::Struct {
+                    Enum::Struct { pinned, unpinned } => EnumProjRef::Struct {
                         pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
-                    Enum::Tuple(_0, _1) => __EnumProjectionRef::Tuple(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                        _1,
-                    ),
-                    Enum::Unit => __EnumProjectionRef::Unit,
+                    Enum::Tuple(_0, _1) => {
+                        EnumProjRef::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                    }
+                    Enum::Unit => EnumProjRef::Unit,
                 }
             }
         }

--- a/tests/expand/tests/expand/default-enum.rs
+++ b/tests/expand/tests/expand/default-enum.rs
@@ -1,6 +1,6 @@
 use pin_project::pin_project;
 
-#[pin_project]
+#[pin_project(project = EnumProj, project_ref = EnumProjRef)]
 enum Enum<T, U> {
     Struct {
         #[pin]

--- a/tests/expand/tests/expand/naming-enum-none.expanded.rs
+++ b/tests/expand/tests/expand/naming-enum-none.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::pin_project;
-# [pin (__private (project = Proj))]
+#[pin(__private())]
 enum Enum<T, U> {
     Struct {
         #[pin]
@@ -9,42 +9,12 @@ enum Enum<T, U> {
     Tuple(#[pin] T, U),
     Unit,
 }
-#[allow(dead_code)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
-enum Proj<'pin, T, U>
-where
-    Enum<T, U>: 'pin,
-{
-    Struct {
-        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-        unpinned: &'pin mut (U),
-    },
-    Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
-    Unit,
-}
 #[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    impl<T, U> Enum<T, U> {
-        fn project<'pin>(self: ::pin_project::__private::Pin<&'pin mut Self>) -> Proj<'pin, T, U> {
-            unsafe {
-                match self.get_unchecked_mut() {
-                    Enum::Struct { pinned, unpinned } => Proj::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
-                        unpinned,
-                    },
-                    Enum::Tuple(_0, _1) => {
-                        Proj::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
-                    }
-                    Enum::Unit => Proj::Unit,
-                }
-            }
-        }
-    }
+    impl<T, U> Enum<T, U> {}
     struct __Enum<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/naming-enum-none.rs
+++ b/tests/expand/tests/expand/naming-enum-none.rs
@@ -1,7 +1,7 @@
 use pin_project::pin_project;
 
-#[pin_project(project = EnumProj, project_ref = EnumProjRef)]
-pub enum Enum<T, U> {
+#[pin_project]
+enum Enum<T, U> {
     Struct {
         #[pin]
         pinned: T,

--- a/tests/expand/tests/expand/naming-enum-own.expanded.rs
+++ b/tests/expand/tests/expand/naming-enum-own.expanded.rs
@@ -25,70 +25,7 @@ enum ProjOwn<T, U> {
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    enum __EnumProjection<'pin, T, U>
-    where
-        Enum<T, U>: 'pin,
-    {
-        Struct {
-            pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-            unpinned: &'pin mut (U),
-        },
-        Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
-        Unit,
-    }
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    enum __EnumProjectionRef<'pin, T, U>
-    where
-        Enum<T, U>: 'pin,
-    {
-        Struct {
-            pinned: ::pin_project::__private::Pin<&'pin (T)>,
-            unpinned: &'pin (U),
-        },
-        Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
-        Unit,
-    }
     impl<T, U> Enum<T, U> {
-        fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
-        ) -> __EnumProjection<'pin, T, U> {
-            unsafe {
-                match self.get_unchecked_mut() {
-                    Enum::Struct { pinned, unpinned } => __EnumProjection::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
-                        unpinned,
-                    },
-                    Enum::Tuple(_0, _1) => __EnumProjection::Tuple(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                        _1,
-                    ),
-                    Enum::Unit => __EnumProjection::Unit,
-                }
-            }
-        }
-        fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
-        ) -> __EnumProjectionRef<'pin, T, U> {
-            unsafe {
-                match self.get_ref() {
-                    Enum::Struct { pinned, unpinned } => __EnumProjectionRef::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
-                        unpinned,
-                    },
-                    Enum::Tuple(_0, _1) => __EnumProjectionRef::Tuple(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                        _1,
-                    ),
-                    Enum::Unit => __EnumProjectionRef::Unit,
-                }
-            }
-        }
         fn project_replace(
             self: ::pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/tests/expand/naming-enum-ref.expanded.rs
+++ b/tests/expand/tests/expand/naming-enum-ref.expanded.rs
@@ -28,39 +28,7 @@ where
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    enum __EnumProjection<'pin, T, U>
-    where
-        Enum<T, U>: 'pin,
-    {
-        Struct {
-            pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-            unpinned: &'pin mut (U),
-        },
-        Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
-        Unit,
-    }
     impl<T, U> Enum<T, U> {
-        fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
-        ) -> __EnumProjection<'pin, T, U> {
-            unsafe {
-                match self.get_unchecked_mut() {
-                    Enum::Struct { pinned, unpinned } => __EnumProjection::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
-                        unpinned,
-                    },
-                    Enum::Tuple(_0, _1) => __EnumProjection::Tuple(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                        _1,
-                    ),
-                    Enum::Unit => __EnumProjection::Unit,
-                }
-            }
-        }
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {

--- a/tests/expand/tests/expand/naming-struct-none.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct-none.expanded.rs
@@ -1,0 +1,86 @@
+use pin_project::pin_project;
+#[pin(__private())]
+struct Struct<T, U> {
+    #[pin]
+    pinned: T,
+    unpinned: U,
+}
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::used_underscore_binding)]
+const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __StructProjection<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned: &'pin mut (U),
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __StructProjectionRef<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned: ::pin_project::__private::Pin<&'pin (T)>,
+        unpinned: &'pin (U),
+    }
+    impl<T, U> Struct<T, U> {
+        fn project<'pin>(
+            self: ::pin_project::__private::Pin<&'pin mut Self>,
+        ) -> __StructProjection<'pin, T, U> {
+            unsafe {
+                let Self { pinned, unpinned } = self.get_unchecked_mut();
+                __StructProjection {
+                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    unpinned,
+                }
+            }
+        }
+        fn project_ref<'pin>(
+            self: ::pin_project::__private::Pin<&'pin Self>,
+        ) -> __StructProjectionRef<'pin, T, U> {
+            unsafe {
+                let Self { pinned, unpinned } = self.get_ref();
+                __StructProjectionRef {
+                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    unpinned,
+                }
+            }
+        }
+    }
+    struct __Struct<'pin, T, U> {
+        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+            'pin,
+            (
+                ::pin_project::__private::PhantomData<T>,
+                ::pin_project::__private::PhantomData<U>,
+            ),
+        >,
+        __field0: T,
+    }
+    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
+        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    {
+    }
+    unsafe impl<T, U> ::pin_project::UnsafeUnpin for Struct<T, U> {}
+    trait StructMustNotImplDrop {}
+    #[allow(clippy::drop_bounds)]
+    impl<T: ::pin_project::__private::Drop> StructMustNotImplDrop for T {}
+    impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
+    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    }
+    #[deny(safe_packed_borrows)]
+    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
+        &val.pinned;
+        &val.unpinned;
+    }
+};
+fn main() {}

--- a/tests/expand/tests/expand/naming-struct-none.rs
+++ b/tests/expand/tests/expand/naming-struct-none.rs
@@ -1,0 +1,10 @@
+use pin_project::pin_project;
+
+#[pin_project]
+struct Struct<T, U> {
+    #[pin]
+    pinned: T,
+    unpinned: U,
+}
+
+fn main() {}

--- a/tests/expand/tests/expand/naming-tuple_struct-none.expanded.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct-none.expanded.rs
@@ -1,0 +1,74 @@
+use pin_project::pin_project;
+#[pin(__private())]
+struct TupleStruct<T, U>(#[pin] T, U);
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::used_underscore_binding)]
+const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __TupleStructProjection<'pin, T, U>(
+        ::pin_project::__private::Pin<&'pin mut (T)>,
+        &'pin mut (U),
+    )
+    where
+        TupleStruct<T, U>: 'pin;
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct __TupleStructProjectionRef<'pin, T, U>(
+        ::pin_project::__private::Pin<&'pin (T)>,
+        &'pin (U),
+    )
+    where
+        TupleStruct<T, U>: 'pin;
+    impl<T, U> TupleStruct<T, U> {
+        fn project<'pin>(
+            self: ::pin_project::__private::Pin<&'pin mut Self>,
+        ) -> __TupleStructProjection<'pin, T, U> {
+            unsafe {
+                let Self(_0, _1) = self.get_unchecked_mut();
+                __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
+            }
+        }
+        fn project_ref<'pin>(
+            self: ::pin_project::__private::Pin<&'pin Self>,
+        ) -> __TupleStructProjectionRef<'pin, T, U> {
+            unsafe {
+                let Self(_0, _1) = self.get_ref();
+                __TupleStructProjectionRef(::pin_project::__private::Pin::new_unchecked(_0), _1)
+            }
+        }
+    }
+    struct __TupleStruct<'pin, T, U> {
+        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+            'pin,
+            (
+                ::pin_project::__private::PhantomData<T>,
+                ::pin_project::__private::PhantomData<U>,
+            ),
+        >,
+        __field0: T,
+    }
+    impl<'pin, T, U> ::pin_project::__private::Unpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    {
+    }
+    unsafe impl<T, U> ::pin_project::UnsafeUnpin for TupleStruct<T, U> {}
+    trait TupleStructMustNotImplDrop {}
+    #[allow(clippy::drop_bounds)]
+    impl<T: ::pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
+    impl<T, U> TupleStructMustNotImplDrop for TupleStruct<T, U> {}
+    impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
+        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    }
+    #[deny(safe_packed_borrows)]
+    fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
+        &val.0;
+        &val.1;
+    }
+};
+fn main() {}

--- a/tests/expand/tests/expand/naming-tuple_struct-none.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct-none.rs
@@ -1,0 +1,6 @@
+use pin_project::pin_project;
+
+#[pin_project]
+struct TupleStruct<T, U>(#[pin] T, U);
+
+fn main() {}

--- a/tests/expand/tests/expand/not_unpin-enum.expanded.rs
+++ b/tests/expand/tests/expand/not_unpin-enum.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::pin_project;
-# [pin (__private (! Unpin))]
+# [pin (__private (! Unpin , project = EnumProj , project_ref = EnumProjRef))]
 enum Enum<T, U> {
     Struct {
         #[pin]
@@ -9,72 +9,70 @@ enum Enum<T, U> {
     Tuple(#[pin] T, U),
     Unit,
 }
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::mut_mut)]
+#[allow(clippy::type_repetition_in_bounds)]
+enum EnumProj<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Struct {
+        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned: &'pin mut (U),
+    },
+    Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
+    Unit,
+}
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::type_repetition_in_bounds)]
+enum EnumProjRef<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Struct {
+        pinned: ::pin_project::__private::Pin<&'pin (T)>,
+        unpinned: &'pin (U),
+    },
+    Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
+    Unit,
+}
 #[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    enum __EnumProjection<'pin, T, U>
-    where
-        Enum<T, U>: 'pin,
-    {
-        Struct {
-            pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-            unpinned: &'pin mut (U),
-        },
-        Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
-        Unit,
-    }
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    enum __EnumProjectionRef<'pin, T, U>
-    where
-        Enum<T, U>: 'pin,
-    {
-        Struct {
-            pinned: ::pin_project::__private::Pin<&'pin (T)>,
-            unpinned: &'pin (U),
-        },
-        Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
-        Unit,
-    }
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,
-        ) -> __EnumProjection<'pin, T, U> {
+        ) -> EnumProj<'pin, T, U> {
             unsafe {
                 match self.get_unchecked_mut() {
-                    Enum::Struct { pinned, unpinned } => __EnumProjection::Struct {
+                    Enum::Struct { pinned, unpinned } => EnumProj::Struct {
                         pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
-                    Enum::Tuple(_0, _1) => __EnumProjection::Tuple(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                        _1,
-                    ),
-                    Enum::Unit => __EnumProjection::Unit,
+                    Enum::Tuple(_0, _1) => {
+                        EnumProj::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                    }
+                    Enum::Unit => EnumProj::Unit,
                 }
             }
         }
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
-        ) -> __EnumProjectionRef<'pin, T, U> {
+        ) -> EnumProjRef<'pin, T, U> {
             unsafe {
                 match self.get_ref() {
-                    Enum::Struct { pinned, unpinned } => __EnumProjectionRef::Struct {
+                    Enum::Struct { pinned, unpinned } => EnumProjRef::Struct {
                         pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
-                    Enum::Tuple(_0, _1) => __EnumProjectionRef::Tuple(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                        _1,
-                    ),
-                    Enum::Unit => __EnumProjectionRef::Unit,
+                    Enum::Tuple(_0, _1) => {
+                        EnumProjRef::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                    }
+                    Enum::Unit => EnumProjRef::Unit,
                 }
             }
         }

--- a/tests/expand/tests/expand/not_unpin-enum.rs
+++ b/tests/expand/tests/expand/not_unpin-enum.rs
@@ -1,6 +1,6 @@
 use pin_project::pin_project;
 
-#[pin_project(!Unpin)]
+#[pin_project(!Unpin, project = EnumProj, project_ref = EnumProjRef)]
 enum Enum<T, U> {
     Struct {
         #[pin]

--- a/tests/expand/tests/expand/pinned_drop-enum.expanded.rs
+++ b/tests/expand/tests/expand/pinned_drop-enum.expanded.rs
@@ -1,6 +1,6 @@
 use pin_project::{pin_project, pinned_drop};
 use std::pin::Pin;
-#[pin(__private(PinnedDrop))]
+# [pin (__private (PinnedDrop , project = EnumProj , project_ref = EnumProjRef))]
 enum Enum<T, U> {
     Struct {
         #[pin]
@@ -10,72 +10,70 @@ enum Enum<T, U> {
     Tuple(#[pin] T, U),
     Unit,
 }
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::mut_mut)]
+#[allow(clippy::type_repetition_in_bounds)]
+enum EnumProj<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Struct {
+        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned: &'pin mut (U),
+    },
+    Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
+    Unit,
+}
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::type_repetition_in_bounds)]
+enum EnumProjRef<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Struct {
+        pinned: ::pin_project::__private::Pin<&'pin (T)>,
+        unpinned: &'pin (U),
+    },
+    Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
+    Unit,
+}
 #[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    enum __EnumProjection<'pin, T, U>
-    where
-        Enum<T, U>: 'pin,
-    {
-        Struct {
-            pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-            unpinned: &'pin mut (U),
-        },
-        Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
-        Unit,
-    }
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    enum __EnumProjectionRef<'pin, T, U>
-    where
-        Enum<T, U>: 'pin,
-    {
-        Struct {
-            pinned: ::pin_project::__private::Pin<&'pin (T)>,
-            unpinned: &'pin (U),
-        },
-        Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
-        Unit,
-    }
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,
-        ) -> __EnumProjection<'pin, T, U> {
+        ) -> EnumProj<'pin, T, U> {
             unsafe {
                 match self.get_unchecked_mut() {
-                    Enum::Struct { pinned, unpinned } => __EnumProjection::Struct {
+                    Enum::Struct { pinned, unpinned } => EnumProj::Struct {
                         pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
-                    Enum::Tuple(_0, _1) => __EnumProjection::Tuple(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                        _1,
-                    ),
-                    Enum::Unit => __EnumProjection::Unit,
+                    Enum::Tuple(_0, _1) => {
+                        EnumProj::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                    }
+                    Enum::Unit => EnumProj::Unit,
                 }
             }
         }
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
-        ) -> __EnumProjectionRef<'pin, T, U> {
+        ) -> EnumProjRef<'pin, T, U> {
             unsafe {
                 match self.get_ref() {
-                    Enum::Struct { pinned, unpinned } => __EnumProjectionRef::Struct {
+                    Enum::Struct { pinned, unpinned } => EnumProjRef::Struct {
                         pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
-                    Enum::Tuple(_0, _1) => __EnumProjectionRef::Tuple(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                        _1,
-                    ),
-                    Enum::Unit => __EnumProjectionRef::Unit,
+                    Enum::Tuple(_0, _1) => {
+                        EnumProjRef::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                    }
+                    Enum::Unit => EnumProjRef::Unit,
                 }
             }
         }

--- a/tests/expand/tests/expand/pinned_drop-enum.rs
+++ b/tests/expand/tests/expand/pinned_drop-enum.rs
@@ -1,7 +1,7 @@
 use pin_project::{pin_project, pinned_drop};
 use std::pin::Pin;
 
-#[pin_project(PinnedDrop)]
+#[pin_project(PinnedDrop, project = EnumProj, project_ref = EnumProjRef)]
 enum Enum<T, U> {
     Struct {
         #[pin]

--- a/tests/expand/tests/expand/project_replace-enum.expanded.rs
+++ b/tests/expand/tests/expand/project_replace-enum.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::pin_project;
-#[pin(__private(project_replace))]
+# [pin (__private (project_replace = EnumProjOwn))]
 enum Enum<T, U> {
     Struct {
         #[pin]
@@ -9,95 +9,32 @@ enum Enum<T, U> {
     Tuple(#[pin] T, U),
     Unit,
 }
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
+enum EnumProjOwn<T, U> {
+    Struct {
+        pinned: ::pin_project::__private::PhantomData<T>,
+        unpinned: U,
+    },
+    Tuple(::pin_project::__private::PhantomData<T>, U),
+    Unit,
+}
 #[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    enum __EnumProjection<'pin, T, U>
-    where
-        Enum<T, U>: 'pin,
-    {
-        Struct {
-            pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-            unpinned: &'pin mut (U),
-        },
-        Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
-        Unit,
-    }
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    enum __EnumProjectionRef<'pin, T, U>
-    where
-        Enum<T, U>: 'pin,
-    {
-        Struct {
-            pinned: ::pin_project::__private::Pin<&'pin (T)>,
-            unpinned: &'pin (U),
-        },
-        Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
-        Unit,
-    }
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    enum __EnumProjectionOwned<T, U> {
-        Struct {
-            pinned: ::pin_project::__private::PhantomData<T>,
-            unpinned: U,
-        },
-        Tuple(::pin_project::__private::PhantomData<T>, U),
-        Unit,
-    }
     impl<T, U> Enum<T, U> {
-        fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
-        ) -> __EnumProjection<'pin, T, U> {
-            unsafe {
-                match self.get_unchecked_mut() {
-                    Enum::Struct { pinned, unpinned } => __EnumProjection::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
-                        unpinned,
-                    },
-                    Enum::Tuple(_0, _1) => __EnumProjection::Tuple(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                        _1,
-                    ),
-                    Enum::Unit => __EnumProjection::Unit,
-                }
-            }
-        }
-        fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
-        ) -> __EnumProjectionRef<'pin, T, U> {
-            unsafe {
-                match self.get_ref() {
-                    Enum::Struct { pinned, unpinned } => __EnumProjectionRef::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
-                        unpinned,
-                    },
-                    Enum::Tuple(_0, _1) => __EnumProjectionRef::Tuple(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                        _1,
-                    ),
-                    Enum::Unit => __EnumProjectionRef::Unit,
-                }
-            }
-        }
         fn project_replace(
             self: ::pin_project::__private::Pin<&mut Self>,
             __replacement: Self,
-        ) -> __EnumProjectionOwned<T, U> {
+        ) -> EnumProjOwn<T, U> {
             unsafe {
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
                 match &mut *__self_ptr {
                     Enum::Struct { pinned, unpinned } => {
-                        let __result = __EnumProjectionOwned::Struct {
+                        let __result = EnumProjOwn::Struct {
                             pinned: ::pin_project::__private::PhantomData,
                             unpinned: ::pin_project::__private::ptr::read(unpinned),
                         };
@@ -111,7 +48,7 @@ const _: () = {
                         __result
                     }
                     Enum::Tuple(_0, _1) => {
-                        let __result = __EnumProjectionOwned::Tuple(
+                        let __result = EnumProjOwn::Tuple(
                             ::pin_project::__private::PhantomData,
                             ::pin_project::__private::ptr::read(_1),
                         );
@@ -125,7 +62,7 @@ const _: () = {
                         __result
                     }
                     Enum::Unit => {
-                        let __result = __EnumProjectionOwned::Unit;
+                        let __result = EnumProjOwn::Unit;
                         let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
                             target: __self_ptr,
                             value: ::pin_project::__private::ManuallyDrop::new(__replacement),

--- a/tests/expand/tests/expand/project_replace-enum.rs
+++ b/tests/expand/tests/expand/project_replace-enum.rs
@@ -1,6 +1,6 @@
 use pin_project::pin_project;
 
-#[pin_project(project_replace)]
+#[pin_project(project_replace = EnumProjOwn)]
 enum Enum<T, U> {
     Struct {
         #[pin]

--- a/tests/expand/tests/expand/pub-enum.expanded.rs
+++ b/tests/expand/tests/expand/pub-enum.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::pin_project;
-#[pin(__private())]
+# [pin (__private (project = EnumProj , project_ref = EnumProjRef))]
 pub enum Enum<T, U> {
     Struct {
         #[pin]
@@ -9,72 +9,70 @@ pub enum Enum<T, U> {
     Tuple(#[pin] T, U),
     Unit,
 }
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::mut_mut)]
+#[allow(clippy::type_repetition_in_bounds)]
+pub(crate) enum EnumProj<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Struct {
+        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned: &'pin mut (U),
+    },
+    Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
+    Unit,
+}
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::type_repetition_in_bounds)]
+pub(crate) enum EnumProjRef<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Struct {
+        pinned: ::pin_project::__private::Pin<&'pin (T)>,
+        unpinned: &'pin (U),
+    },
+    Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
+    Unit,
+}
 #[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    pub(crate) enum __EnumProjection<'pin, T, U>
-    where
-        Enum<T, U>: 'pin,
-    {
-        Struct {
-            pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-            unpinned: &'pin mut (U),
-        },
-        Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
-        Unit,
-    }
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    pub(crate) enum __EnumProjectionRef<'pin, T, U>
-    where
-        Enum<T, U>: 'pin,
-    {
-        Struct {
-            pinned: ::pin_project::__private::Pin<&'pin (T)>,
-            unpinned: &'pin (U),
-        },
-        Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
-        Unit,
-    }
     impl<T, U> Enum<T, U> {
         pub(crate) fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,
-        ) -> __EnumProjection<'pin, T, U> {
+        ) -> EnumProj<'pin, T, U> {
             unsafe {
                 match self.get_unchecked_mut() {
-                    Enum::Struct { pinned, unpinned } => __EnumProjection::Struct {
+                    Enum::Struct { pinned, unpinned } => EnumProj::Struct {
                         pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
-                    Enum::Tuple(_0, _1) => __EnumProjection::Tuple(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                        _1,
-                    ),
-                    Enum::Unit => __EnumProjection::Unit,
+                    Enum::Tuple(_0, _1) => {
+                        EnumProj::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                    }
+                    Enum::Unit => EnumProj::Unit,
                 }
             }
         }
         pub(crate) fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
-        ) -> __EnumProjectionRef<'pin, T, U> {
+        ) -> EnumProjRef<'pin, T, U> {
             unsafe {
                 match self.get_ref() {
-                    Enum::Struct { pinned, unpinned } => __EnumProjectionRef::Struct {
+                    Enum::Struct { pinned, unpinned } => EnumProjRef::Struct {
                         pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
-                    Enum::Tuple(_0, _1) => __EnumProjectionRef::Tuple(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                        _1,
-                    ),
-                    Enum::Unit => __EnumProjectionRef::Unit,
+                    Enum::Tuple(_0, _1) => {
+                        EnumProjRef::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                    }
+                    Enum::Unit => EnumProjRef::Unit,
                 }
             }
         }

--- a/tests/expand/tests/expand/unsafe_unpin-enum.expanded.rs
+++ b/tests/expand/tests/expand/unsafe_unpin-enum.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::{pin_project, UnsafeUnpin};
-#[pin(__private(UnsafeUnpin))]
+# [pin (__private (UnsafeUnpin , project = EnumProj , project_ref = EnumProjRef))]
 enum Enum<T, U> {
     Struct {
         #[pin]
@@ -9,72 +9,70 @@ enum Enum<T, U> {
     Tuple(#[pin] T, U),
     Unit,
 }
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::mut_mut)]
+#[allow(clippy::type_repetition_in_bounds)]
+enum EnumProj<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Struct {
+        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned: &'pin mut (U),
+    },
+    Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
+    Unit,
+}
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::type_repetition_in_bounds)]
+enum EnumProjRef<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Struct {
+        pinned: ::pin_project::__private::Pin<&'pin (T)>,
+        unpinned: &'pin (U),
+    },
+    Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
+    Unit,
+}
 #[doc(hidden)]
 #[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    enum __EnumProjection<'pin, T, U>
-    where
-        Enum<T, U>: 'pin,
-    {
-        Struct {
-            pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
-            unpinned: &'pin mut (U),
-        },
-        Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
-        Unit,
-    }
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    enum __EnumProjectionRef<'pin, T, U>
-    where
-        Enum<T, U>: 'pin,
-    {
-        Struct {
-            pinned: ::pin_project::__private::Pin<&'pin (T)>,
-            unpinned: &'pin (U),
-        },
-        Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
-        Unit,
-    }
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,
-        ) -> __EnumProjection<'pin, T, U> {
+        ) -> EnumProj<'pin, T, U> {
             unsafe {
                 match self.get_unchecked_mut() {
-                    Enum::Struct { pinned, unpinned } => __EnumProjection::Struct {
+                    Enum::Struct { pinned, unpinned } => EnumProj::Struct {
                         pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
-                    Enum::Tuple(_0, _1) => __EnumProjection::Tuple(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                        _1,
-                    ),
-                    Enum::Unit => __EnumProjection::Unit,
+                    Enum::Tuple(_0, _1) => {
+                        EnumProj::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                    }
+                    Enum::Unit => EnumProj::Unit,
                 }
             }
         }
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
-        ) -> __EnumProjectionRef<'pin, T, U> {
+        ) -> EnumProjRef<'pin, T, U> {
             unsafe {
                 match self.get_ref() {
-                    Enum::Struct { pinned, unpinned } => __EnumProjectionRef::Struct {
+                    Enum::Struct { pinned, unpinned } => EnumProjRef::Struct {
                         pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
-                    Enum::Tuple(_0, _1) => __EnumProjectionRef::Tuple(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                        _1,
-                    ),
-                    Enum::Unit => __EnumProjectionRef::Unit,
+                    Enum::Tuple(_0, _1) => {
+                        EnumProjRef::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                    }
+                    Enum::Unit => EnumProjRef::Unit,
                 }
             }
         }

--- a/tests/expand/tests/expand/unsafe_unpin-enum.rs
+++ b/tests/expand/tests/expand/unsafe_unpin-enum.rs
@@ -1,6 +1,6 @@
 use pin_project::{pin_project, UnsafeUnpin};
 
-#[pin_project(UnsafeUnpin)]
+#[pin_project(UnsafeUnpin, project = EnumProj, project_ref = EnumProjRef)]
 enum Enum<T, U> {
     Struct {
         #[pin]

--- a/tests/include/basic-safe-part.rs
+++ b/tests/include/basic-safe-part.rs
@@ -12,7 +12,10 @@ pub struct DefaultStruct<T, U> {
 #[derive(Debug)]
 pub struct DefaultTupleStruct<T, U>(#[pin] pub T, pub U);
 
-#[::pin_project::pin_project]
+#[::pin_project::pin_project(
+    project = DefaultEnumProj,
+    project_ref = DefaultEnumProjRef,
+)]
 #[derive(Debug)]
 pub enum DefaultEnum<T, U> {
     Struct {
@@ -46,7 +49,11 @@ impl<T, U> PinnedDrop for PinnedDropTupleStruct<T, U> {
     fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
 }
 
-#[::pin_project::pin_project(PinnedDrop)]
+#[::pin_project::pin_project(
+    PinnedDrop,
+    project = PinnedDropEnumProj,
+    project_ref = PinnedDropEnumProjRef,
+)]
 #[derive(Debug)]
 pub enum PinnedDropEnum<T, U> {
     Struct {
@@ -75,7 +82,11 @@ pub struct ReplaceStruct<T, U> {
 #[derive(Debug)]
 pub struct ReplaceTupleStruct<T, U>(#[pin] pub T, pub U);
 
-#[::pin_project::pin_project(project_replace)]
+#[::pin_project::pin_project(
+    project = ReplaceEnumProj,
+    project_ref = ReplaceEnumProjRef,
+    project_replace = ReplaceEnumProjOwn,
+)]
 #[derive(Debug)]
 pub enum ReplaceEnum<T, U> {
     Struct {
@@ -99,7 +110,11 @@ pub struct UnsafeUnpinStruct<T, U> {
 #[derive(Debug)]
 pub struct UnsafeUnpinTupleStruct<T, U>(#[pin] pub T, pub U);
 
-#[::pin_project::pin_project(UnsafeUnpin)]
+#[::pin_project::pin_project(
+    UnsafeUnpin,
+    project = UnsafeUnpinEnumProj,
+    project_ref = UnsafeUnpinEnumProjRef,
+)]
 #[derive(Debug)]
 pub enum UnsafeUnpinEnum<T, U> {
     Struct {
@@ -123,7 +138,11 @@ pub struct NotUnpinStruct<T, U> {
 #[derive(Debug)]
 pub struct NotUnpinTupleStruct<T, U>(#[pin] pub T, pub U);
 
-#[::pin_project::pin_project(!Unpin)]
+#[::pin_project::pin_project(
+    !Unpin,
+    project = NotUnpinEnumProj,
+    project_ref = NotUnpinEnumProjRef,
+)]
 #[derive(Debug)]
 pub enum NotUnpinEnum<T, U> {
     Struct {

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -67,7 +67,11 @@ pub mod clippy {
     pub struct MutMutTupleStruct<'a, T, U>(#[pin] &'a mut T, &'a mut U);
 
     #[rustversion::attr(before(1.37), allow(single_use_lifetimes))] // https://github.com/rust-lang/rust/issues/53738
-    #[pin_project(project_replace)]
+    #[pin_project(
+        project = MutMutProjEnum,
+        project_ref = MutMutEnumProjRef,
+        project_replace = MutMutEnumProjOwn,
+    )]
     #[derive(Debug)]
     pub enum MutMutEnum<'a, T, U> {
         Struct {
@@ -96,7 +100,11 @@ pub mod clippy {
     where
         Self: Sized;
 
-    #[pin_project(project_replace)]
+    #[pin_project(
+        project = TypeRepetitionInBoundsProjEnum,
+        project_ref = TypeRepetitionInBoundsEnumProjRef,
+        project_replace = TypeRepetitionInBoundsEnumProjOwn,
+    )]
     #[derive(Debug)]
     pub enum TypeRepetitionInBoundsEnum<T, U>
     where
@@ -111,7 +119,11 @@ pub mod clippy {
         Unit,
     }
 
-    #[pin_project(project_replace)]
+    #[pin_project(
+        project = UsedUnderscoreBindingStructProj,
+        project_ref = UsedUnderscoreBindingStructProjRef,
+        project_replace = UsedUnderscoreBindingStructProjOwn,
+    )]
     #[derive(Debug)]
     pub struct UsedUnderscoreBindingStruct<T, U> {
         #[pin]
@@ -119,7 +131,11 @@ pub mod clippy {
         pub _unpinned: U,
     }
 
-    #[pin_project(project_replace)]
+    #[pin_project(
+        project = UsedUnderscoreBindingEnumProj,
+        project_ref = UsedUnderscoreBindingEnumProjRef,
+        project_replace = UsedUnderscoreBindingEnumProjOwn,
+    )]
     #[derive(Debug)]
     pub enum UsedUnderscoreBindingEnum<T, U> {
         Struct {

--- a/tests/pin_project.rs
+++ b/tests/pin_project.rs
@@ -62,7 +62,7 @@ fn projection() {
     let y: &mut i32 = s.1;
     assert_eq!(*y, 2);
 
-    #[pin_project(project_replace, project = EnumProj)]
+    #[pin_project(project = EnumProj, project_ref = EnumProjRef, project_replace = EnumProjOwn)]
     #[derive(Eq, PartialEq, Debug)]
     enum Enum<A, B, C, D> {
         Tuple(#[pin] A, B),
@@ -121,7 +121,7 @@ fn projection() {
 
 #[test]
 fn enum_project_set() {
-    #[pin_project(project_replace, project = EnumProj)]
+    #[pin_project(project = EnumProj, project_ref = EnumProjRef, project_replace = EnumProjOwn)]
     #[derive(Eq, PartialEq, Debug)]
     enum Enum {
         V1(#[pin] u8),
@@ -158,7 +158,7 @@ fn where_clause() {
     where
         T: Copy;
 
-    #[pin_project]
+    #[pin_project(project = EnumProj, project_ref = EnumProjRef, project_replace = EnumProjOwn)]
     enum EnumWhere<T>
     where
         T: Copy,
@@ -206,7 +206,7 @@ fn where_clause_and_associated_type_field() {
     where
         I: Iterator;
 
-    #[pin_project(project_replace)]
+    #[pin_project(project = EnumProj, project_ref = EnumProjRef, project_replace = EnumProjOwn)]
     enum Enum<I>
     where
         I: Iterator,
@@ -241,7 +241,7 @@ fn move_out() {
     let x = Struct { f: NotCopy };
     let _val: NotCopy = x.f;
 
-    #[pin_project(project_replace)]
+    #[pin_project(project = EnumProj, project_ref = EnumProjRef, project_replace = EnumProjOwn)]
     enum Enum {
         V(NotCopy),
     }
@@ -305,7 +305,7 @@ fn trait_bounds_on_type_generics() {
     #[pin_project(project_replace)]
     pub struct TupleStruct<'a, T: ?Sized>(&'a mut T);
 
-    #[pin_project(project_replace)]
+    #[pin_project(project = EnumProj, project_ref = EnumProjRef, project_replace = EnumProjOwn)]
     enum Enum<'a, T: ?Sized> {
         V(&'a mut T),
     }
@@ -408,7 +408,7 @@ fn lifetime_project() {
         unpinned: U,
     }
 
-    #[pin_project(project_replace, project = EnumProj, project_ref = EnumProjRef)]
+    #[pin_project(project = EnumProj, project_ref = EnumProjRef, project_replace = EnumProjOwn)]
     enum Enum<T, U> {
         V {
             #[pin]
@@ -466,7 +466,7 @@ fn lifetime_project_elided() {
         unpinned: U,
     }
 
-    #[pin_project(project_replace, project = EnumProj, project_ref = EnumProjRef)]
+    #[pin_project(project = EnumProj, project_ref = EnumProjRef, project_replace = EnumProjOwn)]
     enum Enum<T, U> {
         V {
             #[pin]
@@ -779,7 +779,7 @@ fn parse_self() {
         type Assoc = Self;
     }
 
-    #[pin_project(project_replace)]
+    #[pin_project(project = EnumProj, project_ref = EnumProjRef, project_replace = EnumProjOwn)]
     enum Enum {
         Struct {
             _f1: Box<Self>,

--- a/tests/pinned_drop.rs
+++ b/tests/pinned_drop.rs
@@ -143,7 +143,7 @@ fn self_struct() {
 #[rustversion::since(1.37)] // type_alias_enum_variants requires Rust 1.37
 #[test]
 fn self_enum() {
-    #[pin_project(PinnedDrop)]
+    #[pin_project(PinnedDrop, project = EnumProj, project_ref = EnumProjRef)]
     pub enum Enum {
         Struct { f: () },
         Tuple(()),

--- a/tests/ui/pin_project/invalid.rs
+++ b/tests/ui/pin_project/invalid.rs
@@ -186,6 +186,11 @@ mod pin_project_argument {
 
     #[pin_project(project_replace = !)] //~ ERROR expected identifier
     struct ProjectReplace3(#[pin] ());
+
+    #[pin_project(project_replace)] //~ ERROR `project_replace` argument requires a value when used on enums
+    enum ProjectReplaceEnum {
+        V(#[pin] ()),
+    }
 }
 
 mod pin_project_conflict_naming {

--- a/tests/ui/pin_project/invalid.stderr
+++ b/tests/ui/pin_project/invalid.stderr
@@ -244,109 +244,115 @@ error: expected identifier
 187 |     #[pin_project(project_replace = !)] //~ ERROR expected identifier
     |                                     ^
 
-error: name `OrigAndProj` is the same as the original type name
-   --> $DIR/invalid.rs:194:29
+error: `project_replace` argument requires a value when used on enums
+   --> $DIR/invalid.rs:190:19
     |
-194 |     #[pin_project(project = OrigAndProj)] //~ ERROR name `OrigAndProj` is the same as the original type name
+190 |     #[pin_project(project_replace)] //~ ERROR `project_replace` argument requires a value when used on enums
+    |                   ^^^^^^^^^^^^^^^
+
+error: name `OrigAndProj` is the same as the original type name
+   --> $DIR/invalid.rs:199:29
+    |
+199 |     #[pin_project(project = OrigAndProj)] //~ ERROR name `OrigAndProj` is the same as the original type name
     |                             ^^^^^^^^^^^
 
 error: name `OrigAndProjRef` is the same as the original type name
-   --> $DIR/invalid.rs:197:33
+   --> $DIR/invalid.rs:202:33
     |
-197 |     #[pin_project(project_ref = OrigAndProjRef)] //~ ERROR name `OrigAndProjRef` is the same as the original type name
+202 |     #[pin_project(project_ref = OrigAndProjRef)] //~ ERROR name `OrigAndProjRef` is the same as the original type name
     |                                 ^^^^^^^^^^^^^^
 
 error: name `OrigAndProjOwn` is the same as the original type name
-   --> $DIR/invalid.rs:200:37
+   --> $DIR/invalid.rs:205:37
     |
-200 |     #[pin_project(project_replace = OrigAndProjOwn)] //~ ERROR name `OrigAndProjOwn` is the same as the original type name
+205 |     #[pin_project(project_replace = OrigAndProjOwn)] //~ ERROR name `OrigAndProjOwn` is the same as the original type name
     |                                     ^^^^^^^^^^^^^^
 
 error: name `A` is already specified by `project` argument
-   --> $DIR/invalid.rs:203:46
+   --> $DIR/invalid.rs:208:46
     |
-203 |     #[pin_project(project = A, project_ref = A)] //~ ERROR name `A` is already specified by `project` argument
+208 |     #[pin_project(project = A, project_ref = A)] //~ ERROR name `A` is already specified by `project` argument
     |                                              ^
 
 error: name `A` is already specified by `project` argument
-   --> $DIR/invalid.rs:206:50
+   --> $DIR/invalid.rs:211:50
     |
-206 |     #[pin_project(project = A, project_replace = A)] //~ ERROR name `A` is already specified by `project` argument
+211 |     #[pin_project(project = A, project_replace = A)] //~ ERROR name `A` is already specified by `project` argument
     |                                                  ^
 
 error: name `A` is already specified by `project_ref` argument
-   --> $DIR/invalid.rs:209:54
+   --> $DIR/invalid.rs:214:54
     |
-209 |     #[pin_project(project_ref = A, project_replace = A)] //~ ERROR name `A` is already specified by `project_ref` argument
+214 |     #[pin_project(project_ref = A, project_replace = A)] //~ ERROR name `A` is already specified by `project_ref` argument
     |                                                      ^
 
 error: duplicate #[pin_project] attribute
-   --> $DIR/invalid.rs:217:5
+   --> $DIR/invalid.rs:222:5
     |
-217 |     #[pin_project] //~ ERROR duplicate #[pin_project] attribute
+222 |     #[pin_project] //~ ERROR duplicate #[pin_project] attribute
     |     ^^^^^^^^^^^^^^
 
 error: #[pin_project] attribute may not be used on structs with zero fields
-   --> $DIR/invalid.rs:225:19
+   --> $DIR/invalid.rs:230:19
     |
-225 |     struct Struct {} //~ ERROR may not be used on structs with zero fields
+230 |     struct Struct {} //~ ERROR may not be used on structs with zero fields
     |                   ^^
 
 error: #[pin_project] attribute may not be used on structs with zero fields
-   --> $DIR/invalid.rs:228:23
+   --> $DIR/invalid.rs:233:23
     |
-228 |     struct TupleStruct(); //~ ERROR may not be used on structs with zero fields
+233 |     struct TupleStruct(); //~ ERROR may not be used on structs with zero fields
     |                       ^^
 
 error: #[pin_project] attribute may not be used on structs with zero fields
-   --> $DIR/invalid.rs:231:12
+   --> $DIR/invalid.rs:236:12
     |
-231 |     struct UnitStruct; //~ ERROR may not be used on structs with zero fields
+236 |     struct UnitStruct; //~ ERROR may not be used on structs with zero fields
     |            ^^^^^^^^^^
 
 error: #[pin_project] attribute may not be used on enums without variants
-   --> $DIR/invalid.rs:234:20
+   --> $DIR/invalid.rs:239:20
     |
-234 |     enum EnumEmpty {} //~ ERROR may not be used on enums without variants
+239 |     enum EnumEmpty {} //~ ERROR may not be used on enums without variants
     |                    ^^
 
 error: #[pin_project] attribute may not be used on enums with discriminants
-   --> $DIR/invalid.rs:238:13
+   --> $DIR/invalid.rs:243:13
     |
-238 |         V = 2, //~ ERROR may not be used on enums with discriminants
+243 |         V = 2, //~ ERROR may not be used on enums with discriminants
     |             ^
 
 error: #[pin_project] attribute may not be used on enums with zero fields
-   --> $DIR/invalid.rs:243:9
+   --> $DIR/invalid.rs:248:9
     |
-243 | /         Unit, //~ ERROR may not be used on enums with zero fields
-244 | |         Tuple(),
-245 | |         Struct {},
+248 | /         Unit, //~ ERROR may not be used on enums with zero fields
+249 | |         Tuple(),
+250 | |         Struct {},
     | |__________________^
 
 error: #[pin_project] attribute may only be used on structs or enums
-   --> $DIR/invalid.rs:249:5
+   --> $DIR/invalid.rs:254:5
     |
-249 | /     union Union {
-250 | |         //~^ ERROR may only be used on structs or enums
-251 | |         f: (),
-252 | |     }
+254 | /     union Union {
+255 | |         //~^ ERROR may only be used on structs or enums
+256 | |         f: (),
+257 | |     }
     | |_____^
 
 error: #[pin_project] attribute may not be used on #[repr(packed)] types
-   --> $DIR/invalid.rs:260:12
+   --> $DIR/invalid.rs:265:12
     |
-260 |     #[repr(packed)]
+265 |     #[repr(packed)]
     |            ^^^^^^
 
 error: #[pin_project] attribute may not be used on #[repr(packed)] types
-   --> $DIR/invalid.rs:264:12
+   --> $DIR/invalid.rs:269:12
     |
-264 |     #[repr(packed)]
+269 |     #[repr(packed)]
     |            ^^^^^^
 
 error: #[pin_project] attribute may not be used on #[repr(packed)] types
-   --> $DIR/invalid.rs:268:12
+   --> $DIR/invalid.rs:273:12
     |
-268 |     #[repr(packed)]
+273 |     #[repr(packed)]
     |            ^^^^^^


### PR DESCRIPTION
When `#[pin_project]` is used on enums, only named projection types and methods are generated because there is no way to access variants of projected types without naming it. (When `#[pin_project]` is used on structs, both methods are always generated.)

Addresses https://github.com/taiki-e/pin-project/pull/268#discussion_r484313531