### PR TITLE
Improve output of check_lint_list test when failed

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,2 @@
-[attr]rust text eol=lf whitespace=tab-in-indent,trailing-space,tabwidth=4
-
 * text=auto eol=lf
-*.rs rust
+*.rs text eol=lf whitespace=tab-in-indent,trailing-space,tabwidth=4

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -1024,7 +1024,7 @@ pub mod clippy_used_underscore_binding {
 #[cfg(not(miri))]
 #[allow(box_pointers)]
 #[allow(clippy::restriction)]
-#[rustversion::attr(before(2020-10-26), ignore)]
+#[rustversion::attr(before(2020-10-27), ignore)]
 #[test]
 fn check_lint_list() {
     use std::{env, fs, path::Path, process::Command, str};

--- a/tests/lint.txt
+++ b/tests/lint.txt
@@ -59,6 +59,7 @@ Lint checks provided by rustc:
                                                 drop-bounds  warn     bounds of the form `T: Drop` are useless
                           ellipsis-inclusive-range-patterns  warn     `...` range patterns are deprecated
                               exported-private-dependencies  warn     public interface leaks type from a private dependency
+                                   function-item-references  warn     suggest casting to a function pointer when attempting to take references to function items
                      illegal-floating-point-literal-pattern  warn     floating-point literals cannot be used in patterns
                                             improper-ctypes  warn     proper use of libc types in foreign modules
                                 improper-ctypes-definitions  warn     proper use of libc types in foreign item definitions


### PR DESCRIPTION
This test is to make sure that the lint list (`tests/lint.txt`) is up to date, but [the output when it fails](https://github.com/taiki-e/pin-project/runs/1318282067?check_suite_focus=true) is bad and the fix was a bit annoying.

Context: 9cf58447084445407c358d7a0852495c5588efe0