### PR TITLE
Fix warnings when #[pin_project] used within macro_rules! macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+* Fix warnings when `#[pin_project]` attribute used within `macro_rules!` macros.
+
 ## [1.0.0] - 2020-10-13
 
 * [Remove deprecated `#[project]`, `#[project_ref]`, and `#[project_replace]` attributes.](https://github.com/taiki-e/pin-project/pull/265)

--- a/tests/expand/tests/expand/default-enum.expanded.rs
+++ b/tests/expand/tests/expand/default-enum.expanded.rs
@@ -15,6 +15,7 @@ enum Enum<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum EnumProj<'pin, T, U>
@@ -33,6 +34,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum EnumProjRef<'pin, T, U>
@@ -49,6 +51,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -70,6 +73,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {
@@ -87,6 +91,7 @@ const _: () = {
             }
         }
     }
+    #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/default-struct.expanded.rs
+++ b/tests/expand/tests/expand/default-struct.expanded.rs
@@ -8,6 +8,7 @@ struct Struct<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -18,6 +19,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjection<'pin, T, U>
@@ -32,6 +34,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjectionRef<'pin, T, U>
@@ -53,6 +56,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
@@ -70,6 +74,7 @@ const _: () = {
         let _ = &this.pinned;
         let _ = &this.unpinned;
     }
+    #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/default-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/default-tuple_struct.expanded.rs
@@ -4,6 +4,7 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -14,6 +15,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -27,6 +29,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjectionRef<'pin, T, U>(
@@ -44,6 +47,7 @@ const _: () = {
                 __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
@@ -58,6 +62,7 @@ const _: () = {
         let _ = &this.0;
         let _ = &this.1;
     }
+    #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/multifields-enum.expanded.rs
+++ b/tests/expand/tests/expand/multifields-enum.expanded.rs
@@ -18,6 +18,7 @@ enum Enum<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum EnumProj<'pin, T, U>
@@ -43,6 +44,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum EnumProjRef<'pin, T, U>
@@ -64,11 +66,12 @@ where
     Unit,
 }
 #[allow(dead_code)]
-#[allow(unreachable_pub)]
+#[allow(variant_size_differences)]
 #[allow(clippy::large_enum_variant)]
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum EnumProjOwn<T, U> {
@@ -89,6 +92,7 @@ enum EnumProjOwn<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -120,6 +124,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {
@@ -205,6 +210,7 @@ const _: () = {
             }
         }
     }
+    #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/multifields-struct.expanded.rs
+++ b/tests/expand/tests/expand/multifields-struct.expanded.rs
@@ -11,6 +11,7 @@ struct Struct<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -21,6 +22,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjection<'pin, T, U>
@@ -37,6 +39,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjectionRef<'pin, T, U>
@@ -49,10 +52,10 @@ const _: () = {
         unpinned2: &'pin (U),
     }
     #[allow(dead_code)]
-    #[allow(unreachable_pub)]
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjectionOwned<T, U> {
@@ -80,6 +83,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
@@ -135,6 +139,7 @@ const _: () = {
         let _ = &this.unpinned1;
         let _ = &this.unpinned2;
     }
+    #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/multifields-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/multifields-tuple_struct.expanded.rs
@@ -4,6 +4,7 @@ struct TupleStruct<T, U>(#[pin] T, #[pin] T, U, U);
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -14,6 +15,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -29,6 +31,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjectionRef<'pin, T, U>(
@@ -40,10 +43,10 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     #[allow(dead_code)]
-    #[allow(unreachable_pub)]
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjectionOwned<T, U>(
@@ -66,6 +69,7 @@ const _: () = {
                 )
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
@@ -111,6 +115,7 @@ const _: () = {
         let _ = &this.2;
         let _ = &this.3;
     }
+    #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/naming-enum-all.expanded.rs
+++ b/tests/expand/tests/expand/naming-enum-all.expanded.rs
@@ -15,6 +15,7 @@ enum Enum<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum Proj<'pin, T, U>
@@ -33,6 +34,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum ProjRef<'pin, T, U>
@@ -47,11 +49,12 @@ where
     Unit,
 }
 #[allow(dead_code)]
-#[allow(unreachable_pub)]
+#[allow(variant_size_differences)]
 #[allow(clippy::large_enum_variant)]
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum ProjOwn<T, U> {
@@ -65,6 +68,7 @@ enum ProjOwn<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -84,6 +88,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {
@@ -148,6 +153,7 @@ const _: () = {
             }
         }
     }
+    #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/naming-enum-mut.expanded.rs
+++ b/tests/expand/tests/expand/naming-enum-mut.expanded.rs
@@ -15,6 +15,7 @@ enum Enum<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum Proj<'pin, T, U>
@@ -31,6 +32,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -51,6 +53,7 @@ const _: () = {
             }
         }
     }
+    #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/naming-enum-none.expanded.rs
+++ b/tests/expand/tests/expand/naming-enum-none.expanded.rs
@@ -12,11 +12,13 @@ enum Enum<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {}
+    #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/naming-enum-own.expanded.rs
+++ b/tests/expand/tests/expand/naming-enum-own.expanded.rs
@@ -10,11 +10,12 @@ enum Enum<T, U> {
     Unit,
 }
 #[allow(dead_code)]
-#[allow(unreachable_pub)]
+#[allow(variant_size_differences)]
 #[allow(clippy::large_enum_variant)]
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum ProjOwn<T, U> {
@@ -28,6 +29,7 @@ enum ProjOwn<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -81,6 +83,7 @@ const _: () = {
             }
         }
     }
+    #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/naming-enum-ref.expanded.rs
+++ b/tests/expand/tests/expand/naming-enum-ref.expanded.rs
@@ -14,6 +14,7 @@ enum Enum<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum ProjRef<'pin, T, U>
@@ -30,11 +31,13 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {
@@ -52,6 +55,7 @@ const _: () = {
             }
         }
     }
+    #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/naming-struct-all.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct-all.expanded.rs
@@ -11,6 +11,7 @@ struct Struct<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 struct Proj<'pin, T, U>
@@ -25,6 +26,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 struct ProjRef<'pin, T, U>
@@ -35,10 +37,10 @@ where
     unpinned: &'pin (U),
 }
 #[allow(dead_code)]
-#[allow(unreachable_pub)]
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 struct ProjOwn<T, U> {
@@ -48,6 +50,7 @@ struct ProjOwn<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -62,6 +65,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {
@@ -100,6 +104,7 @@ const _: () = {
         let _ = &this.pinned;
         let _ = &this.unpinned;
     }
+    #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/naming-struct-mut.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct-mut.expanded.rs
@@ -11,6 +11,7 @@ struct Struct<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 struct Proj<'pin, T, U>
@@ -23,6 +24,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -32,6 +34,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjectionRef<'pin, T, U>
@@ -51,6 +54,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
@@ -68,6 +72,7 @@ const _: () = {
         let _ = &this.pinned;
         let _ = &this.unpinned;
     }
+    #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/naming-struct-none.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct-none.expanded.rs
@@ -8,6 +8,7 @@ struct Struct<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -18,6 +19,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjection<'pin, T, U>
@@ -32,6 +34,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjectionRef<'pin, T, U>
@@ -53,6 +56,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
@@ -70,6 +74,7 @@ const _: () = {
         let _ = &this.pinned;
         let _ = &this.unpinned;
     }
+    #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/naming-struct-own.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct-own.expanded.rs
@@ -6,10 +6,10 @@ struct Struct<T, U> {
     unpinned: U,
 }
 #[allow(dead_code)]
-#[allow(unreachable_pub)]
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 struct ProjOwn<T, U> {
@@ -19,6 +19,7 @@ struct ProjOwn<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -29,6 +30,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjection<'pin, T, U>
@@ -43,6 +45,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjectionRef<'pin, T, U>
@@ -64,6 +67,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
@@ -102,6 +106,7 @@ const _: () = {
         let _ = &this.pinned;
         let _ = &this.unpinned;
     }
+    #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/naming-struct-ref.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct-ref.expanded.rs
@@ -10,6 +10,7 @@ struct Struct<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 struct ProjRef<'pin, T, U>
@@ -22,6 +23,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -32,6 +34,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjection<'pin, T, U>
@@ -53,6 +56,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {
@@ -70,6 +74,7 @@ const _: () = {
         let _ = &this.pinned;
         let _ = &this.unpinned;
     }
+    #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/naming-tuple_struct-all.expanded.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct-all.expanded.rs
@@ -7,6 +7,7 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 struct Proj<'pin, T, U>(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U))
@@ -17,22 +18,24 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 struct ProjRef<'pin, T, U>(::pin_project::__private::Pin<&'pin (T)>, &'pin (U))
 where
     TupleStruct<T, U>: 'pin;
 #[allow(dead_code)]
-#[allow(unreachable_pub)]
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 struct ProjOwn<T, U>(::pin_project::__private::PhantomData<T>, U);
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -44,6 +47,7 @@ const _: () = {
                 Proj(::pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {
@@ -79,6 +83,7 @@ const _: () = {
         let _ = &this.0;
         let _ = &this.1;
     }
+    #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/naming-tuple_struct-mut.expanded.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct-mut.expanded.rs
@@ -7,6 +7,7 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 struct Proj<'pin, T, U>(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U))
@@ -15,6 +16,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -24,6 +26,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjectionRef<'pin, T, U>(
@@ -39,6 +42,7 @@ const _: () = {
                 Proj(::pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
@@ -53,6 +57,7 @@ const _: () = {
         let _ = &this.0;
         let _ = &this.1;
     }
+    #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/naming-tuple_struct-none.expanded.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct-none.expanded.rs
@@ -4,6 +4,7 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -14,6 +15,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -27,6 +29,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjectionRef<'pin, T, U>(
@@ -44,6 +47,7 @@ const _: () = {
                 __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
@@ -58,6 +62,7 @@ const _: () = {
         let _ = &this.0;
         let _ = &this.1;
     }
+    #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/naming-tuple_struct-own.expanded.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct-own.expanded.rs
@@ -2,16 +2,17 @@ use pin_project::pin_project;
 # [pin (__private (project_replace = ProjOwn))]
 struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(dead_code)]
-#[allow(unreachable_pub)]
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 struct ProjOwn<T, U>(::pin_project::__private::PhantomData<T>, U);
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -22,6 +23,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -35,6 +37,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjectionRef<'pin, T, U>(
@@ -52,6 +55,7 @@ const _: () = {
                 __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
@@ -87,6 +91,7 @@ const _: () = {
         let _ = &this.0;
         let _ = &this.1;
     }
+    #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/naming-tuple_struct-ref.expanded.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct-ref.expanded.rs
@@ -6,6 +6,7 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 struct ProjRef<'pin, T, U>(::pin_project::__private::Pin<&'pin (T)>, &'pin (U))
@@ -14,6 +15,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -24,6 +26,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -41,6 +44,7 @@ const _: () = {
                 __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {
@@ -55,6 +59,7 @@ const _: () = {
         let _ = &this.0;
         let _ = &this.1;
     }
+    #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/not_unpin-enum.expanded.rs
+++ b/tests/expand/tests/expand/not_unpin-enum.expanded.rs
@@ -15,6 +15,7 @@ enum Enum<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum EnumProj<'pin, T, U>
@@ -33,6 +34,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum EnumProjRef<'pin, T, U>
@@ -49,6 +51,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -70,6 +73,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {

--- a/tests/expand/tests/expand/not_unpin-struct.expanded.rs
+++ b/tests/expand/tests/expand/not_unpin-struct.expanded.rs
@@ -8,6 +8,7 @@ struct Struct<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -18,6 +19,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjection<'pin, T, U>
@@ -32,6 +34,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjectionRef<'pin, T, U>
@@ -53,6 +56,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/tests/expand/not_unpin-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/not_unpin-tuple_struct.expanded.rs
@@ -4,6 +4,7 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -14,6 +15,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -27,6 +29,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjectionRef<'pin, T, U>(
@@ -44,6 +47,7 @@ const _: () = {
                 __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/tests/expand/pinned_drop-enum.expanded.rs
+++ b/tests/expand/tests/expand/pinned_drop-enum.expanded.rs
@@ -16,6 +16,7 @@ enum Enum<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum EnumProj<'pin, T, U>
@@ -34,6 +35,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum EnumProjRef<'pin, T, U>
@@ -50,6 +52,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -71,6 +74,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {
@@ -88,6 +92,7 @@ const _: () = {
             }
         }
     }
+    #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/pinned_drop-struct.expanded.rs
+++ b/tests/expand/tests/expand/pinned_drop-struct.expanded.rs
@@ -9,6 +9,7 @@ struct Struct<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -19,6 +20,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjection<'pin, T, U>
@@ -33,6 +35,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjectionRef<'pin, T, U>
@@ -54,6 +57,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
@@ -71,6 +75,7 @@ const _: () = {
         let _ = &this.pinned;
         let _ = &this.unpinned;
     }
+    #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/pinned_drop-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/pinned_drop-tuple_struct.expanded.rs
@@ -5,6 +5,7 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -15,6 +16,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -28,6 +30,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjectionRef<'pin, T, U>(
@@ -45,6 +48,7 @@ const _: () = {
                 __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
@@ -59,6 +63,7 @@ const _: () = {
         let _ = &this.0;
         let _ = &this.1;
     }
+    #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/project_replace-enum.expanded.rs
+++ b/tests/expand/tests/expand/project_replace-enum.expanded.rs
@@ -10,11 +10,12 @@ enum Enum<T, U> {
     Unit,
 }
 #[allow(dead_code)]
-#[allow(unreachable_pub)]
+#[allow(variant_size_differences)]
 #[allow(clippy::large_enum_variant)]
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum EnumProjOwn<T, U> {
@@ -28,6 +29,7 @@ enum EnumProjOwn<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -81,6 +83,7 @@ const _: () = {
             }
         }
     }
+    #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/project_replace-struct.expanded.rs
+++ b/tests/expand/tests/expand/project_replace-struct.expanded.rs
@@ -8,6 +8,7 @@ struct Struct<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -18,6 +19,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjection<'pin, T, U>
@@ -32,6 +34,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjectionRef<'pin, T, U>
@@ -42,10 +45,10 @@ const _: () = {
         unpinned: &'pin (U),
     }
     #[allow(dead_code)]
-    #[allow(unreachable_pub)]
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjectionOwned<T, U> {
@@ -64,6 +67,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
@@ -102,6 +106,7 @@ const _: () = {
         let _ = &this.pinned;
         let _ = &this.unpinned;
     }
+    #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/project_replace-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/project_replace-tuple_struct.expanded.rs
@@ -4,6 +4,7 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -14,6 +15,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -27,6 +29,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjectionRef<'pin, T, U>(
@@ -36,10 +39,10 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     #[allow(dead_code)]
-    #[allow(unreachable_pub)]
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjectionOwned<T, U>(::pin_project::__private::PhantomData<T>, U);
@@ -52,6 +55,7 @@ const _: () = {
                 __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
@@ -87,6 +91,7 @@ const _: () = {
         let _ = &this.0;
         let _ = &this.1;
     }
+    #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/pub-enum.expanded.rs
+++ b/tests/expand/tests/expand/pub-enum.expanded.rs
@@ -15,6 +15,7 @@ pub enum Enum<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 pub(crate) enum EnumProj<'pin, T, U>
@@ -33,6 +34,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 pub(crate) enum EnumProjRef<'pin, T, U>
@@ -49,6 +51,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -70,6 +73,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         pub(crate) fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {
@@ -87,6 +91,7 @@ const _: () = {
             }
         }
     }
+    #[allow(missing_debug_implementations)]
     pub struct __Enum<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/pub-struct.expanded.rs
+++ b/tests/expand/tests/expand/pub-struct.expanded.rs
@@ -8,6 +8,7 @@ pub struct Struct<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -18,6 +19,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     pub(crate) struct __StructProjection<'pin, T, U>
@@ -32,6 +34,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     pub(crate) struct __StructProjectionRef<'pin, T, U>
@@ -53,6 +56,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         pub(crate) fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
@@ -70,6 +74,7 @@ const _: () = {
         let _ = &this.pinned;
         let _ = &this.unpinned;
     }
+    #[allow(missing_debug_implementations)]
     pub struct __Struct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/pub-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/pub-tuple_struct.expanded.rs
@@ -4,6 +4,7 @@ pub struct TupleStruct<T, U>(#[pin] pub T, pub U);
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -14,6 +15,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     pub(crate) struct __TupleStructProjection<'pin, T, U>(
@@ -27,6 +29,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     pub(crate) struct __TupleStructProjectionRef<'pin, T, U>(
@@ -44,6 +47,7 @@ const _: () = {
                 __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         pub(crate) fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
@@ -58,6 +62,7 @@ const _: () = {
         let _ = &this.0;
         let _ = &this.1;
     }
+    #[allow(missing_debug_implementations)]
     pub struct __TupleStruct<'pin, T, U> {
         __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
             'pin,

--- a/tests/expand/tests/expand/unsafe_unpin-enum.expanded.rs
+++ b/tests/expand/tests/expand/unsafe_unpin-enum.expanded.rs
@@ -15,6 +15,7 @@ enum Enum<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum EnumProj<'pin, T, U>
@@ -33,6 +34,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 enum EnumProjRef<'pin, T, U>
@@ -49,6 +51,7 @@ where
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -70,6 +73,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {

--- a/tests/expand/tests/expand/unsafe_unpin-struct.expanded.rs
+++ b/tests/expand/tests/expand/unsafe_unpin-struct.expanded.rs
@@ -8,6 +8,7 @@ struct Struct<T, U> {
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -18,6 +19,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjection<'pin, T, U>
@@ -32,6 +34,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __StructProjectionRef<'pin, T, U>
@@ -53,6 +56,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/tests/expand/unsafe_unpin-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/unsafe_unpin-tuple_struct.expanded.rs
@@ -4,6 +4,7 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(box_pointers)]
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(unreachable_pub)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
@@ -14,6 +15,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -27,6 +29,7 @@ const _: () = {
     #[allow(box_pointers)]
     #[allow(explicit_outlives_requirements)]
     #[allow(single_use_lifetimes)]
+    #[allow(unreachable_pub)]
     #[allow(clippy::pattern_type_mismatch)]
     #[allow(clippy::redundant_pub_crate)]
     struct __TupleStructProjectionRef<'pin, T, U>(
@@ -44,6 +47,7 @@ const _: () = {
                 __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
+        #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: ::pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -41,6 +41,182 @@
 
 pub mod basic {
     include!("include/basic.rs");
+
+    pub mod inside_macro {
+        #[rustfmt::skip]
+        macro_rules! mac {
+            () => {
+                #[::pin_project::pin_project]
+                #[derive(Debug)]
+                pub struct DefaultStruct<T, U> {
+                    #[pin]
+                    pub pinned: T,
+                    pub unpinned: U,
+                }
+
+                #[::pin_project::pin_project]
+                #[derive(Debug)]
+                pub struct DefaultTupleStruct<T, U>(#[pin] pub T, pub U);
+
+                #[::pin_project::pin_project(
+                    project = DefaultEnumProj,
+                    project_ref = DefaultEnumProjRef,
+                )]
+                #[derive(Debug)]
+                pub enum DefaultEnum<T, U> {
+                    Struct {
+                        #[pin]
+                        pinned: T,
+                        unpinned: U,
+                    },
+                    Tuple(#[pin] T, U),
+                    Unit,
+                }
+
+                #[::pin_project::pin_project(PinnedDrop)]
+                #[derive(Debug)]
+                pub struct PinnedDropStruct<T, U> {
+                    #[pin]
+                    pub pinned: T,
+                    pub unpinned: U,
+                }
+
+                #[::pin_project::pinned_drop]
+                impl<T, U> PinnedDrop for PinnedDropStruct<T, U> {
+                    fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+                }
+
+                #[::pin_project::pin_project(PinnedDrop)]
+                #[derive(Debug)]
+                pub struct PinnedDropTupleStruct<T, U>(#[pin] pub T, pub U);
+
+                #[::pin_project::pinned_drop]
+                impl<T, U> PinnedDrop for PinnedDropTupleStruct<T, U> {
+                    fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+                }
+
+                #[::pin_project::pin_project(
+                    PinnedDrop,
+                    project = PinnedDropEnumProj,
+                    project_ref = PinnedDropEnumProjRef,
+                )]
+                #[derive(Debug)]
+                pub enum PinnedDropEnum<T, U> {
+                    Struct {
+                        #[pin]
+                        pinned: T,
+                        unpinned: U,
+                    },
+                    Tuple(#[pin] T, U),
+                    Unit,
+                }
+
+                #[::pin_project::pinned_drop]
+                impl<T, U> PinnedDrop for PinnedDropEnum<T, U> {
+                    fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+                }
+
+                #[::pin_project::pin_project(project_replace)]
+                #[derive(Debug)]
+                pub struct ReplaceStruct<T, U> {
+                    #[pin]
+                    pub pinned: T,
+                    pub unpinned: U,
+                }
+
+                #[::pin_project::pin_project(project_replace)]
+                #[derive(Debug)]
+                pub struct ReplaceTupleStruct<T, U>(#[pin] pub T, pub U);
+
+                #[::pin_project::pin_project(
+                    project = ReplaceEnumProj,
+                    project_ref = ReplaceEnumProjRef,
+                    project_replace = ReplaceEnumProjOwn,
+                )]
+                #[derive(Debug)]
+                pub enum ReplaceEnum<T, U> {
+                    Struct {
+                        #[pin]
+                        pinned: T,
+                        unpinned: U,
+                    },
+                    Tuple(#[pin] T, U),
+                    Unit,
+                }
+
+                #[::pin_project::pin_project(UnsafeUnpin)]
+                #[derive(Debug)]
+                pub struct UnsafeUnpinStruct<T, U> {
+                    #[pin]
+                    pub pinned: T,
+                    pub unpinned: U,
+                }
+
+                #[::pin_project::pin_project(UnsafeUnpin)]
+                #[derive(Debug)]
+                pub struct UnsafeUnpinTupleStruct<T, U>(#[pin] pub T, pub U);
+
+                #[::pin_project::pin_project(
+                    UnsafeUnpin,
+                    project = UnsafeUnpinEnumProj,
+                    project_ref = UnsafeUnpinEnumProjRef,
+                )]
+                #[derive(Debug)]
+                pub enum UnsafeUnpinEnum<T, U> {
+                    Struct {
+                        #[pin]
+                        pinned: T,
+                        unpinned: U,
+                    },
+                    Tuple(#[pin] T, U),
+                    Unit,
+                }
+
+                #[::pin_project::pin_project(!Unpin)]
+                #[derive(Debug)]
+                pub struct NotUnpinStruct<T, U> {
+                    #[pin]
+                    pub pinned: T,
+                    pub unpinned: U,
+                }
+
+                #[::pin_project::pin_project(!Unpin)]
+                #[derive(Debug)]
+                pub struct NotUnpinTupleStruct<T, U>(#[pin] pub T, pub U);
+
+                #[::pin_project::pin_project(
+                    !Unpin,
+                    project = NotUnpinEnumProj,
+                    project_ref = NotUnpinEnumProjRef,
+                )]
+                #[derive(Debug)]
+                pub enum NotUnpinEnum<T, U> {
+                    Struct {
+                        #[pin]
+                        pinned: T,
+                        unpinned: U,
+                    },
+                    Tuple(#[pin] T, U),
+                    Unit,
+                }
+
+                unsafe impl<T: ::pin_project::__private::Unpin, U: ::pin_project::__private::Unpin>
+                    ::pin_project::UnsafeUnpin for UnsafeUnpinStruct<T, U>
+                {
+                }
+                unsafe impl<T: ::pin_project::__private::Unpin, U: ::pin_project::__private::Unpin>
+                    ::pin_project::UnsafeUnpin for UnsafeUnpinTupleStruct<T, U>
+                {
+                }
+                unsafe impl<T: ::pin_project::__private::Unpin, U: ::pin_project::__private::Unpin>
+                    ::pin_project::UnsafeUnpin for UnsafeUnpinEnum<T, U>
+                {
+                }
+            };
+        }
+
+        mac!();
+    }
 }
 
 pub mod forbid_unsafe {
@@ -81,6 +257,48 @@ pub mod box_pointers {
         },
         Tuple(#[pin] Box<isize>, Box<isize>),
         Unit,
+    }
+
+    pub mod inside_macro {
+        use pin_project::pin_project;
+
+        #[rustfmt::skip]
+        macro_rules! mac {
+            () => {
+                #[allow(box_pointers)] // for the type itself
+                #[pin_project(project_replace)]
+                #[derive(Debug)]
+                pub struct Struct {
+                    #[pin]
+                    pub p: Box<isize>,
+                    pub u: Box<isize>,
+                }
+
+                #[allow(box_pointers)] // for the type itself
+                #[pin_project(project_replace)]
+                #[derive(Debug)]
+                pub struct TupleStruct(#[pin] pub Box<isize>, pub Box<isize>);
+
+                #[allow(box_pointers)] // for the type itself
+                #[pin_project(
+                    project = EnumProj,
+                    project_ref = EnumProjRef,
+                    project_replace = EnumProjOwn,
+                )]
+                #[derive(Debug)]
+                pub enum Enum {
+                    Struct {
+                        #[pin]
+                        p: Box<isize>,
+                        u: Box<isize>,
+                    },
+                    Tuple(#[pin] Box<isize>, Box<isize>),
+                    Unit,
+                }
+            };
+        }
+
+        mac!();
     }
 }
 
@@ -128,6 +346,59 @@ pub mod explicit_outlives_requirements {
         Tuple(#[pin] &'a mut T, &'a mut U),
         Unit,
     }
+
+    pub mod inside_macro {
+        use pin_project::pin_project;
+
+        #[rustfmt::skip]
+        macro_rules! mac {
+            () => {
+                #[allow(explicit_outlives_requirements)] // for the type itself: https://github.com/rust-lang/rust/issues/60993
+                #[pin_project(project_replace)]
+                #[derive(Debug)]
+                pub struct Struct<'a, T, U>
+                where
+                    T: ?Sized,
+                    U: ?Sized,
+                {
+                    #[pin]
+                    pub pinned: &'a mut T,
+                    pub unpinned: &'a mut U,
+                }
+
+                #[allow(explicit_outlives_requirements)] // for the type itself: https://github.com/rust-lang/rust/issues/60993
+                #[pin_project(project_replace)]
+                #[derive(Debug)]
+                pub struct TupleStruct<'a, T, U>(#[pin] pub &'a mut T, pub &'a mut U)
+                where
+                    T: ?Sized,
+                    U: ?Sized;
+
+                #[allow(explicit_outlives_requirements)] // for the type itself: https://github.com/rust-lang/rust/issues/60993
+                #[pin_project(
+                    project = EnumProj,
+                    project_ref = EnumProjRef,
+                    project_replace = EnumProjOwn,
+                )]
+                #[derive(Debug)]
+                pub enum Enum<'a, T, U>
+                where
+                    T: ?Sized,
+                    U: ?Sized,
+                {
+                    Struct {
+                        #[pin]
+                        pinned: &'a mut T,
+                        unpinned: &'a mut U,
+                    },
+                    Tuple(#[pin] &'a mut T, &'a mut U),
+                    Unit,
+                }
+            };
+        }
+
+        mac!();
+    }
 }
 
 pub mod single_use_lifetimes {
@@ -149,6 +420,34 @@ pub mod single_use_lifetimes {
         #[pin]
         f: &'pin___ mut T,
     }
+
+    pub mod inside_macro {
+        use pin_project::pin_project;
+
+        #[rustfmt::skip]
+        macro_rules! mac {
+            () => {
+                #[allow(unused_lifetimes)]
+                pub trait Trait<'a> {}
+
+                #[allow(unused_lifetimes)] // for the type itself
+                #[allow(single_use_lifetimes)] // for the type itself: https://github.com/rust-lang/rust/issues/55058
+                #[pin_project(project_replace)]
+                #[derive(Debug)]
+                pub struct HRTB<'pin___, T>
+                where
+                    for<'pin> &'pin T: Unpin,
+                    T: for<'pin> Trait<'pin>,
+                    for<'pin, 'pin_, 'pin__> &'pin &'pin_ &'pin__ T: Unpin,
+                {
+                    #[pin]
+                    f: &'pin___ mut T,
+                }
+            };
+        }
+
+        mac!();
+    }
 }
 
 pub mod variant_size_differences {
@@ -165,6 +464,30 @@ pub mod variant_size_differences {
     pub enum Enum {
         V1(u8),
         V2([u8; 1024]),
+    }
+
+    pub mod inside_macro {
+        use pin_project::pin_project;
+
+        #[rustfmt::skip]
+        macro_rules! mac {
+            () => {
+                #[allow(missing_debug_implementations, missing_copy_implementations)] // https://github.com/rust-lang/rust/pull/74060
+                #[allow(variant_size_differences)] // for the type itself
+                #[allow(clippy::large_enum_variant)] // for the type itself
+                #[pin_project(
+                    project = EnumProj,
+                    project_ref = EnumProjRef,
+                    project_replace = EnumProjOwn,
+                )]
+                pub enum Enum {
+                    V1(u8),
+                    V2([u8; 1024]),
+                }
+            };
+        }
+
+        mac!();
     }
 }
 
@@ -197,6 +520,45 @@ pub mod clippy_mut_mut {
         },
         Tuple(#[pin] &'a mut T, &'a mut U),
         Unit,
+    }
+
+    pub mod inside_macro {
+        use pin_project::pin_project;
+
+        #[rustfmt::skip]
+        macro_rules! mac {
+            () => {
+                #[pin_project(project_replace)]
+                #[derive(Debug)]
+                pub struct Struct<'a, T, U> {
+                    #[pin]
+                    pub pinned: &'a mut T,
+                    pub unpinned: &'a mut U,
+                }
+
+                #[pin_project(project_replace)]
+                #[derive(Debug)]
+                pub struct TupleStruct<'a, T, U>(#[pin] &'a mut T, &'a mut U);
+
+                #[pin_project(
+                    project = EnumProj,
+                    project_ref = EnumProjRef,
+                    project_replace = EnumProjOwn,
+                )]
+                #[derive(Debug)]
+                pub enum Enum<'a, T, U> {
+                    Struct {
+                        #[pin]
+                        pinned: &'a mut T,
+                        unpinned: &'a mut U,
+                    },
+                    Tuple(#[pin] &'a mut T, &'a mut U),
+                    Unit,
+                }
+            };
+        }
+
+        mac!();
     }
 }
 
@@ -231,6 +593,46 @@ mod clippy_redundant_pub_crate {
         },
         Tuple(#[pin] T, U),
         Unit,
+    }
+
+    pub mod inside_macro {
+        use pin_project::pin_project;
+
+        #[rustfmt::skip]
+        macro_rules! mac {
+            () => {
+                #[pin_project(project_replace)]
+                #[derive(Debug)]
+                pub struct Struct<T, U> {
+                    #[pin]
+                    pub pinned: T,
+                    pub unpinned: U,
+                }
+
+                #[pin_project(project_replace)]
+                #[derive(Debug)]
+                pub struct TupleStruct<T, U>(#[pin] pub T, pub U);
+
+                #[allow(dead_code)]
+                #[pin_project(
+                    project = EnumProj,
+                    project_ref = EnumProjRef,
+                    project_replace = EnumProjOwn,
+                )]
+                #[derive(Debug)]
+                pub enum Enum<T, U> {
+                    Struct {
+                        #[pin]
+                        pinned: T,
+                        unpinned: U,
+                    },
+                    Tuple(#[pin] T, U),
+                    Unit,
+                }
+            };
+        }
+
+        mac!();
     }
 }
 
@@ -272,6 +674,53 @@ pub mod clippy_type_repetition_in_bounds {
         Tuple(#[pin] T, U),
         Unit,
     }
+
+    pub mod inside_macro {
+        use pin_project::pin_project;
+
+        #[rustfmt::skip]
+        macro_rules! mac {
+            () => {
+                #[pin_project(project_replace)]
+                #[derive(Debug)]
+                pub struct Struct<T, U>
+                where
+                    Self: Sized,
+                {
+                    #[pin]
+                    pub pinned: T,
+                    pub unpinned: U,
+                }
+
+                #[pin_project(project_replace)]
+                #[derive(Debug)]
+                pub struct TupleStruct<T, U>(#[pin] T, U)
+                where
+                    Self: Sized;
+
+                #[pin_project(
+                    project = EnumProj,
+                    project_ref = EnumProjRef,
+                    project_replace = EnumProjOwn,
+                )]
+                #[derive(Debug)]
+                pub enum Enum<T, U>
+                where
+                    Self: Sized,
+                {
+                    Struct {
+                        #[pin]
+                        pinned: T,
+                        unpinned: U,
+                    },
+                    Tuple(#[pin] T, U),
+                    Unit,
+                }
+            };
+        }
+
+        mac!();
+    }
 }
 
 pub mod clippy_used_underscore_binding {
@@ -297,6 +746,39 @@ pub mod clippy_used_underscore_binding {
             _pinned: T,
             _unpinned: U,
         },
+    }
+
+    pub mod inside_macro {
+        use pin_project::pin_project;
+
+        #[rustfmt::skip]
+        macro_rules! mac {
+            () => {
+                #[pin_project(project_replace)]
+                #[derive(Debug)]
+                pub struct Struct<T, U> {
+                    #[pin]
+                    pub _pinned: T,
+                    pub _unpinned: U,
+                }
+
+                #[pin_project(
+                    project = EnumProj,
+                    project_ref = EnumProjRef,
+                    project_replace = EnumProjOwn,
+                )]
+                #[derive(Debug)]
+                pub enum Enum<T, U> {
+                    Struct {
+                        #[pin]
+                        _pinned: T,
+                        _unpinned: U,
+                    },
+                }
+            };
+        }
+
+        mac!();
     }
 }
 


### PR DESCRIPTION
When `#[pin_project]` attribute used within `macro_rules!` macros, the generated code receives warnings.

```rust
#![warn(missing_debug_implementations)]

#[pin_project::pin_project] // <- no warning
#[derive(Debug)]
pub struct A {
    #[pin]
    _f: (),
}

macro_rules! mac {
    () => {
        #[pin_project::pin_project] //~WARN type does not implement `Debug`
        #[derive(Debug)]
        pub struct B {
            #[pin]
            _f: (),
        }
    };
}

mac!();
```

[playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=fb33b572fc967f70710edb5026083266)

Refs: https://github.com/rust-lang/rust/issues/77973