### PR TITLE
v0.4: Fix drop order of pinned fields in project_replace

### DIFF
--- a/tests/drop_order.rs
+++ b/tests/drop_order.rs
@@ -1,0 +1,157 @@
+#![warn(rust_2018_idioms, single_use_lifetimes)]
+
+use pin_project::pin_project;
+use std::{cell::Cell, pin::Pin, thread};
+
+struct D<'a>(&'a Cell<usize>, usize);
+
+impl Drop for D<'_> {
+    fn drop(&mut self) {
+        if !thread::panicking() {
+            let old = self.0.replace(self.1);
+            assert_eq!(old, self.1 - 1);
+        }
+    }
+}
+
+#[pin_project(project_replace)]
+struct StructPinned<'a> {
+    #[pin]
+    f1: D<'a>,
+    #[pin]
+    f2: D<'a>,
+}
+
+#[pin_project(project_replace)]
+struct StructUnpinned<'a> {
+    f1: D<'a>,
+    f2: D<'a>,
+}
+
+#[pin_project(project_replace)]
+struct TuplePinned<'a>(#[pin] D<'a>, #[pin] D<'a>);
+
+#[pin_project(project_replace)]
+struct TupleUnpinned<'a>(D<'a>, D<'a>);
+
+#[pin_project(project_replace= EnumProj)]
+enum Enum<'a> {
+    StructPinned {
+        #[pin]
+        f1: D<'a>,
+        #[pin]
+        f2: D<'a>,
+    },
+    StructUnpinned {
+        f1: D<'a>,
+        f2: D<'a>,
+    },
+    TuplePinned(#[pin] D<'a>, #[pin] D<'a>),
+    TupleUnpinned(D<'a>, D<'a>),
+}
+
+#[test]
+fn struct_pinned() {
+    {
+        let c = Cell::new(0);
+        let _x = StructPinned { f1: D(&c, 1), f2: D(&c, 2) };
+    }
+    {
+        let c = Cell::new(0);
+        let mut _x = StructPinned { f1: D(&c, 1), f2: D(&c, 2) };
+        let _y = Pin::new(&mut _x);
+        let _z = _y.project_replace(StructPinned { f1: D(&c, 3), f2: D(&c, 4) });
+    }
+}
+
+#[test]
+fn struct_unpinned() {
+    {
+        let c = Cell::new(0);
+        let _x = StructUnpinned { f1: D(&c, 1), f2: D(&c, 2) };
+    }
+    {
+        let c = Cell::new(0);
+        let mut _x = StructUnpinned { f1: D(&c, 1), f2: D(&c, 2) };
+        let _y = Pin::new(&mut _x);
+        let _z = _y.project_replace(StructUnpinned { f1: D(&c, 3), f2: D(&c, 4) });
+    }
+}
+
+#[test]
+fn tuple_pinned() {
+    {
+        let c = Cell::new(0);
+        let _x = TuplePinned(D(&c, 1), D(&c, 2));
+    }
+    {
+        let c = Cell::new(0);
+        let mut _x = TuplePinned(D(&c, 1), D(&c, 2));
+        let _y = Pin::new(&mut _x);
+        let _z = _y.project_replace(TuplePinned(D(&c, 3), D(&c, 4)));
+    }
+}
+
+#[test]
+fn tuple_unpinned() {
+    {
+        let c = Cell::new(0);
+        let _x = TupleUnpinned(D(&c, 1), D(&c, 2));
+    }
+    {
+        let c = Cell::new(0);
+        let mut _x = TupleUnpinned(D(&c, 1), D(&c, 2));
+        let _y = Pin::new(&mut _x);
+        let _z = _y.project_replace(TupleUnpinned(D(&c, 3), D(&c, 4)));
+    }
+}
+
+#[test]
+fn enum_struct() {
+    {
+        let c = Cell::new(0);
+        let _x = Enum::StructPinned { f1: D(&c, 1), f2: D(&c, 2) };
+    }
+    {
+        let c = Cell::new(0);
+        let mut _x = Enum::StructPinned { f1: D(&c, 1), f2: D(&c, 2) };
+        let _y = Pin::new(&mut _x);
+        let _z = _y.project_replace(Enum::StructPinned { f1: D(&c, 3), f2: D(&c, 4) });
+    }
+
+    {
+        let c = Cell::new(0);
+        let _x = Enum::StructUnpinned { f1: D(&c, 1), f2: D(&c, 2) };
+    }
+    {
+        let c = Cell::new(0);
+        let mut _x = Enum::StructUnpinned { f1: D(&c, 1), f2: D(&c, 2) };
+        let _y = Pin::new(&mut _x);
+        let _z = _y.project_replace(Enum::StructUnpinned { f1: D(&c, 3), f2: D(&c, 4) });
+    }
+}
+
+#[test]
+fn enum_tuple() {
+    {
+        let c = Cell::new(0);
+        let _x = Enum::TuplePinned(D(&c, 1), D(&c, 2));
+    }
+    {
+        let c = Cell::new(0);
+        let mut _x = Enum::TuplePinned(D(&c, 1), D(&c, 2));
+        let _y = Pin::new(&mut _x);
+        let _z = _y.project_replace(Enum::TuplePinned(D(&c, 3), D(&c, 4)));
+    }
+
+    {
+        let c = Cell::new(0);
+        let _x = Enum::TupleUnpinned(D(&c, 1), D(&c, 2));
+    }
+    {
+        let c = Cell::new(0);
+        let mut _x = Enum::TupleUnpinned(D(&c, 1), D(&c, 2));
+        let _y = Pin::new(&mut _x);
+        let _z = _y.project_replace(Enum::TupleUnpinned(D(&c, 3), D(&c, 4)));
+    }
+}

--- a/tests/expand/tests/expand/multifields-enum.expanded.rs
+++ b/tests/expand/tests/expand/multifields-enum.expanded.rs
@@ -13,13 +13,9 @@ enum Enum<T, U> {
     Unit,
 }
 #[allow(dead_code)]
+#[allow(single_use_lifetimes)]
 #[allow(clippy::mut_mut)]
 #[allow(clippy::type_repetition_in_bounds)]
-#[allow(box_pointers)]
-#[allow(explicit_outlives_requirements)]
-#[allow(single_use_lifetimes)]
-#[allow(clippy::pattern_type_mismatch)]
-#[allow(clippy::redundant_pub_crate)]
 enum EnumProj<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -39,12 +35,8 @@ where
     Unit,
 }
 #[allow(dead_code)]
-#[allow(clippy::type_repetition_in_bounds)]
-#[allow(box_pointers)]
-#[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
-#[allow(clippy::pattern_type_mismatch)]
-#[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 enum EnumProjRef<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -64,13 +56,8 @@ where
     Unit,
 }
 #[allow(dead_code)]
-#[allow(unreachable_pub)]
-#[allow(clippy::large_enum_variant)]
-#[allow(box_pointers)]
-#[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
-#[allow(clippy::pattern_type_mismatch)]
-#[allow(clippy::redundant_pub_crate)]
+#[allow(unreachable_pub)]
 enum EnumProjOwn<T, U> {
     Struct {
         pinned1: ::pin_project::__private::PhantomData<T>,
@@ -87,12 +74,9 @@ enum EnumProjOwn<T, U> {
     Unit,
 }
 #[doc(hidden)]
-#[allow(clippy::used_underscore_binding)]
-#[allow(box_pointers)]
-#[allow(explicit_outlives_requirements)]
+#[allow(non_upper_case_globals)]
 #[allow(single_use_lifetimes)]
-#[allow(clippy::pattern_type_mismatch)]
-#[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
@@ -223,16 +207,11 @@ const _: () = {
         __Enum<'pin, T, U>: ::pin_project::__private::Unpin
     {
     }
-    #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
-    {
-    }
+    unsafe impl<T, U> ::pin_project::UnsafeUnpin for Enum<T, U> {}
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
     impl<T: ::pin_project::__private::Drop> EnumMustNotImplDrop for T {}
     impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
-    #[doc(hidden)]
     impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }

--- a/tests/expand/tests/expand/multifields-enum.expanded.rs
+++ b/tests/expand/tests/expand/multifields-enum.expanded.rs
@@ -1,0 +1,240 @@
+use pin_project::pin_project;
+# [pin (__private (project = EnumProj , project_ref = EnumProjRef , project_replace = EnumProjOwn))]
+enum Enum<T, U> {
+    Struct {
+        #[pin]
+        pinned1: T,
+        #[pin]
+        pinned2: T,
+        unpinned1: U,
+        unpinned2: U,
+    },
+    Tuple(#[pin] T, #[pin] T, U, U),
+    Unit,
+}
+#[allow(dead_code)]
+#[allow(clippy::mut_mut)]
+#[allow(clippy::type_repetition_in_bounds)]
+#[allow(box_pointers)]
+#[allow(explicit_outlives_requirements)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::pattern_type_mismatch)]
+#[allow(clippy::redundant_pub_crate)]
+enum EnumProj<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Struct {
+        pinned1: ::pin_project::__private::Pin<&'pin mut (T)>,
+        pinned2: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned1: &'pin mut (U),
+        unpinned2: &'pin mut (U),
+    },
+    Tuple(
+        ::pin_project::__private::Pin<&'pin mut (T)>,
+        ::pin_project::__private::Pin<&'pin mut (T)>,
+        &'pin mut (U),
+        &'pin mut (U),
+    ),
+    Unit,
+}
+#[allow(dead_code)]
+#[allow(clippy::type_repetition_in_bounds)]
+#[allow(box_pointers)]
+#[allow(explicit_outlives_requirements)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::pattern_type_mismatch)]
+#[allow(clippy::redundant_pub_crate)]
+enum EnumProjRef<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Struct {
+        pinned1: ::pin_project::__private::Pin<&'pin (T)>,
+        pinned2: ::pin_project::__private::Pin<&'pin (T)>,
+        unpinned1: &'pin (U),
+        unpinned2: &'pin (U),
+    },
+    Tuple(
+        ::pin_project::__private::Pin<&'pin (T)>,
+        ::pin_project::__private::Pin<&'pin (T)>,
+        &'pin (U),
+        &'pin (U),
+    ),
+    Unit,
+}
+#[allow(dead_code)]
+#[allow(unreachable_pub)]
+#[allow(clippy::large_enum_variant)]
+#[allow(box_pointers)]
+#[allow(explicit_outlives_requirements)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::pattern_type_mismatch)]
+#[allow(clippy::redundant_pub_crate)]
+enum EnumProjOwn<T, U> {
+    Struct {
+        pinned1: ::pin_project::__private::PhantomData<T>,
+        pinned2: ::pin_project::__private::PhantomData<T>,
+        unpinned1: U,
+        unpinned2: U,
+    },
+    Tuple(
+        ::pin_project::__private::PhantomData<T>,
+        ::pin_project::__private::PhantomData<T>,
+        U,
+        U,
+    ),
+    Unit,
+}
+#[doc(hidden)]
+#[allow(clippy::used_underscore_binding)]
+#[allow(box_pointers)]
+#[allow(explicit_outlives_requirements)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::pattern_type_mismatch)]
+#[allow(clippy::redundant_pub_crate)]
+const _: () = {
+    impl<T, U> Enum<T, U> {
+        fn project<'pin>(
+            self: ::pin_project::__private::Pin<&'pin mut Self>,
+        ) -> EnumProj<'pin, T, U> {
+            unsafe {
+                match self.get_unchecked_mut() {
+                    Enum::Struct {
+                        pinned1,
+                        pinned2,
+                        unpinned1,
+                        unpinned2,
+                    } => EnumProj::Struct {
+                        pinned1: ::pin_project::__private::Pin::new_unchecked(pinned1),
+                        pinned2: ::pin_project::__private::Pin::new_unchecked(pinned2),
+                        unpinned1,
+                        unpinned2,
+                    },
+                    Enum::Tuple(_0, _1, _2, _3) => EnumProj::Tuple(
+                        ::pin_project::__private::Pin::new_unchecked(_0),
+                        ::pin_project::__private::Pin::new_unchecked(_1),
+                        _2,
+                        _3,
+                    ),
+                    Enum::Unit => EnumProj::Unit,
+                }
+            }
+        }
+        fn project_ref<'pin>(
+            self: ::pin_project::__private::Pin<&'pin Self>,
+        ) -> EnumProjRef<'pin, T, U> {
+            unsafe {
+                match self.get_ref() {
+                    Enum::Struct {
+                        pinned1,
+                        pinned2,
+                        unpinned1,
+                        unpinned2,
+                    } => EnumProjRef::Struct {
+                        pinned1: ::pin_project::__private::Pin::new_unchecked(pinned1),
+                        pinned2: ::pin_project::__private::Pin::new_unchecked(pinned2),
+                        unpinned1,
+                        unpinned2,
+                    },
+                    Enum::Tuple(_0, _1, _2, _3) => EnumProjRef::Tuple(
+                        ::pin_project::__private::Pin::new_unchecked(_0),
+                        ::pin_project::__private::Pin::new_unchecked(_1),
+                        _2,
+                        _3,
+                    ),
+                    Enum::Unit => EnumProjRef::Unit,
+                }
+            }
+        }
+        fn project_replace(
+            self: ::pin_project::__private::Pin<&mut Self>,
+            __replacement: Self,
+        ) -> EnumProjOwn<T, U> {
+            unsafe {
+                let __self_ptr: *mut Self = self.get_unchecked_mut();
+                match &mut *__self_ptr {
+                    Enum::Struct {
+                        pinned1,
+                        pinned2,
+                        unpinned1,
+                        unpinned2,
+                    } => {
+                        let __result = EnumProjOwn::Struct {
+                            pinned1: ::pin_project::__private::PhantomData,
+                            pinned2: ::pin_project::__private::PhantomData,
+                            unpinned1: ::pin_project::__private::ptr::read(unpinned1),
+                            unpinned2: ::pin_project::__private::ptr::read(unpinned2),
+                        };
+                        let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                            target: __self_ptr,
+                            value: ::pin_project::__private::ManuallyDrop::new(__replacement),
+                        };
+                        {
+                            let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned2);
+                            let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned1);
+                        }
+                        __result
+                    }
+                    Enum::Tuple(_0, _1, _2, _3) => {
+                        let __result = EnumProjOwn::Tuple(
+                            ::pin_project::__private::PhantomData,
+                            ::pin_project::__private::PhantomData,
+                            ::pin_project::__private::ptr::read(_2),
+                            ::pin_project::__private::ptr::read(_3),
+                        );
+                        let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                            target: __self_ptr,
+                            value: ::pin_project::__private::ManuallyDrop::new(__replacement),
+                        };
+                        {
+                            let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(_1);
+                            let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(_0);
+                        }
+                        __result
+                    }
+                    Enum::Unit => {
+                        let __result = EnumProjOwn::Unit;
+                        let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                            target: __self_ptr,
+                            value: ::pin_project::__private::ManuallyDrop::new(__replacement),
+                        };
+                        {}
+                        __result
+                    }
+                }
+            }
+        }
+    }
+    struct __Enum<'pin, T, U> {
+        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+            'pin,
+            (
+                ::pin_project::__private::PhantomData<T>,
+                ::pin_project::__private::PhantomData<U>,
+            ),
+        >,
+        __field0: T,
+        __field1: T,
+        __field2: T,
+        __field3: T,
+    }
+    impl<'pin, T, U> ::pin_project::__private::Unpin for Enum<T, U> where
+        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    {
+    }
+    #[doc(hidden)]
+    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Enum<T, U> where
+        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    {
+    }
+    trait EnumMustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::pin_project::__private::Drop> EnumMustNotImplDrop for T {}
+    impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
+    #[doc(hidden)]
+    impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
+        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    }
+};
+fn main() {}

--- a/tests/expand/tests/expand/multifields-enum.rs
+++ b/tests/expand/tests/expand/multifields-enum.rs
@@ -1,0 +1,17 @@
+use pin_project::pin_project;
+
+#[pin_project(project = EnumProj, project_ref = EnumProjRef, project_replace = EnumProjOwn)]
+enum Enum<T, U> {
+    Struct {
+        #[pin]
+        pinned1: T,
+        #[pin]
+        pinned2: T,
+        unpinned1: U,
+        unpinned2: U,
+    },
+    Tuple(#[pin] T, #[pin] T, U, U),
+    Unit,
+}
+
+fn main() {}

--- a/tests/expand/tests/expand/multifields-struct.expanded.rs
+++ b/tests/expand/tests/expand/multifields-struct.expanded.rs
@@ -9,59 +9,47 @@ struct Struct<T, U> {
     unpinned2: U,
 }
 #[doc(hidden)]
-#[allow(clippy::used_underscore_binding)]
-#[allow(box_pointers)]
-#[allow(explicit_outlives_requirements)]
+#[allow(dead_code)]
 #[allow(single_use_lifetimes)]
-#[allow(clippy::pattern_type_mismatch)]
-#[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::mut_mut)]
+#[allow(clippy::type_repetition_in_bounds)]
+struct __StructProjection<'pin, T, U>
+where
+    Struct<T, U>: 'pin,
+{
+    pinned1: ::pin_project::__private::Pin<&'pin mut (T)>,
+    pinned2: ::pin_project::__private::Pin<&'pin mut (T)>,
+    unpinned1: &'pin mut (U),
+    unpinned2: &'pin mut (U),
+}
+#[doc(hidden)]
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::type_repetition_in_bounds)]
+struct __StructProjectionRef<'pin, T, U>
+where
+    Struct<T, U>: 'pin,
+{
+    pinned1: ::pin_project::__private::Pin<&'pin (T)>,
+    pinned2: ::pin_project::__private::Pin<&'pin (T)>,
+    unpinned1: &'pin (U),
+    unpinned2: &'pin (U),
+}
+#[doc(hidden)]
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
+struct __StructProjectionOwned<T, U> {
+    pinned1: ::pin_project::__private::PhantomData<T>,
+    pinned2: ::pin_project::__private::PhantomData<T>,
+    unpinned1: U,
+    unpinned2: U,
+}
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(dead_code)]
-    #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    #[allow(box_pointers)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
-    struct __StructProjection<'pin, T, U>
-    where
-        Struct<T, U>: 'pin,
-    {
-        pinned1: ::pin_project::__private::Pin<&'pin mut (T)>,
-        pinned2: ::pin_project::__private::Pin<&'pin mut (T)>,
-        unpinned1: &'pin mut (U),
-        unpinned2: &'pin mut (U),
-    }
-    #[allow(dead_code)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    #[allow(box_pointers)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
-    struct __StructProjectionRef<'pin, T, U>
-    where
-        Struct<T, U>: 'pin,
-    {
-        pinned1: ::pin_project::__private::Pin<&'pin (T)>,
-        pinned2: ::pin_project::__private::Pin<&'pin (T)>,
-        unpinned1: &'pin (U),
-        unpinned2: &'pin (U),
-    }
-    #[allow(dead_code)]
-    #[allow(unreachable_pub)]
-    #[allow(box_pointers)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
-    struct __StructProjectionOwned<T, U> {
-        pinned1: ::pin_project::__private::PhantomData<T>,
-        pinned2: ::pin_project::__private::PhantomData<T>,
-        unpinned1: U,
-        unpinned2: U,
-    }
     impl<T, U> Struct<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,
@@ -144,25 +132,20 @@ const _: () = {
         __Struct<'pin, T, U>: ::pin_project::__private::Unpin
     {
     }
-    #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
-    {
-    }
+    unsafe impl<T, U> ::pin_project::UnsafeUnpin for Struct<T, U> {}
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
     impl<T: ::pin_project::__private::Drop> StructMustNotImplDrop for T {}
     impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
-    #[doc(hidden)]
     impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
-        let _ = &this.pinned1;
-        let _ = &this.pinned2;
-        let _ = &this.unpinned1;
-        let _ = &this.unpinned2;
+    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
+        &val.pinned1;
+        &val.pinned2;
+        &val.unpinned1;
+        &val.unpinned2;
     }
 };
 fn main() {}

--- a/tests/expand/tests/expand/multifields-struct.expanded.rs
+++ b/tests/expand/tests/expand/multifields-struct.expanded.rs
@@ -1,0 +1,168 @@
+use pin_project::pin_project;
+#[pin(__private(project_replace))]
+struct Struct<T, U> {
+    #[pin]
+    pinned1: T,
+    #[pin]
+    pinned2: T,
+    unpinned1: U,
+    unpinned2: U,
+}
+#[doc(hidden)]
+#[allow(clippy::used_underscore_binding)]
+#[allow(box_pointers)]
+#[allow(explicit_outlives_requirements)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::pattern_type_mismatch)]
+#[allow(clippy::redundant_pub_crate)]
+const _: () = {
+    #[allow(dead_code)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    #[allow(box_pointers)]
+    #[allow(explicit_outlives_requirements)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::pattern_type_mismatch)]
+    #[allow(clippy::redundant_pub_crate)]
+    struct __StructProjection<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned1: ::pin_project::__private::Pin<&'pin mut (T)>,
+        pinned2: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned1: &'pin mut (U),
+        unpinned2: &'pin mut (U),
+    }
+    #[allow(dead_code)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    #[allow(box_pointers)]
+    #[allow(explicit_outlives_requirements)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::pattern_type_mismatch)]
+    #[allow(clippy::redundant_pub_crate)]
+    struct __StructProjectionRef<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pinned1: ::pin_project::__private::Pin<&'pin (T)>,
+        pinned2: ::pin_project::__private::Pin<&'pin (T)>,
+        unpinned1: &'pin (U),
+        unpinned2: &'pin (U),
+    }
+    #[allow(dead_code)]
+    #[allow(unreachable_pub)]
+    #[allow(box_pointers)]
+    #[allow(explicit_outlives_requirements)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::pattern_type_mismatch)]
+    #[allow(clippy::redundant_pub_crate)]
+    struct __StructProjectionOwned<T, U> {
+        pinned1: ::pin_project::__private::PhantomData<T>,
+        pinned2: ::pin_project::__private::PhantomData<T>,
+        unpinned1: U,
+        unpinned2: U,
+    }
+    impl<T, U> Struct<T, U> {
+        fn project<'pin>(
+            self: ::pin_project::__private::Pin<&'pin mut Self>,
+        ) -> __StructProjection<'pin, T, U> {
+            unsafe {
+                let Self {
+                    pinned1,
+                    pinned2,
+                    unpinned1,
+                    unpinned2,
+                } = self.get_unchecked_mut();
+                __StructProjection {
+                    pinned1: ::pin_project::__private::Pin::new_unchecked(pinned1),
+                    pinned2: ::pin_project::__private::Pin::new_unchecked(pinned2),
+                    unpinned1,
+                    unpinned2,
+                }
+            }
+        }
+        fn project_ref<'pin>(
+            self: ::pin_project::__private::Pin<&'pin Self>,
+        ) -> __StructProjectionRef<'pin, T, U> {
+            unsafe {
+                let Self {
+                    pinned1,
+                    pinned2,
+                    unpinned1,
+                    unpinned2,
+                } = self.get_ref();
+                __StructProjectionRef {
+                    pinned1: ::pin_project::__private::Pin::new_unchecked(pinned1),
+                    pinned2: ::pin_project::__private::Pin::new_unchecked(pinned2),
+                    unpinned1,
+                    unpinned2,
+                }
+            }
+        }
+        fn project_replace(
+            self: ::pin_project::__private::Pin<&mut Self>,
+            __replacement: Self,
+        ) -> __StructProjectionOwned<T, U> {
+            unsafe {
+                let __self_ptr: *mut Self = self.get_unchecked_mut();
+                let Self {
+                    pinned1,
+                    pinned2,
+                    unpinned1,
+                    unpinned2,
+                } = &mut *__self_ptr;
+                let __result = __StructProjectionOwned {
+                    pinned1: ::pin_project::__private::PhantomData,
+                    pinned2: ::pin_project::__private::PhantomData,
+                    unpinned1: ::pin_project::__private::ptr::read(unpinned1),
+                    unpinned2: ::pin_project::__private::ptr::read(unpinned2),
+                };
+                let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                    target: __self_ptr,
+                    value: ::pin_project::__private::ManuallyDrop::new(__replacement),
+                };
+                {
+                    let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned2);
+                    let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned1);
+                }
+                __result
+            }
+        }
+    }
+    struct __Struct<'pin, T, U> {
+        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+            'pin,
+            (
+                ::pin_project::__private::PhantomData<T>,
+                ::pin_project::__private::PhantomData<U>,
+            ),
+        >,
+        __field0: T,
+        __field1: T,
+    }
+    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
+        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    {
+    }
+    #[doc(hidden)]
+    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
+        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    {
+    }
+    trait StructMustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::pin_project::__private::Drop> StructMustNotImplDrop for T {}
+    impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
+    #[doc(hidden)]
+    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    }
+    #[forbid(safe_packed_borrows)]
+    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
+        let _ = &this.pinned1;
+        let _ = &this.pinned2;
+        let _ = &this.unpinned1;
+        let _ = &this.unpinned2;
+    }
+};
+fn main() {}

--- a/tests/expand/tests/expand/multifields-struct.rs
+++ b/tests/expand/tests/expand/multifields-struct.rs
@@ -1,0 +1,13 @@
+use pin_project::pin_project;
+
+#[pin_project(project_replace)]
+struct Struct<T, U> {
+    #[pin]
+    pinned1: T,
+    #[pin]
+    pinned2: T,
+    unpinned1: U,
+    unpinned2: U,
+}
+
+fn main() {}

--- a/tests/expand/tests/expand/multifields-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/multifields-tuple_struct.expanded.rs
@@ -1,0 +1,144 @@
+use pin_project::pin_project;
+#[pin(__private(project_replace))]
+struct TupleStruct<T, U>(#[pin] T, #[pin] T, U, U);
+#[doc(hidden)]
+#[allow(clippy::used_underscore_binding)]
+#[allow(box_pointers)]
+#[allow(explicit_outlives_requirements)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::pattern_type_mismatch)]
+#[allow(clippy::redundant_pub_crate)]
+const _: () = {
+    #[allow(dead_code)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    #[allow(box_pointers)]
+    #[allow(explicit_outlives_requirements)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::pattern_type_mismatch)]
+    #[allow(clippy::redundant_pub_crate)]
+    struct __TupleStructProjection<'pin, T, U>(
+        ::pin_project::__private::Pin<&'pin mut (T)>,
+        ::pin_project::__private::Pin<&'pin mut (T)>,
+        &'pin mut (U),
+        &'pin mut (U),
+    )
+    where
+        TupleStruct<T, U>: 'pin;
+    #[allow(dead_code)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    #[allow(box_pointers)]
+    #[allow(explicit_outlives_requirements)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::pattern_type_mismatch)]
+    #[allow(clippy::redundant_pub_crate)]
+    struct __TupleStructProjectionRef<'pin, T, U>(
+        ::pin_project::__private::Pin<&'pin (T)>,
+        ::pin_project::__private::Pin<&'pin (T)>,
+        &'pin (U),
+        &'pin (U),
+    )
+    where
+        TupleStruct<T, U>: 'pin;
+    #[allow(dead_code)]
+    #[allow(unreachable_pub)]
+    #[allow(box_pointers)]
+    #[allow(explicit_outlives_requirements)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::pattern_type_mismatch)]
+    #[allow(clippy::redundant_pub_crate)]
+    struct __TupleStructProjectionOwned<T, U>(
+        ::pin_project::__private::PhantomData<T>,
+        ::pin_project::__private::PhantomData<T>,
+        U,
+        U,
+    );
+    impl<T, U> TupleStruct<T, U> {
+        fn project<'pin>(
+            self: ::pin_project::__private::Pin<&'pin mut Self>,
+        ) -> __TupleStructProjection<'pin, T, U> {
+            unsafe {
+                let Self(_0, _1, _2, _3) = self.get_unchecked_mut();
+                __TupleStructProjection(
+                    ::pin_project::__private::Pin::new_unchecked(_0),
+                    ::pin_project::__private::Pin::new_unchecked(_1),
+                    _2,
+                    _3,
+                )
+            }
+        }
+        fn project_ref<'pin>(
+            self: ::pin_project::__private::Pin<&'pin Self>,
+        ) -> __TupleStructProjectionRef<'pin, T, U> {
+            unsafe {
+                let Self(_0, _1, _2, _3) = self.get_ref();
+                __TupleStructProjectionRef(
+                    ::pin_project::__private::Pin::new_unchecked(_0),
+                    ::pin_project::__private::Pin::new_unchecked(_1),
+                    _2,
+                    _3,
+                )
+            }
+        }
+        fn project_replace(
+            self: ::pin_project::__private::Pin<&mut Self>,
+            __replacement: Self,
+        ) -> __TupleStructProjectionOwned<T, U> {
+            unsafe {
+                let __self_ptr: *mut Self = self.get_unchecked_mut();
+                let Self(_0, _1, _2, _3) = &mut *__self_ptr;
+                let __result = __TupleStructProjectionOwned(
+                    ::pin_project::__private::PhantomData,
+                    ::pin_project::__private::PhantomData,
+                    ::pin_project::__private::ptr::read(_2),
+                    ::pin_project::__private::ptr::read(_3),
+                );
+                let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                    target: __self_ptr,
+                    value: ::pin_project::__private::ManuallyDrop::new(__replacement),
+                };
+                {
+                    let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(_1);
+                    let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(_0);
+                }
+                __result
+            }
+        }
+    }
+    struct __TupleStruct<'pin, T, U> {
+        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+            'pin,
+            (
+                ::pin_project::__private::PhantomData<T>,
+                ::pin_project::__private::PhantomData<U>,
+            ),
+        >,
+        __field0: T,
+        __field1: T,
+    }
+    impl<'pin, T, U> ::pin_project::__private::Unpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    {
+    }
+    #[doc(hidden)]
+    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    {
+    }
+    trait TupleStructMustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
+    impl<T, U> TupleStructMustNotImplDrop for TupleStruct<T, U> {}
+    #[doc(hidden)]
+    impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
+        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    }
+    #[forbid(safe_packed_borrows)]
+    fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
+        let _ = &this.0;
+        let _ = &this.1;
+        let _ = &this.2;
+        let _ = &this.3;
+    }
+};
+fn main() {}

--- a/tests/expand/tests/expand/multifields-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/multifields-tuple_struct.expanded.rs
@@ -2,57 +2,45 @@ use pin_project::pin_project;
 #[pin(__private(project_replace))]
 struct TupleStruct<T, U>(#[pin] T, #[pin] T, U, U);
 #[doc(hidden)]
-#[allow(clippy::used_underscore_binding)]
-#[allow(box_pointers)]
-#[allow(explicit_outlives_requirements)]
+#[allow(dead_code)]
 #[allow(single_use_lifetimes)]
-#[allow(clippy::pattern_type_mismatch)]
-#[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::mut_mut)]
+#[allow(clippy::type_repetition_in_bounds)]
+struct __TupleStructProjection<'pin, T, U>(
+    ::pin_project::__private::Pin<&'pin mut (T)>,
+    ::pin_project::__private::Pin<&'pin mut (T)>,
+    &'pin mut (U),
+    &'pin mut (U),
+)
+where
+    TupleStruct<T, U>: 'pin;
+#[doc(hidden)]
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::type_repetition_in_bounds)]
+struct __TupleStructProjectionRef<'pin, T, U>(
+    ::pin_project::__private::Pin<&'pin (T)>,
+    ::pin_project::__private::Pin<&'pin (T)>,
+    &'pin (U),
+    &'pin (U),
+)
+where
+    TupleStruct<T, U>: 'pin;
+#[doc(hidden)]
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
+struct __TupleStructProjectionOwned<T, U>(
+    ::pin_project::__private::PhantomData<T>,
+    ::pin_project::__private::PhantomData<T>,
+    U,
+    U,
+);
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(dead_code)]
-    #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    #[allow(box_pointers)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
-    struct __TupleStructProjection<'pin, T, U>(
-        ::pin_project::__private::Pin<&'pin mut (T)>,
-        ::pin_project::__private::Pin<&'pin mut (T)>,
-        &'pin mut (U),
-        &'pin mut (U),
-    )
-    where
-        TupleStruct<T, U>: 'pin;
-    #[allow(dead_code)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    #[allow(box_pointers)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
-    struct __TupleStructProjectionRef<'pin, T, U>(
-        ::pin_project::__private::Pin<&'pin (T)>,
-        ::pin_project::__private::Pin<&'pin (T)>,
-        &'pin (U),
-        &'pin (U),
-    )
-    where
-        TupleStruct<T, U>: 'pin;
-    #[allow(dead_code)]
-    #[allow(unreachable_pub)]
-    #[allow(box_pointers)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
-    struct __TupleStructProjectionOwned<T, U>(
-        ::pin_project::__private::PhantomData<T>,
-        ::pin_project::__private::PhantomData<T>,
-        U,
-        U,
-    );
     impl<T, U> TupleStruct<T, U> {
         fn project<'pin>(
             self: ::pin_project::__private::Pin<&'pin mut Self>,
@@ -120,25 +108,20 @@ const _: () = {
         __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
     {
     }
-    #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
-    {
-    }
+    unsafe impl<T, U> ::pin_project::UnsafeUnpin for TupleStruct<T, U> {}
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
     impl<T: ::pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
     impl<T, U> TupleStructMustNotImplDrop for TupleStruct<T, U> {}
-    #[doc(hidden)]
     impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
-        let _ = &this.0;
-        let _ = &this.1;
-        let _ = &this.2;
-        let _ = &this.3;
+    fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
+        &val.0;
+        &val.1;
+        &val.2;
+        &val.3;
     }
 };
 fn main() {}

--- a/tests/expand/tests/expand/multifields-tuple_struct.rs
+++ b/tests/expand/tests/expand/multifields-tuple_struct.rs
@@ -1,0 +1,6 @@
+use pin_project::pin_project;
+
+#[pin_project(project_replace)]
+struct TupleStruct<T, U>(#[pin] T, #[pin] T, U, U);
+
+fn main() {}


### PR DESCRIPTION
This is the backport of #287