### PR TITLE
v0.4: Fix compatibility of generated code with forbid(future_incompatible)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - master
       - staging
       - trying
+      - v0.4
   schedule:
     - cron: '00 01 * * *'
 

--- a/examples/not_unpin-expanded.rs
+++ b/examples/not_unpin-expanded.rs
@@ -116,7 +116,7 @@ const _: () = {
     //
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
     // for details.
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
         &val.pinned;
         &val.unpinned;

--- a/examples/pinned_drop-expanded.rs
+++ b/examples/pinned_drop-expanded.rs
@@ -121,7 +121,7 @@ const _: () = {
     //
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
     // for details.
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<'a, T>(val: &Struct<'a, T>) {
         &val.was_dropped;
         &val.field;

--- a/examples/project_replace-expanded.rs
+++ b/examples/project_replace-expanded.rs
@@ -155,7 +155,7 @@ const _: () = {
     //
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
     // for details.
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
         &val.pinned;
         &val.unpinned;

--- a/examples/struct-default-expanded.rs
+++ b/examples/struct-default-expanded.rs
@@ -144,7 +144,7 @@ const _: () = {
     // struct.
     //
     // Taking a reference to a packed field is unsafe, and applying
-    // #[deny(safe_packed_borrows)] makes sure that doing this without
+    // #[forbid(safe_packed_borrows)] makes sure that doing this without
     // an 'unsafe' block (which we deliberately do not generate)
     // is a hard error.
     //
@@ -154,7 +154,7 @@ const _: () = {
     // a much nicer error above.
     //
     // See https://github.com/taiki-e/pin-project/pull/34 for more details.
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
         &val.pinned;
         &val.unpinned;

--- a/examples/unsafe_unpin-expanded.rs
+++ b/examples/unsafe_unpin-expanded.rs
@@ -103,7 +103,7 @@ const _: () = {
     //
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
     // for details.
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
         &val.pinned;
         &val.unpinned;

--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -1166,7 +1166,7 @@ impl<'a> Context<'a> {
         // struct, we generate code like this:
         //
         // ```rust
-        // #[deny(safe_packed_borrows)]
+        // #[forbid(safe_packed_borrows)]
         // fn assert_not_repr_packed(val: &MyStruct) {
         //     let _field1 = &val.field1;
         //     let _field2 = &val.field2;
@@ -1176,7 +1176,7 @@ impl<'a> Context<'a> {
         // ```
         //
         // Taking a reference to a packed field is unsafe, and applying
-        // `#[deny(safe_packed_borrows)]` makes sure that doing this without
+        // `#[forbid(safe_packed_borrows)]` makes sure that doing this without
         // an `unsafe` block (which we deliberately do not generate)
         // is a hard error.
         //
@@ -1217,7 +1217,7 @@ impl<'a> Context<'a> {
         let (impl_generics, ty_generics, where_clause) = self.orig.generics.split_for_impl();
         let ident = self.orig.ident;
         Ok(quote! {
-            #[deny(safe_packed_borrows)]
+            #[forbid(safe_packed_borrows)]
             fn __assert_not_repr_packed #impl_generics (val: &#ident #ty_generics) #where_clause {
                 #(#field_refs)*
             }

--- a/tests/expand/tests/expand/default-struct.expanded.rs
+++ b/tests/expand/tests/expand/default-struct.expanded.rs
@@ -79,7 +79,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
         &val.pinned;
         &val.unpinned;

--- a/tests/expand/tests/expand/default-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/default-tuple_struct.expanded.rs
@@ -64,7 +64,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
         &val.0;
         &val.1;

--- a/tests/expand/tests/expand/naming-enum.expanded.rs
+++ b/tests/expand/tests/expand/naming-enum.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::pin_project;
-# [ pin ( __private ( project = Proj , project_ref = ProjRef , project_replace = ProjOwn ) ) ]
+# [pin (__private (project = Proj , project_ref = ProjRef , project_replace = ProjOwn))]
 enum Enum<T, U> {
     Struct {
         #[pin]

--- a/tests/expand/tests/expand/naming-struct.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::pin_project;
-# [ pin ( __private ( project = Proj , project_ref = ProjRef , project_replace = ProjOwn ) ) ]
+# [pin (__private (project = Proj , project_ref = ProjRef , project_replace = ProjOwn))]
 struct Struct<T, U> {
     #[pin]
     pinned: T,
@@ -103,7 +103,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
         &val.pinned;
         &val.unpinned;

--- a/tests/expand/tests/expand/naming-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::pin_project;
-# [ pin ( __private ( project = Proj , project_ref = ProjRef , project_replace = ProjOwn ) ) ]
+# [pin (__private (project = Proj , project_ref = ProjRef , project_replace = ProjOwn))]
 struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(dead_code)]
 #[allow(single_use_lifetimes)]
@@ -82,7 +82,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
         &val.0;
         &val.1;

--- a/tests/expand/tests/expand/not_unpin-enum.expanded.rs
+++ b/tests/expand/tests/expand/not_unpin-enum.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::pin_project;
-# [ pin ( __private ( ! Unpin ) ) ]
+# [pin (__private (! Unpin))]
 enum Enum<T, U> {
     Struct {
         #[pin]

--- a/tests/expand/tests/expand/not_unpin-struct.expanded.rs
+++ b/tests/expand/tests/expand/not_unpin-struct.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::pin_project;
-# [ pin ( __private ( ! Unpin ) ) ]
+# [pin (__private (! Unpin))]
 struct Struct<T, U> {
     #[pin]
     pinned: T,
@@ -70,7 +70,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
         &val.pinned;
         &val.unpinned;

--- a/tests/expand/tests/expand/not_unpin-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/not_unpin-tuple_struct.expanded.rs
@@ -1,5 +1,5 @@
 use pin_project::pin_project;
-# [ pin ( __private ( ! Unpin ) ) ]
+# [pin (__private (! Unpin))]
 struct TupleStruct<T, U>(#[pin] T, U);
 #[doc(hidden)]
 #[allow(dead_code)]
@@ -55,7 +55,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
         &val.0;
         &val.1;

--- a/tests/expand/tests/expand/pinned_drop-struct.expanded.rs
+++ b/tests/expand/tests/expand/pinned_drop-struct.expanded.rs
@@ -81,7 +81,7 @@ const _: () = {
             }
         }
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
         &val.pinned;
         &val.unpinned;

--- a/tests/expand/tests/expand/pinned_drop-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/pinned_drop-tuple_struct.expanded.rs
@@ -66,7 +66,7 @@ const _: () = {
             }
         }
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
         &val.0;
         &val.1;

--- a/tests/expand/tests/expand/project_replace-struct.expanded.rs
+++ b/tests/expand/tests/expand/project_replace-struct.expanded.rs
@@ -108,7 +108,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
         &val.pinned;
         &val.unpinned;

--- a/tests/expand/tests/expand/project_replace-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/project_replace-tuple_struct.expanded.rs
@@ -90,7 +90,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
         &val.0;
         &val.1;

--- a/tests/expand/tests/expand/pub-struct.expanded.rs
+++ b/tests/expand/tests/expand/pub-struct.expanded.rs
@@ -79,7 +79,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
         &val.pinned;
         &val.unpinned;

--- a/tests/expand/tests/expand/pub-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/pub-tuple_struct.expanded.rs
@@ -67,7 +67,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
         &val.0;
         &val.1;

--- a/tests/expand/tests/expand/unsafe_unpin-struct.expanded.rs
+++ b/tests/expand/tests/expand/unsafe_unpin-struct.expanded.rs
@@ -68,7 +68,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
         &val.pinned;
         &val.unpinned;

--- a/tests/expand/tests/expand/unsafe_unpin-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/unsafe_unpin-tuple_struct.expanded.rs
@@ -53,7 +53,7 @@ const _: () = {
     impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
         &val.0;
         &val.1;

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -1,5 +1,8 @@
 #![warn(rust_2018_idioms, single_use_lifetimes)]
-#![warn(future_incompatible, nonstandard_style, rust_2018_compatibility, unused)]
+#![warn(nonstandard_style, rust_2018_compatibility, unused)]
+// Note: This does not guarantee compatibility with `forbid(future_incompatible)` in the future.
+// If rustc adds a new lint, we may not be able to keep this.
+#![forbid(future_incompatible)]
 #![warn(clippy::all, clippy::pedantic, clippy::nursery)]
 #![allow(unknown_lints)] // for old compilers
 #![warn(

--- a/tests/lint.txt
+++ b/tests/lint.txt
@@ -51,6 +51,8 @@ Lint checks provided by rustc:
                                clashing-extern-declarations  warn     detects when an extern fn has been declared with the same name but different types
                                        coherence-leak-check  warn     distinct impls distinguished only by the leak-check code
                                           confusable-idents  warn     detects visually confusable pairs between identifiers
+                                const-evaluatable-unchecked  warn     detects a generic constant is used in a type without a emitting a warning
+                                        const-item-mutation  warn     detects attempts to mutate a `const` item
                                                   dead-code  warn     detect unused, unexported items
                                                  deprecated  warn     detects use of deprecated items
                           ellipsis-inclusive-range-patterns  warn     `...` range patterns are deprecated
@@ -131,7 +133,7 @@ Lint groups provided by rustc:
                        name  sub-lints
                        ----  ---------
                    warnings  all lints that are set to issue warnings
-        future-incompatible  keyword-idents, anonymous-parameters, illegal-floating-point-literal-pattern, private-in-public, pub-use-of-private-extern-crate, invalid-type-param-default, safe-packed-borrows, patterns-in-fns-without-body, late-bound-lifetime-arguments, order-dependent-trait-objects, coherence-leak-check, tyvar-behind-raw-pointer, absolute-paths-not-starting-with-crate, unstable-name-collisions, where-clauses-object-safety, proc-macro-derive-resolution-fallback, macro-expanded-macro-exports-accessed-by-absolute-paths, ill-formed-attribute-input, conflicting-repr-hints, ambiguous-associated-items, mutable-borrow-reservation-conflict, indirect-structural-match, soft-unstable, cenum-impl-drop-cast, array-into-iter
+        future-incompatible  keyword-idents, anonymous-parameters, illegal-floating-point-literal-pattern, private-in-public, pub-use-of-private-extern-crate, invalid-type-param-default, safe-packed-borrows, patterns-in-fns-without-body, late-bound-lifetime-arguments, order-dependent-trait-objects, coherence-leak-check, tyvar-behind-raw-pointer, absolute-paths-not-starting-with-crate, unstable-name-collisions, where-clauses-object-safety, proc-macro-derive-resolution-fallback, macro-expanded-macro-exports-accessed-by-absolute-paths, ill-formed-attribute-input, conflicting-repr-hints, ambiguous-associated-items, mutable-borrow-reservation-conflict, indirect-structural-match, soft-unstable, cenum-impl-drop-cast, const-evaluatable-unchecked, array-into-iter
           nonstandard-style  non-camel-case-types, non-snake-case, non-upper-case-globals
     rust-2018-compatibility  keyword-idents, anonymous-parameters, tyvar-behind-raw-pointer, absolute-paths-not-starting-with-crate
            rust-2018-idioms  bare-trait-objects, unused-extern-crates, ellipsis-inclusive-range-patterns, elided-lifetimes-in-paths, explicit-outlives-requirements

--- a/tests/repr_packed.rs
+++ b/tests/repr_packed.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms, single_use_lifetimes)]
-#![deny(safe_packed_borrows)]
+#![forbid(safe_packed_borrows)]
 
 use std::cell::Cell;
 

--- a/tests/ui/cfg/cfg_attr-resolve.stderr
+++ b/tests/ui/cfg/cfg_attr-resolve.stderr
@@ -1,5 +1,5 @@
-error[E0599]: no method named `project` found for struct `std::pin::Pin<&mut Foo<u8>>` in the current scope
+error[E0599]: no method named `project` found for struct `Pin<&mut Foo<u8>>` in the current scope
   --> $DIR/cfg_attr-resolve.rs:10:31
    |
 10 |     let _x = Pin::new(&mut x).project(); //~ ERROR E0599
-   |                               ^^^^^^^ method not found in `std::pin::Pin<&mut Foo<u8>>`
+   |                               ^^^^^^^ method not found in `Pin<&mut Foo<u8>>`

--- a/tests/ui/cfg/cfg_attr-type-mismatch.stderr
+++ b/tests/ui/cfg/cfg_attr-type-mismatch.stderr
@@ -2,11 +2,11 @@ error[E0308]: mismatched types
   --> $DIR/cfg_attr-type-mismatch.rs:19:27
    |
 19 |     let _: Pin<&mut u8> = x.inner; //~ ERROR E0308
-   |            ------------   ^^^^^^^ expected struct `std::pin::Pin`, found `&mut u8`
+   |            ------------   ^^^^^^^ expected struct `Pin`, found `&mut u8`
    |            |
    |            expected due to this
    |
-   = note:         expected struct `std::pin::Pin<&mut u8>`
+   = note:         expected struct `Pin<&mut u8>`
            found mutable reference `&mut u8`
 
 error[E0308]: mismatched types
@@ -15,9 +15,9 @@ error[E0308]: mismatched types
 23 |     let _: &mut u8 = x.inner; //~ ERROR E0308
    |            -------   ^^^^^^^
    |            |         |
-   |            |         expected `&mut u8`, found struct `std::pin::Pin`
+   |            |         expected `&mut u8`, found struct `Pin`
    |            |         help: consider mutably borrowing here: `&mut x.inner`
    |            expected due to this
    |
    = note: expected mutable reference `&mut u8`
-                         found struct `std::pin::Pin<&mut u8>`
+                         found struct `Pin<&mut u8>`

--- a/tests/ui/cfg/cfg_attr-unpin.stderr
+++ b/tests/ui/cfg/cfg_attr-unpin.stderr
@@ -1,22 +1,22 @@
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/cfg_attr-unpin.rs:18:5
    |
 15 | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 18 |     is_unpin::<Foo<PhantomPinned>>(); // ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `Foo<std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `Foo<PhantomPinned>`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `Foo<std::marker::PhantomPinned>`
+   = note: required because it appears within the type `Foo<PhantomPinned>`
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/cfg_attr-unpin.rs:20:5
    |
 15 | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 20 |     is_unpin::<Bar<PhantomPinned>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `_::__Bar<'_, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `__Bar<'_, PhantomPinned>`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `_::__Bar<'_, std::marker::PhantomPinned>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Bar<std::marker::PhantomPinned>`
+   = note: required because it appears within the type `__Bar<'_, PhantomPinned>`
+   = note: required because of the requirements on the impl of `Unpin` for `Bar<PhantomPinned>`

--- a/tests/ui/cfg/proper_unpin.stderr
+++ b/tests/ui/cfg/proper_unpin.stderr
@@ -1,11 +1,11 @@
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/proper_unpin.rs:27:5
    |
 22 | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 27 |     is_unpin::<Bar<PhantomPinned>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `_::__Bar<'_, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `__Bar<'_, PhantomPinned>`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `_::__Bar<'_, std::marker::PhantomPinned>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Bar<std::marker::PhantomPinned>`
+   = note: required because it appears within the type `__Bar<'_, PhantomPinned>`
+   = note: required because of the requirements on the impl of `Unpin` for `Bar<PhantomPinned>`

--- a/tests/ui/not_unpin/assert-not-unpin.stderr
+++ b/tests/ui/not_unpin/assert-not-unpin.stderr
@@ -1,83 +1,83 @@
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/assert-not-unpin.rs:31:5
    |
 28 | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 31 |     is_unpin::<Foo<(), ()>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ within `pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ within `Wrapper<'_, PhantomPinned>`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Foo<(), ()>`
+   = note: required because it appears within the type `Wrapper<'_, PhantomPinned>`
+   = note: required because of the requirements on the impl of `Unpin` for `Foo<(), ()>`
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/assert-not-unpin.rs:32:5
    |
 28 | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 32 |     is_unpin::<Foo<PhantomPinned, ()>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `Wrapper<'_, PhantomPinned>`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Foo<std::marker::PhantomPinned, ()>`
+   = note: required because it appears within the type `Wrapper<'_, PhantomPinned>`
+   = note: required because of the requirements on the impl of `Unpin` for `Foo<PhantomPinned, ()>`
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/assert-not-unpin.rs:33:5
    |
 28 | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 33 |     is_unpin::<Foo<(), PhantomPinned>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `Wrapper<'_, PhantomPinned>`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Foo<(), std::marker::PhantomPinned>`
+   = note: required because it appears within the type `Wrapper<'_, PhantomPinned>`
+   = note: required because of the requirements on the impl of `Unpin` for `Foo<(), PhantomPinned>`
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/assert-not-unpin.rs:34:5
    |
 28 | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 34 |     is_unpin::<Foo<PhantomPinned, PhantomPinned>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `Wrapper<'_, PhantomPinned>`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Foo<std::marker::PhantomPinned, std::marker::PhantomPinned>`
+   = note: required because it appears within the type `Wrapper<'_, PhantomPinned>`
+   = note: required because of the requirements on the impl of `Unpin` for `Foo<PhantomPinned, PhantomPinned>`
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/assert-not-unpin.rs:36:5
    |
 28 | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 36 |     is_unpin::<TrivialBounds>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ within `pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ within `Wrapper<'_, PhantomPinned>`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `TrivialBounds`
+   = note: required because it appears within the type `Wrapper<'_, PhantomPinned>`
+   = note: required because of the requirements on the impl of `Unpin` for `TrivialBounds`
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/assert-not-unpin.rs:38:5
    |
 28 | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 38 |     is_unpin::<Bar<'_, (), ()>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `Wrapper<'_, PhantomPinned>`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Bar<'_, (), ()>`
+   = note: required because it appears within the type `Wrapper<'_, PhantomPinned>`
+   = note: required because of the requirements on the impl of `Unpin` for `Bar<'_, (), ()>`
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/assert-not-unpin.rs:39:5
    |
 28 | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 39 |     is_unpin::<Bar<'_, PhantomPinned, PhantomPinned>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `Wrapper<'_, PhantomPinned>`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Bar<'_, std::marker::PhantomPinned, std::marker::PhantomPinned>`
+   = note: required because it appears within the type `Wrapper<'_, PhantomPinned>`
+   = note: required because of the requirements on the impl of `Unpin` for `Bar<'_, PhantomPinned, PhantomPinned>`

--- a/tests/ui/pin_project/add-pinned-field.stderr
+++ b/tests/ui/pin_project/add-pinned-field.stderr
@@ -1,23 +1,23 @@
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/add-pinned-field.rs:21:5
    |
 4  | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 21 |     is_unpin::<Foo>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^ within `_::__Foo<'_>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^ within `__Foo<'_>`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `_::__Foo<'_>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Foo`
+   = note: required because it appears within the type `__Foo<'_>`
+   = note: required because of the requirements on the impl of `Unpin` for `Foo`
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/add-pinned-field.rs:22:5
    |
 4  | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 22 |     is_unpin::<Bar>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^ within `_::__Bar<'_>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^ within `__Bar<'_>`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `_::__Bar<'_>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Bar`
+   = note: required because it appears within the type `__Bar<'_>`
+   = note: required because of the requirements on the impl of `Unpin` for `Bar`

--- a/tests/ui/pin_project/overlapping_unpin_struct.stderr
+++ b/tests/ui/pin_project/overlapping_unpin_struct.stderr
@@ -1,11 +1,11 @@
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/overlapping_unpin_struct.rs:17:5
    |
 14 | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 17 |     is_unpin::<Foo<PhantomPinned>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `_::__Foo<'_, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `_::__Foo<'_, PhantomPinned>`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `_::__Foo<'_, std::marker::PhantomPinned>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Foo<std::marker::PhantomPinned>`
+   = note: required because it appears within the type `_::__Foo<'_, PhantomPinned>`
+   = note: required because of the requirements on the impl of `Unpin` for `Foo<PhantomPinned>`

--- a/tests/ui/pin_project/project_replace_unsized.stderr
+++ b/tests/ui/pin_project/project_replace_unsized.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 3 | #[pin_project(project_replace)] //~ ERROR E0277
   |               ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
 4 | struct Struct<T: ?Sized> {
-  |               - this type parameter needs to be `std::marker::Sized`
+  |               - this type parameter needs to be `Sized`
   |
   = note: required because it appears within the type `Struct<T>`
   = help: unsized locals are gated as an unstable feature
@@ -17,7 +17,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
    --> $DIR/project_replace_unsized.rs:5:5
     |
 4   | struct Struct<T: ?Sized> {
-    |               - this type parameter needs to be `std::marker::Sized`
+    |               - this type parameter needs to be `Sized`
 5   |     x: T,
     |     ^ doesn't have a size known at compile-time
 
@@ -27,7 +27,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 3 | #[pin_project(project_replace)] //~ ERROR E0277
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
 4 | struct Struct<T: ?Sized> {
-  |               - this type parameter needs to be `std::marker::Sized`
+  |               - this type parameter needs to be `Sized`
   |
   = note: required because it appears within the type `__StructProjectionOwned<T>`
   = note: structs must have a statically known size to be initialized
@@ -39,7 +39,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 8 | #[pin_project(project_replace)] //~ ERROR E0277
   |               ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
 9 | struct TupleStruct<T: ?Sized>(T);
-  |                    - this type parameter needs to be `std::marker::Sized`
+  |                    - this type parameter needs to be `Sized`
   |
   = note: required because it appears within the type `TupleStruct<T>`
   = help: unsized locals are gated as an unstable feature
@@ -54,7 +54,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 8   | #[pin_project(project_replace)] //~ ERROR E0277
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
 9   | struct TupleStruct<T: ?Sized>(T);
-    |                    - this type parameter needs to be `std::marker::Sized`
+    |                    - this type parameter needs to be `Sized`
     |
     = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -62,7 +62,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
  --> $DIR/project_replace_unsized.rs:9:8
   |
 9 | struct TupleStruct<T: ?Sized>(T);
-  |        ^^^^^^^^^^^ - this type parameter needs to be `std::marker::Sized`
+  |        ^^^^^^^^^^^ - this type parameter needs to be `Sized`
   |        |
   |        doesn't have a size known at compile-time
   |

--- a/tests/ui/pin_project/project_replace_unsized_locals.stderr
+++ b/tests/ui/pin_project/project_replace_unsized_locals.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 6 | struct Struct<T: ?Sized> {
   |        ^^^^^^^-^^^^^^^^^
   |        |      |
-  |        |      this type parameter needs to be `std::marker::Sized`
+  |        |      this type parameter needs to be `Sized`
   |        doesn't have a size known at compile-time
   |
   = note: required because it appears within the type `__StructProjectionOwned<T>`
@@ -14,7 +14,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
    --> $DIR/project_replace_unsized_locals.rs:7:5
     |
 6   | struct Struct<T: ?Sized> {
-    |               - this type parameter needs to be `std::marker::Sized`
+    |               - this type parameter needs to be `Sized`
 7   |     x: T,
     |     ^ doesn't have a size known at compile-time
 
@@ -24,7 +24,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 5 | #[pin_project(project_replace)] //~ ERROR E0277
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
 6 | struct Struct<T: ?Sized> {
-  |               - this type parameter needs to be `std::marker::Sized`
+  |               - this type parameter needs to be `Sized`
   |
   = note: required because it appears within the type `__StructProjectionOwned<T>`
   = note: structs must have a statically known size to be initialized
@@ -36,7 +36,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 11 | struct TupleStruct<T: ?Sized>(T);
    |        ^^^^^^^^^^^^-^^^^^^^^^
    |        |           |
-   |        |           this type parameter needs to be `std::marker::Sized`
+   |        |           this type parameter needs to be `Sized`
    |        doesn't have a size known at compile-time
    |
    = note: required because it appears within the type `__TupleStructProjectionOwned<T>`
@@ -48,6 +48,6 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 10  | #[pin_project(project_replace)] //~ ERROR E0277
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
 11  | struct TupleStruct<T: ?Sized>(T);
-    |                    - this type parameter needs to be `std::marker::Sized`
+    |                    - this type parameter needs to be `Sized`
     |
     = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/pin_project/proper_unpin.stderr
+++ b/tests/ui/pin_project/proper_unpin.stderr
@@ -1,37 +1,37 @@
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/proper_unpin.rs:31:5
    |
 28 | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 31 |     is_unpin::<Foo<PhantomPinned, ()>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `_::__Foo<'_, std::marker::PhantomPinned, ()>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `__Foo<'_, PhantomPinned, ()>`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `Inner<std::marker::PhantomPinned>`
-   = note: required because it appears within the type `_::__Foo<'_, std::marker::PhantomPinned, ()>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Foo<std::marker::PhantomPinned, ()>`
+   = note: required because it appears within the type `Inner<PhantomPinned>`
+   = note: required because it appears within the type `__Foo<'_, PhantomPinned, ()>`
+   = note: required because of the requirements on the impl of `Unpin` for `Foo<PhantomPinned, ()>`
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/proper_unpin.rs:33:5
    |
 28 | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 33 |     is_unpin::<Foo<PhantomPinned, PhantomPinned>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `_::__Foo<'_, std::marker::PhantomPinned, std::marker::PhantomPinned>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `__Foo<'_, PhantomPinned, PhantomPinned>`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `Inner<std::marker::PhantomPinned>`
-   = note: required because it appears within the type `_::__Foo<'_, std::marker::PhantomPinned, std::marker::PhantomPinned>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Foo<std::marker::PhantomPinned, std::marker::PhantomPinned>`
+   = note: required because it appears within the type `Inner<PhantomPinned>`
+   = note: required because it appears within the type `__Foo<'_, PhantomPinned, PhantomPinned>`
+   = note: required because of the requirements on the impl of `Unpin` for `Foo<PhantomPinned, PhantomPinned>`
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/proper_unpin.rs:35:5
    |
 28 | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 35 |     is_unpin::<TrivialBounds>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ within `_::__TrivialBounds<'_>`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ within `__TrivialBounds<'_>`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `_::__TrivialBounds<'_>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `TrivialBounds`
+   = note: required because it appears within the type `__TrivialBounds<'_>`
+   = note: required because of the requirements on the impl of `Unpin` for `TrivialBounds`

--- a/tests/ui/pin_project/remove-attr-from-field.stderr
+++ b/tests/ui/pin_project/remove-attr-from-field.stderr
@@ -2,20 +2,20 @@ error[E0308]: mismatched types
   --> $DIR/remove-attr-from-field.rs:27:38
    |
 27 |     let _: Pin<&mut PhantomPinned> = x.field; //~ ERROR E0308
-   |            -----------------------   ^^^^^^^ expected struct `std::pin::Pin`, found `&mut std::marker::PhantomPinned`
+   |            -----------------------   ^^^^^^^ expected struct `Pin`, found `&mut PhantomPinned`
    |            |
    |            expected due to this
    |
-   = note:         expected struct `std::pin::Pin<&mut std::marker::PhantomPinned>`
-           found mutable reference `&mut std::marker::PhantomPinned`
+   = note:         expected struct `Pin<&mut PhantomPinned>`
+           found mutable reference `&mut PhantomPinned`
 
 error[E0308]: mismatched types
   --> $DIR/remove-attr-from-field.rs:31:38
    |
 31 |     let _: Pin<&mut PhantomPinned> = x.field; //~ ERROR E0308
-   |            -----------------------   ^^^^^^^ expected struct `std::pin::Pin`, found `&mut std::marker::PhantomPinned`
+   |            -----------------------   ^^^^^^^ expected struct `Pin`, found `&mut PhantomPinned`
    |            |
    |            expected due to this
    |
-   = note:         expected struct `std::pin::Pin<&mut std::marker::PhantomPinned>`
-           found mutable reference `&mut std::marker::PhantomPinned`
+   = note:         expected struct `Pin<&mut PhantomPinned>`
+           found mutable reference `&mut PhantomPinned`

--- a/tests/ui/pin_project/remove-attr-from-struct.stderr
+++ b/tests/ui/pin_project/remove-attr-from-struct.stderr
@@ -18,54 +18,54 @@ error: cannot find attribute `pin` in this scope
 17 |     #[pin] //~ ERROR cannot find attribute `pin` in this scope
    |       ^^^
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/remove-attr-from-struct.rs:34:5
    |
 5  | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 34 |     is_unpin::<A>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^ within `A`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^ within `A`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
    = note: required because it appears within the type `A`
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/remove-attr-from-struct.rs:35:5
    |
 5  | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 35 |     is_unpin::<B>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^ within `B`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^ within `B`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
    = note: required because it appears within the type `B`
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/remove-attr-from-struct.rs:39:13
    |
 39 |     let _ = Pin::new(&mut x).project(); //~ ERROR E0277,E0599
-   |             ^^^^^^^^ within `A`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |             ^^^^^^^^ within `A`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
    = note: required because it appears within the type `A`
-   = note: required by `std::pin::Pin::<P>::new`
+   = note: required by `Pin::<P>::new`
 
-error[E0599]: no method named `project` found for struct `std::pin::Pin<&mut A>` in the current scope
+error[E0599]: no method named `project` found for struct `Pin<&mut A>` in the current scope
   --> $DIR/remove-attr-from-struct.rs:39:30
    |
 39 |     let _ = Pin::new(&mut x).project(); //~ ERROR E0277,E0599
-   |                              ^^^^^^^ method not found in `std::pin::Pin<&mut A>`
+   |                              ^^^^^^^ method not found in `Pin<&mut A>`
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/remove-attr-from-struct.rs:42:13
    |
 42 |     let _ = Pin::new(&mut x).project(); //~ ERROR E0277,E0599
-   |             ^^^^^^^^ within `B`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |             ^^^^^^^^ within `B`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
    = note: required because it appears within the type `B`
-   = note: required by `std::pin::Pin::<P>::new`
+   = note: required by `Pin::<P>::new`
 
-error[E0599]: no method named `project` found for struct `std::pin::Pin<&mut B>` in the current scope
+error[E0599]: no method named `project` found for struct `Pin<&mut B>` in the current scope
   --> $DIR/remove-attr-from-struct.rs:42:30
    |
 42 |     let _ = Pin::new(&mut x).project(); //~ ERROR E0277,E0599
-   |                              ^^^^^^^ method not found in `std::pin::Pin<&mut B>`
+   |                              ^^^^^^^ method not found in `Pin<&mut B>`

--- a/tests/ui/pin_project/safe_packed_borrows.rs
+++ b/tests/ui/pin_project/safe_packed_borrows.rs
@@ -1,4 +1,4 @@
-#![deny(safe_packed_borrows)]
+#![forbid(safe_packed_borrows)]
 
 // Refs: https://github.com/rust-lang/rust/issues/46043
 

--- a/tests/ui/pin_project/safe_packed_borrows.stderr
+++ b/tests/ui/pin_project/safe_packed_borrows.stderr
@@ -5,10 +5,10 @@ error: borrow of packed field is unsafe and requires unsafe function or block (e
    |     ^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/safe_packed_borrows.rs:1:9
+  --> $DIR/safe_packed_borrows.rs:1:11
    |
-1  | #![deny(safe_packed_borrows)]
-   |         ^^^^^^^^^^^^^^^^^^^
+1  | #![forbid(safe_packed_borrows)]
+   |           ^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #46043 <https://github.com/rust-lang/rust/issues/46043>
    = note: fields of packed structs might be misaligned: dereferencing a misaligned pointer or even just creating a misaligned reference is undefined behavior

--- a/tests/ui/pin_project/unpin_sneaky.stderr
+++ b/tests/ui/pin_project/unpin_sneaky.stderr
@@ -4,7 +4,7 @@ error[E0412]: cannot find type `__Foo` in this scope
 9 | impl Unpin for __Foo {} //~ ERROR E0412,E0321
   |                ^^^^^ not found in this scope
 
-error[E0321]: cross-crate traits with a default impl, like `std::marker::Unpin`, can only be implemented for a struct/enum type, not `[type error]`
+error[E0321]: cross-crate traits with a default impl, like `Unpin`, can only be implemented for a struct/enum type, not `[type error]`
  --> $DIR/unpin_sneaky.rs:9:1
   |
 9 | impl Unpin for __Foo {} //~ ERROR E0412,E0321

--- a/tests/ui/pinned_drop/conditional-drop-impl.stderr
+++ b/tests/ui/pinned_drop/conditional-drop-impl.stderr
@@ -1,4 +1,4 @@
-error[E0367]: `Drop` impl requires `T: std::marker::Unpin` but the struct it is implemented for does not
+error[E0367]: `Drop` impl requires `T: Unpin` but the struct it is implemented for does not
   --> $DIR/conditional-drop-impl.rs:10:9
    |
 10 | impl<T: Unpin> Drop for DropImpl<T> {
@@ -16,11 +16,11 @@ error[E0277]: `T` cannot be unpinned
   --> $DIR/conditional-drop-impl.rs:15:15
    |
 15 | #[pin_project(PinnedDrop)] //~ ERROR E0277
-   |               ^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `T`
+   |               ^^^^^^^^^^ the trait `Unpin` is not implemented for `T`
    |
-   = note: required because of the requirements on the impl of `pin_project::__private::PinnedDrop` for `PinnedDropImpl<T>`
+   = note: required because of the requirements on the impl of `PinnedDrop` for `PinnedDropImpl<T>`
    = note: required by `pin_project::__private::PinnedDrop::drop`
 help: consider restricting type parameter `T`
    |
-16 | struct PinnedDropImpl<T: std::marker::Unpin> {
-   |                        ^^^^^^^^^^^^^^^^^^^^
+16 | struct PinnedDropImpl<T: Unpin> {
+   |                        ^^^^^^^

--- a/tests/ui/pinned_drop/forget-pinned-drop-impl.stderr
+++ b/tests/ui/pinned_drop/forget-pinned-drop-impl.stderr
@@ -1,7 +1,7 @@
-error[E0277]: the trait bound `Struct: pin_project::__private::PinnedDrop` is not satisfied
+error[E0277]: the trait bound `Struct: PinnedDrop` is not satisfied
  --> $DIR/forget-pinned-drop-impl.rs:3:15
   |
 3 | #[pin_project(PinnedDrop)] //~ ERROR E0277
-  |               ^^^^^^^^^^ the trait `pin_project::__private::PinnedDrop` is not implemented for `Struct`
+  |               ^^^^^^^^^^ the trait `PinnedDrop` is not implemented for `Struct`
   |
   = note: required by `pin_project::__private::PinnedDrop::drop`

--- a/tests/ui/pinned_drop/self.stderr
+++ b/tests/ui/pinned_drop/self.stderr
@@ -37,23 +37,23 @@ error[E0308]: mismatched types
   --> $DIR/self.rs:37:25
    |
 37 |             let _: () = self; //~ ERROR E0308
-   |                    --   ^^^^ expected `()`, found struct `std::pin::Pin`
+   |                    --   ^^^^ expected `()`, found struct `Pin`
    |                    |
    |                    expected due to this
    |
    = note: expected unit type `()`
-                 found struct `std::pin::Pin<&mut self_span::S>`
+                 found struct `Pin<&mut S>`
 
 error[E0308]: mismatched types
   --> $DIR/self.rs:50:25
    |
 50 |             let _: () = self; //~ ERROR E0308
-   |                    --   ^^^^ expected `()`, found struct `std::pin::Pin`
+   |                    --   ^^^^ expected `()`, found struct `Pin`
    |                    |
    |                    expected due to this
    |
    = note: expected unit type `()`
-                 found struct `std::pin::Pin<&mut self_span::E>`
+                 found struct `Pin<&mut E>`
 
 error[E0533]: expected unit struct, unit variant or constant, found struct variant `Self::V`
   --> $DIR/self.rs:51:27

--- a/tests/ui/project/type-mismatch.stderr
+++ b/tests/ui/project/type-mismatch.stderr
@@ -5,10 +5,10 @@ error[E0308]: mismatched types
    |           -------- this expression has type `&mut type_mismatch::__EnumProjection<'_, {integer}, {integer}, _, _>`
 ...
 36 |         None => {} //~ ERROR mismatched types
-   |         ^^^^ expected enum `type_mismatch::__EnumProjection`, found enum `std::option::Option`
+   |         ^^^^ expected enum `type_mismatch::__EnumProjection`, found enum `Option`
    |
    = note: expected enum `type_mismatch::__EnumProjection<'_, {integer}, {integer}, _, _>`
-              found enum `std::option::Option<_>`
+              found enum `Option<_>`
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:68:9
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
    |           -------- this expression has type `&mut type_mismatch_span_issue::__EnumProjection<'_, {integer}, {integer}, _, _>`
 ...
 68 |         None => {} //~ ERROR mismatched types
-   |         ^^^^ expected enum `type_mismatch_span_issue::__EnumProjection`, found enum `std::option::Option`
+   |         ^^^^ expected enum `type_mismatch_span_issue::__EnumProjection`, found enum `Option`
    |
    = note: expected enum `type_mismatch_span_issue::__EnumProjection<'_, {integer}, {integer}, _, _>`
-              found enum `std::option::Option<_>`
+              found enum `Option<_>`

--- a/tests/ui/unsafe_unpin/not-implement-unsafe-unpin.stderr
+++ b/tests/ui/unsafe_unpin/not-implement-unsafe-unpin.stderr
@@ -1,11 +1,11 @@
-error[E0277]: the trait bound `Struct<(), ()>: pin_project::UnsafeUnpin` is not satisfied
+error[E0277]: the trait bound `Struct<(), ()>: UnsafeUnpin` is not satisfied
   --> $DIR/not-implement-unsafe-unpin.rs:13:16
    |
 10 | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 13 |     is_unpin::<Struct<(), ()>>(); //~ ERROR E0277
-   |                ^^^^^^^^^^^^^^ the trait `pin_project::UnsafeUnpin` is not implemented for `Struct<(), ()>`
+   |                ^^^^^^^^^^^^^^ the trait `UnsafeUnpin` is not implemented for `Struct<(), ()>`
    |
-   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `pin_project::__private::Wrapper<'_, Struct<(), ()>>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Struct<(), ()>`
+   = note: required because of the requirements on the impl of `UnsafeUnpin` for `Wrapper<'_, Struct<(), ()>>`
+   = note: required because of the requirements on the impl of `Unpin` for `Struct<(), ()>`

--- a/tests/ui/unsafe_unpin/proper_unpin.stderr
+++ b/tests/ui/unsafe_unpin/proper_unpin.stderr
@@ -1,63 +1,63 @@
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/proper_unpin.rs:33:5
    |
 4  | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 33 |     is_unpin::<Blah<PhantomPinned, ()>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `Blah<std::marker::PhantomPinned, ()>`
-   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `pin_project::__private::Wrapper<'_, Blah<std::marker::PhantomPinned, ()>>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Blah<std::marker::PhantomPinned, ()>`
+   = note: required because of the requirements on the impl of `UnsafeUnpin` for `Blah<PhantomPinned, ()>`
+   = note: required because of the requirements on the impl of `UnsafeUnpin` for `Wrapper<'_, Blah<PhantomPinned, ()>>`
+   = note: required because of the requirements on the impl of `Unpin` for `Blah<PhantomPinned, ()>`
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/proper_unpin.rs:35:5
    |
 4  | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 35 |     is_unpin::<Blah<PhantomPinned, PhantomPinned>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `Blah<std::marker::PhantomPinned, std::marker::PhantomPinned>`
-   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `pin_project::__private::Wrapper<'_, Blah<std::marker::PhantomPinned, std::marker::PhantomPinned>>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `Blah<std::marker::PhantomPinned, std::marker::PhantomPinned>`
+   = note: required because of the requirements on the impl of `UnsafeUnpin` for `Blah<PhantomPinned, PhantomPinned>`
+   = note: required because of the requirements on the impl of `UnsafeUnpin` for `Wrapper<'_, Blah<PhantomPinned, PhantomPinned>>`
+   = note: required because of the requirements on the impl of `Unpin` for `Blah<PhantomPinned, PhantomPinned>`
 
-error[E0277]: the trait bound `TrivialBounds: pin_project::UnsafeUnpin` is not satisfied
+error[E0277]: the trait bound `TrivialBounds: UnsafeUnpin` is not satisfied
   --> $DIR/proper_unpin.rs:37:16
    |
 4  | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 37 |     is_unpin::<TrivialBounds>(); //~ ERROR E0277
-   |                ^^^^^^^^^^^^^ the trait `pin_project::UnsafeUnpin` is not implemented for `TrivialBounds`
+   |                ^^^^^^^^^^^^^ the trait `UnsafeUnpin` is not implemented for `TrivialBounds`
    |
-   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `pin_project::__private::Wrapper<'_, TrivialBounds>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `TrivialBounds`
+   = note: required because of the requirements on the impl of `UnsafeUnpin` for `Wrapper<'_, TrivialBounds>`
+   = note: required because of the requirements on the impl of `Unpin` for `TrivialBounds`
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/proper_unpin.rs:39:5
    |
 4  | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 39 |     is_unpin::<OverlappingLifetimeNames<'_, PhantomPinned, ()>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `OverlappingLifetimeNames<'_, std::marker::PhantomPinned, ()>`
-   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `pin_project::__private::Wrapper<'_, OverlappingLifetimeNames<'_, std::marker::PhantomPinned, ()>>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `OverlappingLifetimeNames<'_, std::marker::PhantomPinned, ()>`
+   = note: required because of the requirements on the impl of `UnsafeUnpin` for `OverlappingLifetimeNames<'_, PhantomPinned, ()>`
+   = note: required because of the requirements on the impl of `UnsafeUnpin` for `Wrapper<'_, OverlappingLifetimeNames<'_, PhantomPinned, ()>>`
+   = note: required because of the requirements on the impl of `Unpin` for `OverlappingLifetimeNames<'_, PhantomPinned, ()>`
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/proper_unpin.rs:40:5
    |
 4  | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
 40 |     is_unpin::<OverlappingLifetimeNames<'_, (), PhantomPinned>>(); //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `OverlappingLifetimeNames<'_, (), std::marker::PhantomPinned>`
-   = note: required because of the requirements on the impl of `pin_project::UnsafeUnpin` for `pin_project::__private::Wrapper<'_, OverlappingLifetimeNames<'_, (), std::marker::PhantomPinned>>`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `OverlappingLifetimeNames<'_, (), std::marker::PhantomPinned>`
+   = note: required because of the requirements on the impl of `UnsafeUnpin` for `OverlappingLifetimeNames<'_, (), PhantomPinned>`
+   = note: required because of the requirements on the impl of `UnsafeUnpin` for `Wrapper<'_, OverlappingLifetimeNames<'_, (), PhantomPinned>>`
+   = note: required because of the requirements on the impl of `Unpin` for `OverlappingLifetimeNames<'_, (), PhantomPinned>`

--- a/tests/ui/unstable-features/trivial_bounds-bug.stderr
+++ b/tests/ui/unstable-features/trivial_bounds-bug.stderr
@@ -1,5 +1,5 @@
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
    --> $DIR/trivial_bounds-bug.rs:13:43
     |
 13  |     impl Unpin for A where PhantomPinned: Unpin {} //~ ERROR E0277
-    |                                           ^^^^^ the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+    |                                           ^^^^^ the trait `Unpin` is not implemented for `PhantomPinned`

--- a/tests/ui/unstable-features/trivial_bounds-feature-gate.stderr
+++ b/tests/ui/unstable-features/trivial_bounds-feature-gate.stderr
@@ -1,45 +1,45 @@
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
  --> $DIR/trivial_bounds-feature-gate.rs:8:5
   |
 8 |     impl Unpin for A where PhantomPinned: Unpin {} //~ ERROR E0277
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unpin` is not implemented for `PhantomPinned`
   |
   = help: see issue #48214
   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
    --> $DIR/trivial_bounds-feature-gate.rs:8:43
     |
 8   |     impl Unpin for A where PhantomPinned: Unpin {} //~ ERROR E0277
-    |                                           ^^^^^ the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+    |                                           ^^^^^ the trait `Unpin` is not implemented for `PhantomPinned`
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/trivial_bounds-feature-gate.rs:16:5
    |
 16 |     impl Unpin for B where Wrapper<PhantomPinned>: Unpin {} //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `phantom_pinned::Wrapper<std::marker::PhantomPinned>`
+   = note: required because of the requirements on the impl of `Unpin` for `phantom_pinned::Wrapper<PhantomPinned>`
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/trivial_bounds-feature-gate.rs:35:5
    |
 35 |     impl Unpin for A where Inner: Unpin {} //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `inner::Inner`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `Inner`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `inner::Inner`
+   = note: required because it appears within the type `Inner`
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
-error[E0277]: `std::marker::PhantomPinned` cannot be unpinned
+error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/trivial_bounds-feature-gate.rs:43:5
    |
 43 |     impl Unpin for B where Wrapper<Inner>: Unpin {} //~ ERROR E0277
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `inner::Inner`, the trait `std::marker::Unpin` is not implemented for `std::marker::PhantomPinned`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `Inner`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: required because it appears within the type `inner::Inner`
-   = note: required because of the requirements on the impl of `std::marker::Unpin` for `inner::Wrapper<inner::Inner>`
+   = note: required because it appears within the type `Inner`
+   = note: required because of the requirements on the impl of `Unpin` for `inner::Wrapper<Inner>`
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable

--- a/tests/ui/unstable-features/trivial_bounds.stderr
+++ b/tests/ui/unstable-features/trivial_bounds.stderr
@@ -1,4 +1,4 @@
-error: Trait bound inner::Inner: std::marker::Unpin does not depend on any type or lifetime parameters
+error: Trait bound Inner: Unpin does not depend on any type or lifetime parameters
   --> $DIR/trivial_bounds.rs:15:35
    |
 15 |     impl Unpin for A where Inner: Unpin {} //~ ERROR std::marker::Unpin does not depend on any type or lifetime parameters
@@ -10,7 +10,7 @@ note: the lint level is defined here
 6  | #![deny(trivial_bounds)]
    |         ^^^^^^^^^^^^^^
 
-error: Trait bound inner::Wrapper<inner::Inner>: std::marker::Unpin does not depend on any type or lifetime parameters
+error: Trait bound Wrapper<Inner>: Unpin does not depend on any type or lifetime parameters
   --> $DIR/trivial_bounds.rs:23:44
    |
 23 |     impl Unpin for B where Wrapper<Inner>: Unpin {} //~ ERROR std::marker::Unpin does not depend on any type or lifetime parameters


### PR DESCRIPTION
This is the backport of #282

