### PR TITLE
Run Miri on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust and rustfmt
+      - name: Install Rust and Rustfmt
         run: ci/install-component.sh rustfmt
       - name: Install cargo-expand
         run: |
@@ -83,6 +83,19 @@ jobs:
       - name: cargo test (expandtest)
         run: |
           bash scripts/expandtest.sh
+
+  miri:
+    name: miri
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust and Miri
+        run: |
+          ci/install-component.sh miri
+          cargo miri setup
+      - name: cargo miri test
+        run: |
+          cargo miri test
 
   clippy:
     name: clippy
@@ -100,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust and rustfmt
+      - name: Install Rust and Rustfmt
         run: ci/install-component.sh rustfmt
       - name: cargo fmt --check
         run: |
@@ -143,6 +156,7 @@ jobs:
       - rustfmt
       - rustdoc
       - expandtest
+      - miri
       - shellcheck
     runs-on: ubuntu-latest
     steps:
@@ -157,6 +171,7 @@ jobs:
       - rustfmt
       - rustdoc
       - expandtest
+      - miri
       - shellcheck
     runs-on: ubuntu-latest
     steps:

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,3 +1,4 @@
+#![cfg(not(miri))]
 #![warn(rust_2018_idioms, single_use_lifetimes)]
 
 #[rustversion::attr(not(nightly), ignore)]

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -310,6 +310,7 @@ pub mod clippy_used_underscore_binding {
     }
 }
 
+#[cfg(not(miri))]
 #[allow(box_pointers)]
 #[allow(clippy::restriction)]
 #[rustversion::attr(not(nightly), ignore)]


### PR DESCRIPTION
The pin guarantees are guarantees of a library, so Miri does not detect
violations of the pin API. However, if the generated unsafe code causes
UB, Miri may be possible to detect it.

Related: https://github.com/rust-lang/miri/issues/823, https://github.com/rust-lang/unsafe-code-guidelines/issues/232#issuecomment-619572693
