### PR TITLE
Fix compatibility of generated code with forbid(future_incompatible)

### DIFF
--- a/examples/not_unpin-expanded.rs
+++ b/examples/not_unpin-expanded.rs
@@ -131,7 +131,7 @@ const _: () = {
     //
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
     // for details.
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/examples/pinned_drop-expanded.rs
+++ b/examples/pinned_drop-expanded.rs
@@ -133,7 +133,7 @@ const _: () = {
     //
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
     // for details.
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<'a, T>(this: &Struct<'a, T>) {
         let _ = &this.was_dropped;
         let _ = &this.field;

--- a/examples/project_replace-expanded.rs
+++ b/examples/project_replace-expanded.rs
@@ -172,7 +172,7 @@ const _: () = {
     //
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
     // for details.
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/examples/struct-default-expanded.rs
+++ b/examples/struct-default-expanded.rs
@@ -156,7 +156,7 @@ const _: () = {
     // struct.
     //
     // Taking a reference to a packed field is unsafe, and applying
-    // #[deny(safe_packed_borrows)] makes sure that doing this without
+    // #[forbid(safe_packed_borrows)] makes sure that doing this without
     // an 'unsafe' block (which we deliberately do not generate)
     // is a hard error.
     //
@@ -166,7 +166,7 @@ const _: () = {
     // a much nicer error above.
     //
     // See https://github.com/taiki-e/pin-project/pull/34 for more details.
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/examples/unsafe_unpin-expanded.rs
+++ b/examples/unsafe_unpin-expanded.rs
@@ -114,7 +114,7 @@ const _: () = {
     //
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
     // for details.
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -1267,7 +1267,7 @@ impl<'a> Context<'a> {
         // struct, we generate code like this:
         //
         // ```rust
-        // #[deny(safe_packed_borrows)]
+        // #[forbid(safe_packed_borrows)]
         // fn assert_not_repr_packed(val: &MyStruct) {
         //     let _field1 = &val.field1;
         //     let _field2 = &val.field2;
@@ -1277,7 +1277,7 @@ impl<'a> Context<'a> {
         // ```
         //
         // Taking a reference to a packed field is unsafe, and applying
-        // `#[deny(safe_packed_borrows)]` makes sure that doing this without
+        // `#[forbid(safe_packed_borrows)]` makes sure that doing this without
         // an `unsafe` block (which we deliberately do not generate)
         // is a hard error.
         //
@@ -1318,7 +1318,7 @@ impl<'a> Context<'a> {
         let (impl_generics, ty_generics, where_clause) = self.orig.generics.split_for_impl();
         let ident = self.orig.ident;
         Ok(quote! {
-            #[deny(safe_packed_borrows)]
+            #[forbid(safe_packed_borrows)]
             fn __assert_not_repr_packed #impl_generics (this: &#ident #ty_generics) #where_clause {
                 #(let _ = #field_refs;)*
             }

--- a/tests/expand/tests/expand/default-struct.expanded.rs
+++ b/tests/expand/tests/expand/default-struct.expanded.rs
@@ -91,7 +91,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/tests/expand/default-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/default-tuple_struct.expanded.rs
@@ -79,7 +79,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/tests/expand/naming-struct-all.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct-all.expanded.rs
@@ -120,7 +120,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/tests/expand/naming-struct-mut.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct-mut.expanded.rs
@@ -89,7 +89,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/tests/expand/naming-struct-none.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct-none.expanded.rs
@@ -91,7 +91,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/tests/expand/naming-struct-own.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct-own.expanded.rs
@@ -122,7 +122,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/tests/expand/naming-struct-ref.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct-ref.expanded.rs
@@ -91,7 +91,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/tests/expand/naming-tuple_struct-all.expanded.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct-all.expanded.rs
@@ -99,7 +99,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/tests/expand/naming-tuple_struct-mut.expanded.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct-mut.expanded.rs
@@ -74,7 +74,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/tests/expand/naming-tuple_struct-none.expanded.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct-none.expanded.rs
@@ -79,7 +79,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/tests/expand/naming-tuple_struct-own.expanded.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct-own.expanded.rs
@@ -107,7 +107,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/tests/expand/naming-tuple_struct-ref.expanded.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct-ref.expanded.rs
@@ -76,7 +76,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/tests/expand/not_unpin-struct.expanded.rs
+++ b/tests/expand/tests/expand/not_unpin-struct.expanded.rs
@@ -83,7 +83,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/tests/expand/not_unpin-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/not_unpin-tuple_struct.expanded.rs
@@ -71,7 +71,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/tests/expand/pinned_drop-struct.expanded.rs
+++ b/tests/expand/tests/expand/pinned_drop-struct.expanded.rs
@@ -92,7 +92,7 @@ const _: () = {
             }
         }
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/tests/expand/pinned_drop-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/pinned_drop-tuple_struct.expanded.rs
@@ -80,7 +80,7 @@ const _: () = {
             }
         }
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/tests/expand/project_replace-struct.expanded.rs
+++ b/tests/expand/tests/expand/project_replace-struct.expanded.rs
@@ -122,7 +122,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/tests/expand/project_replace-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/project_replace-tuple_struct.expanded.rs
@@ -107,7 +107,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/tests/expand/pub-struct.expanded.rs
+++ b/tests/expand/tests/expand/pub-struct.expanded.rs
@@ -91,7 +91,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/tests/expand/pub-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/pub-tuple_struct.expanded.rs
@@ -79,7 +79,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/tests/expand/unsafe_unpin-struct.expanded.rs
+++ b/tests/expand/tests/expand/unsafe_unpin-struct.expanded.rs
@@ -76,7 +76,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/tests/expand/unsafe_unpin-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/unsafe_unpin-tuple_struct.expanded.rs
@@ -64,7 +64,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -1,4 +1,7 @@
-#![warn(future_incompatible, nonstandard_style, rust_2018_compatibility, rust_2018_idioms, unused)]
+#![warn(nonstandard_style, rust_2018_compatibility, rust_2018_idioms, unused)]
+// Note: This does not guarantee compatibility with `forbid(future_incompatible)` in the future.
+// If rustc adds a new lint, we may not be able to keep this.
+#![forbid(future_incompatible)]
 #![allow(unknown_lints)] // for old compilers
 #![warn(
     absolute_paths_not_starting_with_crate,

--- a/tests/repr_packed.rs
+++ b/tests/repr_packed.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms, single_use_lifetimes)]
-#![deny(safe_packed_borrows)]
+#![forbid(safe_packed_borrows)]
 
 use std::cell::Cell;
 

--- a/tests/ui/pin_project/safe_packed_borrows.rs
+++ b/tests/ui/pin_project/safe_packed_borrows.rs
@@ -1,4 +1,4 @@
-#![deny(safe_packed_borrows)]
+#![forbid(safe_packed_borrows)]
 
 // Refs: https://github.com/rust-lang/rust/issues/46043
 

--- a/tests/ui/pin_project/safe_packed_borrows.stderr
+++ b/tests/ui/pin_project/safe_packed_borrows.stderr
@@ -5,10 +5,10 @@ error: borrow of packed field is unsafe and requires unsafe function or block (e
    |     ^^^^
    |
 note: the lint level is defined here
-  --> $DIR/safe_packed_borrows.rs:1:9
+  --> $DIR/safe_packed_borrows.rs:1:11
    |
-1  | #![deny(safe_packed_borrows)]
-   |         ^^^^^^^^^^^^^^^^^^^
+1  | #![forbid(safe_packed_borrows)]
+   |           ^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #46043 <https://github.com/rust-lang/rust/issues/46043>
    = note: fields of packed structs might be misaligned: dereferencing a misaligned pointer or even just creating a misaligned reference is undefined behavior


### PR DESCRIPTION
Note: This does not guarantee compatibility with `forbid(future_incompatible)` in the future.
If rustc adds a new lint, we may not be able to keep this.

cc #281 