### PR TITLE
Prepare for removal of safe_packed_borrows lint

### DIFF
--- a/examples/not_unpin-expanded.rs
+++ b/examples/not_unpin-expanded.rs
@@ -76,7 +76,7 @@ const _: () = {
     //
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
     // for details.
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/examples/pinned_drop-expanded.rs
+++ b/examples/pinned_drop-expanded.rs
@@ -82,7 +82,7 @@ const _: () = {
     //
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
     // for details.
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<'a, T>(this: &Struct<'a, T>) {
         let _ = &this.was_dropped;
         let _ = &this.field;

--- a/examples/project_replace-expanded.rs
+++ b/examples/project_replace-expanded.rs
@@ -112,7 +112,7 @@ const _: () = {
     //
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
     // for details.
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/examples/struct-default-expanded.rs
+++ b/examples/struct-default-expanded.rs
@@ -71,10 +71,8 @@ const _: () = {
     // Ensure that it's impossible to use pin projections on a #[repr(packed)]
     // struct.
     //
-    // Taking a reference to a packed field is unsafe, and applying
-    // #[forbid(safe_packed_borrows)] makes sure that doing this without
-    // an 'unsafe' block (which we deliberately do not generate)
-    // is a hard error.
+    // Taking a reference to a packed field is UB, and applying
+    // `#[forbid(unaligned_references)]` makes sure that doing this is a hard error.
     //
     // If the struct ends up having #[repr(packed)] applied somehow,
     // this will generate an (unfriendly) error message. Under all reasonable
@@ -82,7 +80,7 @@ const _: () = {
     // a much nicer error above.
     //
     // See https://github.com/taiki-e/pin-project/pull/34 for more details.
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/examples/unsafe_unpin-expanded.rs
+++ b/examples/unsafe_unpin-expanded.rs
@@ -75,7 +75,7 @@ const _: () = {
     //
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
     // for details.
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/default/struct.expanded.rs
+++ b/tests/expand/default/struct.expanded.rs
@@ -77,7 +77,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/default/tuple_struct.expanded.rs
+++ b/tests/expand/default/tuple_struct.expanded.rs
@@ -65,7 +65,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/multifields/struct.expanded.rs
+++ b/tests/expand/multifields/struct.expanded.rs
@@ -142,7 +142,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned1;
         let _ = &this.pinned2;

--- a/tests/expand/multifields/tuple_struct.expanded.rs
+++ b/tests/expand/multifields/tuple_struct.expanded.rs
@@ -118,7 +118,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/naming/struct-all.expanded.rs
+++ b/tests/expand/naming/struct-all.expanded.rs
@@ -109,7 +109,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/naming/struct-mut.expanded.rs
+++ b/tests/expand/naming/struct-mut.expanded.rs
@@ -75,7 +75,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/naming/struct-none.expanded.rs
+++ b/tests/expand/naming/struct-none.expanded.rs
@@ -77,7 +77,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/naming/struct-own.expanded.rs
+++ b/tests/expand/naming/struct-own.expanded.rs
@@ -111,7 +111,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/naming/struct-ref.expanded.rs
+++ b/tests/expand/naming/struct-ref.expanded.rs
@@ -77,7 +77,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/naming/tuple_struct-all.expanded.rs
+++ b/tests/expand/naming/tuple_struct-all.expanded.rs
@@ -88,7 +88,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/naming/tuple_struct-mut.expanded.rs
+++ b/tests/expand/naming/tuple_struct-mut.expanded.rs
@@ -60,7 +60,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/naming/tuple_struct-none.expanded.rs
+++ b/tests/expand/naming/tuple_struct-none.expanded.rs
@@ -65,7 +65,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/naming/tuple_struct-own.expanded.rs
+++ b/tests/expand/naming/tuple_struct-own.expanded.rs
@@ -96,7 +96,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/naming/tuple_struct-ref.expanded.rs
+++ b/tests/expand/naming/tuple_struct-ref.expanded.rs
@@ -62,7 +62,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/not_unpin/struct.expanded.rs
+++ b/tests/expand/not_unpin/struct.expanded.rs
@@ -77,7 +77,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/not_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/not_unpin/tuple_struct.expanded.rs
@@ -65,7 +65,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/pinned_drop/enum.expanded.rs
+++ b/tests/expand/pinned_drop/enum.expanded.rs
@@ -1,5 +1,5 @@
-use pin_project::{pin_project, pinned_drop};
 use std::pin::Pin;
+use pin_project::{pin_project, pinned_drop};
 # [pin (__private (PinnedDrop , project = EnumProj , project_ref = EnumProjRef))]
 enum Enum<T, U> {
     Struct {

--- a/tests/expand/pinned_drop/enum.rs
+++ b/tests/expand/pinned_drop/enum.rs
@@ -1,5 +1,6 @@
-use pin_project::{pin_project, pinned_drop};
 use std::pin::Pin;
+
+use pin_project::{pin_project, pinned_drop};
 
 #[pin_project(PinnedDrop, project = EnumProj, project_ref = EnumProjRef)]
 enum Enum<T, U> {

--- a/tests/expand/pinned_drop/struct.expanded.rs
+++ b/tests/expand/pinned_drop/struct.expanded.rs
@@ -1,5 +1,5 @@
-use pin_project::{pin_project, pinned_drop};
 use std::pin::Pin;
+use pin_project::{pin_project, pinned_drop};
 #[pin(__private(PinnedDrop))]
 struct Struct<T, U> {
     #[pin]
@@ -78,7 +78,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/pinned_drop/struct.rs
+++ b/tests/expand/pinned_drop/struct.rs
@@ -1,5 +1,6 @@
-use pin_project::{pin_project, pinned_drop};
 use std::pin::Pin;
+
+use pin_project::{pin_project, pinned_drop};
 
 #[pin_project(PinnedDrop)]
 struct Struct<T, U> {

--- a/tests/expand/pinned_drop/tuple_struct.expanded.rs
+++ b/tests/expand/pinned_drop/tuple_struct.expanded.rs
@@ -1,5 +1,5 @@
-use pin_project::{pin_project, pinned_drop};
 use std::pin::Pin;
+use pin_project::{pin_project, pinned_drop};
 #[pin(__private(PinnedDrop))]
 struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(box_pointers)]
@@ -66,7 +66,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/pinned_drop/tuple_struct.rs
+++ b/tests/expand/pinned_drop/tuple_struct.rs
@@ -1,5 +1,6 @@
-use pin_project::{pin_project, pinned_drop};
 use std::pin::Pin;
+
+use pin_project::{pin_project, pinned_drop};
 
 #[pin_project(PinnedDrop)]
 struct TupleStruct<T, U>(#[pin] T, U);

--- a/tests/expand/project_replace/struct.expanded.rs
+++ b/tests/expand/project_replace/struct.expanded.rs
@@ -111,7 +111,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/project_replace/tuple_struct.expanded.rs
+++ b/tests/expand/project_replace/tuple_struct.expanded.rs
@@ -96,7 +96,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/pub/struct.expanded.rs
+++ b/tests/expand/pub/struct.expanded.rs
@@ -77,7 +77,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/pub/tuple_struct.expanded.rs
+++ b/tests/expand/pub/tuple_struct.expanded.rs
@@ -65,7 +65,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/expand/unsafe_unpin/struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/struct.expanded.rs
@@ -77,7 +77,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
@@ -65,7 +65,7 @@ const _: () = {
             }
         }
     }
-    #[forbid(safe_packed_borrows)]
+    #[forbid(unaligned_references, safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
         let _ = &this.0;
         let _ = &this.1;

--- a/tests/repr_packed.rs
+++ b/tests/repr_packed.rs
@@ -1,5 +1,8 @@
 #![warn(rust_2018_idioms, single_use_lifetimes)]
-#![forbid(safe_packed_borrows)]
+// unaligned_references did not exist in older compilers and safe_packed_borrows was removed in the latest compilers.
+// https://github.com/rust-lang/rust/pull/82525
+#![allow(unknown_lints, renamed_and_removed_lints)]
+#![forbid(unaligned_references, safe_packed_borrows)]
 
 use std::cell::Cell;
 

--- a/tests/ui/cfg/cfg_attr-type-mismatch.rs
+++ b/tests/ui/cfg/cfg_attr-type-mismatch.rs
@@ -1,5 +1,6 @@
-use pin_project::pin_project;
 use std::pin::Pin;
+
+use pin_project::pin_project;
 
 #[cfg_attr(not(any()), pin_project)]
 struct Foo<T> {

--- a/tests/ui/cfg/cfg_attr-type-mismatch.stderr
+++ b/tests/ui/cfg/cfg_attr-type-mismatch.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
-  --> $DIR/cfg_attr-type-mismatch.rs:19:27
+  --> $DIR/cfg_attr-type-mismatch.rs:20:27
    |
-19 |     let _: Pin<&mut u8> = x.f; //~ ERROR E0308
+20 |     let _: Pin<&mut u8> = x.f; //~ ERROR E0308
    |            ------------   ^^^ expected struct `Pin`, found `&mut u8`
    |            |
    |            expected due to this
@@ -10,9 +10,9 @@ error[E0308]: mismatched types
            found mutable reference `&mut u8`
 
 error[E0308]: mismatched types
-  --> $DIR/cfg_attr-type-mismatch.rs:23:22
+  --> $DIR/cfg_attr-type-mismatch.rs:24:22
    |
-23 |     let _: &mut u8 = x.f; //~ ERROR E0308
+24 |     let _: &mut u8 = x.f; //~ ERROR E0308
    |            -------   ^^^
    |            |         |
    |            |         expected `&mut u8`, found struct `Pin`

--- a/tests/ui/pin_project/add-attr-to-struct.rs
+++ b/tests/ui/pin_project/add-attr-to-struct.rs
@@ -1,6 +1,7 @@
+use std::marker::PhantomPinned;
+
 use auxiliary_macro::add_pin_attr;
 use pin_project::pin_project;
-use std::marker::PhantomPinned;
 
 #[pin_project]
 #[add_pin_attr(struct)] //~ ERROR duplicate #[pin] attribute

--- a/tests/ui/pin_project/add-attr-to-struct.stderr
+++ b/tests/ui/pin_project/add-attr-to-struct.stderr
@@ -1,15 +1,15 @@
 error: duplicate #[pin] attribute
- --> $DIR/add-attr-to-struct.rs:6:1
+ --> $DIR/add-attr-to-struct.rs:7:1
   |
-6 | #[add_pin_attr(struct)] //~ ERROR duplicate #[pin] attribute
+7 | #[add_pin_attr(struct)] //~ ERROR duplicate #[pin] attribute
   | ^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: #[pin] attribute may only be used on fields of structs or variants
-  --> $DIR/add-attr-to-struct.rs:12:1
+  --> $DIR/add-attr-to-struct.rs:13:1
    |
-12 | #[add_pin_attr(struct)] //~ ERROR #[pin] attribute may only be used on fields of structs or variants
+13 | #[add_pin_attr(struct)] //~ ERROR #[pin] attribute may only be used on fields of structs or variants
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/pin_project/conflict-drop.rs
+++ b/tests/ui/pin_project/conflict-drop.rs
@@ -1,5 +1,6 @@
-use pin_project::{pin_project, pinned_drop};
 use std::pin::Pin;
+
+use pin_project::{pin_project, pinned_drop};
 
 #[pin_project] //~ ERROR E0119
 struct Foo<T, U> {

--- a/tests/ui/pin_project/conflict-drop.stderr
+++ b/tests/ui/pin_project/conflict-drop.stderr
@@ -1,7 +1,7 @@
 error[E0119]: conflicting implementations of trait `_::FooMustNotImplDrop` for type `Foo<_, _>`:
- --> $DIR/conflict-drop.rs:4:1
+ --> $DIR/conflict-drop.rs:5:1
   |
-4 | #[pin_project] //~ ERROR E0119
+5 | #[pin_project] //~ ERROR E0119
   | ^^^^^^^^^^^^^^
   | |
   | first implementation here
@@ -10,10 +10,10 @@ error[E0119]: conflicting implementations of trait `_::FooMustNotImplDrop` for t
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `std::ops::Drop` for type `Bar<_, _>`:
-  --> $DIR/conflict-drop.rs:15:15
+  --> $DIR/conflict-drop.rs:16:15
    |
-15 | #[pin_project(PinnedDrop)] //~ ERROR E0119
+16 | #[pin_project(PinnedDrop)] //~ ERROR E0119
    |               ^^^^^^^^^^ conflicting implementation for `Bar<_, _>`
 ...
-27 | impl<T, U> Drop for Bar<T, U> {
+28 | impl<T, U> Drop for Bar<T, U> {
    | ----------------------------- first implementation here

--- a/tests/ui/pin_project/overlapping_unpin_struct.rs
+++ b/tests/ui/pin_project/overlapping_unpin_struct.rs
@@ -1,5 +1,6 @@
-use pin_project::pin_project;
 use std::marker::PhantomPinned;
+
+use pin_project::pin_project;
 
 #[pin_project]
 struct S<T> {

--- a/tests/ui/pin_project/overlapping_unpin_struct.stderr
+++ b/tests/ui/pin_project/overlapping_unpin_struct.stderr
@@ -1,10 +1,10 @@
 error[E0277]: `PhantomPinned` cannot be unpinned
-  --> $DIR/overlapping_unpin_struct.rs:17:5
+  --> $DIR/overlapping_unpin_struct.rs:18:5
    |
-14 | fn is_unpin<T: Unpin>() {}
+15 | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
-17 |     is_unpin::<S<PhantomPinned>>(); //~ ERROR E0277
+18 |     is_unpin::<S<PhantomPinned>>(); //~ ERROR E0277
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `_::__S<'_, PhantomPinned>`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
    = note: required because it appears within the type `_::__S<'_, PhantomPinned>`

--- a/tests/ui/pin_project/packed.rs
+++ b/tests/ui/pin_project/packed.rs
@@ -2,7 +2,7 @@ use pin_project::pin_project;
 
 #[pin_project]
 #[repr(packed, C)] //~ ERROR may not be used on #[repr(packed)] types
-struct A {
+struct Packed1 {
     #[pin]
     f: u8,
 }
@@ -10,14 +10,22 @@ struct A {
 // Test putting 'repr' before the 'pin_project' attribute
 #[repr(packed, C)] //~ ERROR may not be used on #[repr(packed)] types
 #[pin_project]
-struct B {
+struct Packed2 {
     #[pin]
     f: u8,
 }
 
 #[pin_project]
 #[repr(packed(2))] //~ ERROR may not be used on #[repr(packed)] types
-struct C {
+struct PackedN1 {
+    #[pin]
+    f: u32,
+}
+
+// Test putting 'repr' before the 'pin_project' attribute
+#[repr(packed(2))] //~ ERROR may not be used on #[repr(packed)] types
+#[pin_project]
+struct PackedN2 {
     #[pin]
     f: u32,
 }

--- a/tests/ui/pin_project/packed.stderr
+++ b/tests/ui/pin_project/packed.stderr
@@ -15,3 +15,9 @@ error: #[pin_project] attribute may not be used on #[repr(packed)] types
    |
 19 | #[repr(packed(2))] //~ ERROR may not be used on #[repr(packed)] types
    |        ^^^^^^^^^
+
+error: #[pin_project] attribute may not be used on #[repr(packed)] types
+  --> $DIR/packed.rs:26:8
+   |
+26 | #[repr(packed(2))] //~ ERROR may not be used on #[repr(packed)] types
+   |        ^^^^^^^^^

--- a/tests/ui/pin_project/packed_sneaky-1.rs
+++ b/tests/ui/pin_project/packed_sneaky-1.rs
@@ -1,6 +1,7 @@
+use std::pin::Pin;
+
 use auxiliary_macro::hidden_repr;
 use pin_project::{pin_project, pinned_drop, UnsafeUnpin};
-use std::pin::Pin;
 
 #[pin_project] //~ ERROR may not be used on #[repr(packed)] types
 #[hidden_repr(packed)]

--- a/tests/ui/pin_project/packed_sneaky-1.stderr
+++ b/tests/ui/pin_project/packed_sneaky-1.stderr
@@ -1,17 +1,17 @@
 error: #[pin_project] attribute may not be used on #[repr(packed)] types
- --> $DIR/packed_sneaky-1.rs:6:15
+ --> $DIR/packed_sneaky-1.rs:7:15
   |
-6 | #[hidden_repr(packed)]
+7 | #[hidden_repr(packed)]
   |               ^^^^^^
 
 error: #[pin_project] attribute may not be used on #[repr(packed)] types
-  --> $DIR/packed_sneaky-1.rs:13:15
+  --> $DIR/packed_sneaky-1.rs:14:15
    |
-13 | #[hidden_repr(packed)]
+14 | #[hidden_repr(packed)]
    |               ^^^^^^
 
 error: #[pin_project] attribute may not be used on #[repr(packed)] types
-  --> $DIR/packed_sneaky-1.rs:22:15
+  --> $DIR/packed_sneaky-1.rs:23:15
    |
-22 | #[hidden_repr(packed)]
+23 | #[hidden_repr(packed)]
    |               ^^^^^^

--- a/tests/ui/pin_project/remove-attr-from-field.rs
+++ b/tests/ui/pin_project/remove-attr-from-field.rs
@@ -1,6 +1,7 @@
+use std::{marker::PhantomPinned, pin::Pin};
+
 use auxiliary_macro::remove_attr;
 use pin_project::pin_project;
-use std::{marker::PhantomPinned, pin::Pin};
 
 fn is_unpin<T: Unpin>() {}
 

--- a/tests/ui/pin_project/remove-attr-from-field.stderr
+++ b/tests/ui/pin_project/remove-attr-from-field.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
-  --> $DIR/remove-attr-from-field.rs:27:38
+  --> $DIR/remove-attr-from-field.rs:28:38
    |
-27 |     let _: Pin<&mut PhantomPinned> = x.f; //~ ERROR E0308
+28 |     let _: Pin<&mut PhantomPinned> = x.f; //~ ERROR E0308
    |            -----------------------   ^^^ expected struct `Pin`, found `&mut PhantomPinned`
    |            |
    |            expected due to this
@@ -10,9 +10,9 @@ error[E0308]: mismatched types
            found mutable reference `&mut PhantomPinned`
 
 error[E0308]: mismatched types
-  --> $DIR/remove-attr-from-field.rs:31:38
+  --> $DIR/remove-attr-from-field.rs:32:38
    |
-31 |     let _: Pin<&mut PhantomPinned> = x.f; //~ ERROR E0308
+32 |     let _: Pin<&mut PhantomPinned> = x.f; //~ ERROR E0308
    |            -----------------------   ^^^ expected struct `Pin`, found `&mut PhantomPinned`
    |            |
    |            expected due to this

--- a/tests/ui/pin_project/remove-attr-from-struct.rs
+++ b/tests/ui/pin_project/remove-attr-from-struct.rs
@@ -1,6 +1,7 @@
+use std::{marker::PhantomPinned, pin::Pin};
+
 use auxiliary_macro::remove_attr;
 use pin_project::pin_project;
-use std::{marker::PhantomPinned, pin::Pin};
 
 fn is_unpin<T: Unpin>() {}
 

--- a/tests/ui/pin_project/remove-attr-from-struct.stderr
+++ b/tests/ui/pin_project/remove-attr-from-struct.stderr
@@ -1,71 +1,71 @@
 error: #[pin_project] attribute has been removed
-  --> $DIR/remove-attr-from-struct.rs:21:1
+  --> $DIR/remove-attr-from-struct.rs:22:1
    |
-21 | #[pin_project] //~ ERROR has been removed
+22 | #[pin_project] //~ ERROR has been removed
    | ^^^^^^^^^^^^^^
    |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot find attribute `pin` in this scope
-  --> $DIR/remove-attr-from-struct.rs:17:7
+  --> $DIR/remove-attr-from-struct.rs:18:7
    |
-17 |     #[pin] //~ ERROR cannot find attribute `pin` in this scope
+18 |     #[pin] //~ ERROR cannot find attribute `pin` in this scope
    |       ^^^
 
 error: cannot find attribute `pin` in this scope
-  --> $DIR/remove-attr-from-struct.rs:10:7
+  --> $DIR/remove-attr-from-struct.rs:11:7
    |
-10 |     #[pin] //~ ERROR cannot find attribute `pin` in this scope
+11 |     #[pin] //~ ERROR cannot find attribute `pin` in this scope
    |       ^^^
 
 error[E0277]: `PhantomPinned` cannot be unpinned
-  --> $DIR/remove-attr-from-struct.rs:34:5
+  --> $DIR/remove-attr-from-struct.rs:35:5
    |
-5  | fn is_unpin<T: Unpin>() {}
+6  | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
-34 |     is_unpin::<A>(); //~ ERROR E0277
+35 |     is_unpin::<A>(); //~ ERROR E0277
    |     ^^^^^^^^^^^^^ within `A`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
    = note: required because it appears within the type `A`
 
 error[E0277]: `PhantomPinned` cannot be unpinned
-  --> $DIR/remove-attr-from-struct.rs:35:5
+  --> $DIR/remove-attr-from-struct.rs:36:5
    |
-5  | fn is_unpin<T: Unpin>() {}
+6  | fn is_unpin<T: Unpin>() {}
    |                ----- required by this bound in `is_unpin`
 ...
-35 |     is_unpin::<B>(); //~ ERROR E0277
+36 |     is_unpin::<B>(); //~ ERROR E0277
    |     ^^^^^^^^^^^^^ within `B`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
    = note: required because it appears within the type `B`
 
 error[E0277]: `PhantomPinned` cannot be unpinned
-  --> $DIR/remove-attr-from-struct.rs:39:13
+  --> $DIR/remove-attr-from-struct.rs:40:13
    |
-39 |     let _ = Pin::new(&mut x).project(); //~ ERROR E0277,E0599
+40 |     let _ = Pin::new(&mut x).project(); //~ ERROR E0277,E0599
    |             ^^^^^^^^ within `A`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
    = note: required because it appears within the type `A`
    = note: required by `Pin::<P>::new`
 
 error[E0599]: no method named `project` found for struct `Pin<&mut A>` in the current scope
-  --> $DIR/remove-attr-from-struct.rs:39:30
+  --> $DIR/remove-attr-from-struct.rs:40:30
    |
-39 |     let _ = Pin::new(&mut x).project(); //~ ERROR E0277,E0599
+40 |     let _ = Pin::new(&mut x).project(); //~ ERROR E0277,E0599
    |                              ^^^^^^^ method not found in `Pin<&mut A>`
 
 error[E0277]: `PhantomPinned` cannot be unpinned
-  --> $DIR/remove-attr-from-struct.rs:42:13
+  --> $DIR/remove-attr-from-struct.rs:43:13
    |
-42 |     let _ = Pin::new(&mut x).project(); //~ ERROR E0277,E0599
+43 |     let _ = Pin::new(&mut x).project(); //~ ERROR E0277,E0599
    |             ^^^^^^^^ within `B`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
    = note: required because it appears within the type `B`
    = note: required by `Pin::<P>::new`
 
 error[E0599]: no method named `project` found for struct `Pin<&mut B>` in the current scope
-  --> $DIR/remove-attr-from-struct.rs:42:30
+  --> $DIR/remove-attr-from-struct.rs:43:30
    |
-42 |     let _ = Pin::new(&mut x).project(); //~ ERROR E0277,E0599
+43 |     let _ = Pin::new(&mut x).project(); //~ ERROR E0277,E0599
    |                              ^^^^^^^ method not found in `Pin<&mut B>`

--- a/tests/ui/pin_project/safe_packed_borrows.rs
+++ b/tests/ui/pin_project/safe_packed_borrows.rs
@@ -1,21 +1,25 @@
 #![forbid(safe_packed_borrows)]
+#![allow(unaligned_references)]
 
-// Refs: https://github.com/rust-lang/rust/issues/46043
+// This lint was removed in https://github.com/rust-lang/rust/pull/82525 (nightly-2021-03-28).
+// Refs:
+// - https://github.com/rust-lang/rust/pull/82525
+// - https://github.com/rust-lang/rust/issues/46043
 
 #[repr(packed)]
-struct A {
+struct Packed {
     f: u32,
 }
 
 #[repr(packed(2))]
-struct B {
+struct PackedN {
     f: u32,
 }
 
 fn main() {
-    let a = A { f: 1 };
+    let a = Packed { f: 1 };
     &a.f; //~ ERROR borrow of packed field is unsafe and requires unsafe function or block
 
-    let b = B { f: 1 };
+    let b = PackedN { f: 1 };
     &b.f; //~ ERROR borrow of packed field is unsafe and requires unsafe function or block
 }

--- a/tests/ui/pin_project/safe_packed_borrows.stderr
+++ b/tests/ui/pin_project/safe_packed_borrows.stderr
@@ -1,7 +1,7 @@
 error: borrow of packed field is unsafe and requires unsafe function or block (error E0133)
-  --> $DIR/safe_packed_borrows.rs:17:5
+  --> $DIR/safe_packed_borrows.rs:21:5
    |
-17 |     &a.f; //~ ERROR borrow of packed field is unsafe and requires unsafe function or block
+21 |     &a.f; //~ ERROR borrow of packed field is unsafe and requires unsafe function or block
    |     ^^^^
    |
 note: the lint level is defined here
@@ -14,9 +14,9 @@ note: the lint level is defined here
    = note: fields of packed structs might be misaligned: dereferencing a misaligned pointer or even just creating a misaligned reference is undefined behavior
 
 error: borrow of packed field is unsafe and requires unsafe function or block (error E0133)
-  --> $DIR/safe_packed_borrows.rs:20:5
+  --> $DIR/safe_packed_borrows.rs:24:5
    |
-20 |     &b.f; //~ ERROR borrow of packed field is unsafe and requires unsafe function or block
+24 |     &b.f; //~ ERROR borrow of packed field is unsafe and requires unsafe function or block
    |     ^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!

--- a/tests/ui/pin_project/unaligned_references.rs
+++ b/tests/ui/pin_project/unaligned_references.rs
@@ -1,0 +1,22 @@
+#![forbid(unaligned_references)]
+#![allow(safe_packed_borrows)]
+
+// Refs: https://github.com/rust-lang/rust/issues/82523
+
+#[repr(packed)]
+struct Packed {
+    f: u32,
+}
+
+#[repr(packed(2))]
+struct PackedN {
+    f: u32,
+}
+
+fn main() {
+    let a = Packed { f: 1 };
+    &a.f; //~ ERROR reference to packed field is unaligned
+
+    let b = PackedN { f: 1 };
+    &b.f; //~ ERROR reference to packed field is unaligned
+}

--- a/tests/ui/pin_project/unaligned_references.stderr
+++ b/tests/ui/pin_project/unaligned_references.stderr
@@ -1,0 +1,20 @@
+error: reference to packed field is unaligned
+  --> $DIR/unaligned_references.rs:18:5
+   |
+18 |     &a.f; //~ ERROR reference to packed field is unaligned
+   |     ^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unaligned_references.rs:1:11
+   |
+1  | #![forbid(unaligned_references)]
+   |           ^^^^^^^^^^^^^^^^^^^^
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+
+error: reference to packed field is unaligned
+  --> $DIR/unaligned_references.rs:21:5
+   |
+21 |     &b.f; //~ ERROR reference to packed field is unaligned
+   |     ^^^^
+   |
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)

--- a/tests/ui/pinned_drop/call-drop-inner.rs
+++ b/tests/ui/pinned_drop/call-drop-inner.rs
@@ -1,5 +1,6 @@
-use pin_project::{pin_project, pinned_drop};
 use std::pin::Pin;
+
+use pin_project::{pin_project, pinned_drop};
 
 #[pin_project(PinnedDrop)]
 struct Struct {

--- a/tests/ui/pinned_drop/call-drop-inner.stderr
+++ b/tests/ui/pinned_drop/call-drop-inner.stderr
@@ -1,14 +1,14 @@
 error[E0061]: this function takes 0 arguments but 1 argument was supplied
-  --> $DIR/call-drop-inner.rs:12:9
+  --> $DIR/call-drop-inner.rs:13:9
    |
-12 |         __drop_inner(__self);
+13 |         __drop_inner(__self);
    |         ^^^^^^^^^^^^ ------ supplied 1 argument
    |         |
    |         expected 0 arguments
    |
 note: function defined here
-  --> $DIR/call-drop-inner.rs:9:1
+  --> $DIR/call-drop-inner.rs:10:1
    |
-9  | #[pinned_drop]
+10 | #[pinned_drop]
    | ^^^^^^^^^^^^^^
    = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/pinned_drop/conditional-drop-impl.rs
+++ b/tests/ui/pinned_drop/conditional-drop-impl.rs
@@ -1,5 +1,6 @@
-use pin_project::{pin_project, pinned_drop};
 use std::pin::Pin;
+
+use pin_project::{pin_project, pinned_drop};
 
 // In `Drop` impl, the implementor must specify the same requirement as type definition.
 

--- a/tests/ui/pinned_drop/conditional-drop-impl.stderr
+++ b/tests/ui/pinned_drop/conditional-drop-impl.stderr
@@ -1,26 +1,26 @@
 error[E0367]: `Drop` impl requires `T: Unpin` but the struct it is implemented for does not
-  --> $DIR/conditional-drop-impl.rs:10:9
+  --> $DIR/conditional-drop-impl.rs:11:9
    |
-10 | impl<T: Unpin> Drop for DropImpl<T> {
+11 | impl<T: Unpin> Drop for DropImpl<T> {
    |         ^^^^^
    |
 note: the implementor must specify the same requirement
-  --> $DIR/conditional-drop-impl.rs:6:1
+  --> $DIR/conditional-drop-impl.rs:7:1
    |
-6  | / struct DropImpl<T> {
-7  | |     f: T,
-8  | | }
+7  | / struct DropImpl<T> {
+8  | |     f: T,
+9  | | }
    | |_^
 
 error[E0277]: `T` cannot be unpinned
-  --> $DIR/conditional-drop-impl.rs:15:15
+  --> $DIR/conditional-drop-impl.rs:16:15
    |
-15 | #[pin_project(PinnedDrop)] //~ ERROR E0277
+16 | #[pin_project(PinnedDrop)] //~ ERROR E0277
    |               ^^^^^^^^^^ the trait `Unpin` is not implemented for `T`
    |
    = note: required because of the requirements on the impl of `PinnedDrop` for `PinnedDropImpl<T>`
    = note: required by `pin_project::__private::PinnedDrop::drop`
 help: consider restricting type parameter `T`
    |
-16 | struct PinnedDropImpl<T: Unpin> {
+17 | struct PinnedDropImpl<T: Unpin> {
    |                        ^^^^^^^

--- a/tests/ui/pinned_drop/invalid.rs
+++ b/tests/ui/pinned_drop/invalid.rs
@@ -1,6 +1,7 @@
 mod argument {
-    use pin_project::{pin_project, pinned_drop};
     use std::pin::Pin;
+
+    use pin_project::{pin_project, pinned_drop};
 
     #[pin_project(PinnedDrop)]
     struct UnexpectedArg1(());
@@ -128,8 +129,9 @@ mod assoc_item {
 }
 
 mod method {
-    use pin_project::{pin_project, pinned_drop};
     use std::pin::Pin;
+
+    use pin_project::{pin_project, pinned_drop};
 
     #[pin_project(PinnedDrop)]
     struct RetUnit(());

--- a/tests/ui/pinned_drop/invalid.stderr
+++ b/tests/ui/pinned_drop/invalid.stderr
@@ -1,143 +1,143 @@
 error: unexpected token: foo
- --> $DIR/invalid.rs:8:19
+ --> $DIR/invalid.rs:9:19
   |
-8 |     #[pinned_drop(foo)] //~ ERROR unexpected token
+9 |     #[pinned_drop(foo)] //~ ERROR unexpected token
   |                   ^^^
 
 error: duplicate #[pinned_drop] attribute
-  --> $DIR/invalid.rs:29:5
+  --> $DIR/invalid.rs:30:5
    |
-29 |     #[pinned_drop] //~ ERROR duplicate #[pinned_drop] attribute
+30 |     #[pinned_drop] //~ ERROR duplicate #[pinned_drop] attribute
    |     ^^^^^^^^^^^^^^
 
 error: #[pinned_drop] may only be used on implementation for the `PinnedDrop` trait
-  --> $DIR/invalid.rs:42:10
+  --> $DIR/invalid.rs:43:10
    |
-42 |     impl Drop for TraitImpl {} //~ ERROR may only be used on implementation for the `PinnedDrop` trait
+43 |     impl Drop for TraitImpl {} //~ ERROR may only be used on implementation for the `PinnedDrop` trait
    |          ^^^^
 
 error: #[pinned_drop] may only be used on implementation for the `PinnedDrop` trait
-  --> $DIR/invalid.rs:48:10
+  --> $DIR/invalid.rs:49:10
    |
-48 |     impl InherentImpl {} //~ ERROR may only be used on implementation for the `PinnedDrop` trait
+49 |     impl InherentImpl {} //~ ERROR may only be used on implementation for the `PinnedDrop` trait
    |          ^^^^^^^^^^^^
 
 error: expected `impl`
-  --> $DIR/invalid.rs:51:5
+  --> $DIR/invalid.rs:52:5
    |
-51 |     fn func(_: Pin<&mut ()>) {} //~ ERROR expected `impl`
+52 |     fn func(_: Pin<&mut ()>) {} //~ ERROR expected `impl`
    |     ^^
 
 error: implementing the trait `PinnedDrop` is not unsafe
-  --> $DIR/invalid.rs:61:5
+  --> $DIR/invalid.rs:62:5
    |
-61 |     unsafe impl PinnedDrop for Impl {
+62 |     unsafe impl PinnedDrop for Impl {
    |     ^^^^^^
 
 error: implementing the method `drop` is not unsafe
-  --> $DIR/invalid.rs:71:9
+  --> $DIR/invalid.rs:72:9
    |
-71 |         unsafe fn drop(self: Pin<&mut Self>) {} //~ ERROR implementing the method `drop` is not unsafe
+72 |         unsafe fn drop(self: Pin<&mut Self>) {} //~ ERROR implementing the method `drop` is not unsafe
    |         ^^^^^^
 
 error: not all trait items implemented, missing: `drop`
-  --> $DIR/invalid.rs:82:5
+  --> $DIR/invalid.rs:83:5
    |
-82 |     impl PinnedDrop for Empty {} //~ ERROR not all trait items implemented, missing: `drop`
+83 |     impl PinnedDrop for Empty {} //~ ERROR not all trait items implemented, missing: `drop`
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: const `A` is not a member of trait `PinnedDrop`
-  --> $DIR/invalid.rs:89:9
+  --> $DIR/invalid.rs:90:9
    |
-89 |         const A: u8 = 0; //~ ERROR const `A` is not a member of trait `PinnedDrop`
+90 |         const A: u8 = 0; //~ ERROR const `A` is not a member of trait `PinnedDrop`
    |         ^^^^^^^^^^^^^^^^
 
 error: const `A` is not a member of trait `PinnedDrop`
-  --> $DIR/invalid.rs:99:9
-   |
-99 |         const A: u8 = 0; //~ ERROR const `A` is not a member of trait `PinnedDrop`
-   |         ^^^^^^^^^^^^^^^^
+   --> $DIR/invalid.rs:100:9
+    |
+100 |         const A: u8 = 0; //~ ERROR const `A` is not a member of trait `PinnedDrop`
+    |         ^^^^^^^^^^^^^^^^
 
 error: type `A` is not a member of trait `PinnedDrop`
-   --> $DIR/invalid.rs:107:9
+   --> $DIR/invalid.rs:108:9
     |
-107 |         type A = u8; //~ ERROR type `A` is not a member of trait `PinnedDrop`
+108 |         type A = u8; //~ ERROR type `A` is not a member of trait `PinnedDrop`
     |         ^^^^^^^^^^^^
 
 error: type `A` is not a member of trait `PinnedDrop`
-   --> $DIR/invalid.rs:117:9
+   --> $DIR/invalid.rs:118:9
     |
-117 |         type A = u8; //~ ERROR type `A` is not a member of trait `PinnedDrop`
+118 |         type A = u8; //~ ERROR type `A` is not a member of trait `PinnedDrop`
     |         ^^^^^^^^^^^^
 
 error: duplicate definitions with name `drop`
-   --> $DIR/invalid.rs:126:9
+   --> $DIR/invalid.rs:127:9
     |
-126 |         fn drop(self: Pin<&mut Self>) {} //~ ERROR duplicate definitions with name `drop`
+127 |         fn drop(self: Pin<&mut Self>) {} //~ ERROR duplicate definitions with name `drop`
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: method `drop` must return the unit type
-   --> $DIR/invalid.rs:147:42
+   --> $DIR/invalid.rs:149:42
     |
-147 |         fn drop(self: Pin<&mut Self>) -> Self {} //~ ERROR method `drop` must return the unit type
+149 |         fn drop(self: Pin<&mut Self>) -> Self {} //~ ERROR method `drop` must return the unit type
     |                                          ^^^^
 
 error: method `drop` must take an argument `self: Pin<&mut Self>`
-   --> $DIR/invalid.rs:155:16
+   --> $DIR/invalid.rs:157:16
     |
-155 |         fn drop() {} //~ ERROR method `drop` must take an argument `self: Pin<&mut Self>`
+157 |         fn drop() {} //~ ERROR method `drop` must take an argument `self: Pin<&mut Self>`
     |                ^^
 
 error: method `drop` must take an argument `self: Pin<&mut Self>`
-   --> $DIR/invalid.rs:163:17
+   --> $DIR/invalid.rs:165:17
     |
-163 |         fn drop(self: Pin<&mut Self>, _: ()) {} //~ ERROR method `drop` must take an argument `self: Pin<&mut Self>`
+165 |         fn drop(self: Pin<&mut Self>, _: ()) {} //~ ERROR method `drop` must take an argument `self: Pin<&mut Self>`
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: method `drop` must take an argument `self: Pin<&mut Self>`
-   --> $DIR/invalid.rs:171:17
+   --> $DIR/invalid.rs:173:17
     |
-171 |         fn drop(&mut self) {} //~ ERROR method `drop` must take an argument `self: Pin<&mut Self>`
+173 |         fn drop(&mut self) {} //~ ERROR method `drop` must take an argument `self: Pin<&mut Self>`
     |                 ^^^^^^^^^
 
 error: method `drop` must take an argument `self: Pin<&mut Self>`
-   --> $DIR/invalid.rs:179:17
+   --> $DIR/invalid.rs:181:17
     |
-179 |         fn drop(_: Pin<&mut Self>) {} //~ ERROR method `drop` must take an argument `self: Pin<&mut Self>`
+181 |         fn drop(_: Pin<&mut Self>) {} //~ ERROR method `drop` must take an argument `self: Pin<&mut Self>`
     |                 ^^^^^^^^^^^^^^^^^
 
 error: method `drop` must take an argument `self: Pin<&mut Self>`
-   --> $DIR/invalid.rs:187:17
+   --> $DIR/invalid.rs:189:17
     |
-187 |         fn drop(self: Pin<&Self>) {} //~ ERROR method `drop` must take an argument `self: Pin<&mut Self>`
+189 |         fn drop(self: Pin<&Self>) {} //~ ERROR method `drop` must take an argument `self: Pin<&mut Self>`
     |                 ^^^^^^^^^^^^^^^^
 
 error: method `drop` must take an argument `self: Pin<&mut Self>`
-   --> $DIR/invalid.rs:195:17
+   --> $DIR/invalid.rs:197:17
     |
-195 |         fn drop(self: Pin<&mut ()>) {} //~ ERROR method `drop` must take an argument `self: Pin<&mut Self>`
+197 |         fn drop(self: Pin<&mut ()>) {} //~ ERROR method `drop` must take an argument `self: Pin<&mut Self>`
     |                 ^^^^^^^^^^^^^^^^^^
 
 error: method `pinned_drop` is not a member of trait `PinnedDrop
-   --> $DIR/invalid.rs:203:12
+   --> $DIR/invalid.rs:205:12
     |
-203 |         fn pinned_drop(self: Pin<&mut Self>) {} //~ ERROR method `pinned_drop` is not a member of trait `PinnedDrop
+205 |         fn pinned_drop(self: Pin<&mut Self>) {} //~ ERROR method `pinned_drop` is not a member of trait `PinnedDrop
     |            ^^^^^^^^^^^
 
 error: implementing the trait `PinnedDrop` on this type is unsupported
-   --> $DIR/invalid.rs:211:25
+   --> $DIR/invalid.rs:213:25
     |
-211 |     impl PinnedDrop for () {
+213 |     impl PinnedDrop for () {
     |                         ^^
 
 error: implementing the trait `PinnedDrop` on this type is unsupported
-   --> $DIR/invalid.rs:217:25
+   --> $DIR/invalid.rs:219:25
     |
-217 |     impl PinnedDrop for &mut A {
+219 |     impl PinnedDrop for &mut A {
     |                         ^^^^^^
 
 error: implementing the trait `PinnedDrop` on this type is unsupported
-   --> $DIR/invalid.rs:223:25
+   --> $DIR/invalid.rs:225:25
     |
-223 |     impl PinnedDrop for [A] {
+225 |     impl PinnedDrop for [A] {
     |                         ^^^

--- a/tests/ui/pinned_drop/pinned-drop-no-attr-arg.rs
+++ b/tests/ui/pinned_drop/pinned-drop-no-attr-arg.rs
@@ -1,5 +1,6 @@
-use pin_project::{pin_project, pinned_drop};
 use std::pin::Pin;
+
+use pin_project::{pin_project, pinned_drop};
 
 #[pin_project]
 struct S {

--- a/tests/ui/pinned_drop/pinned-drop-no-attr-arg.stderr
+++ b/tests/ui/pinned_drop/pinned-drop-no-attr-arg.stderr
@@ -1,8 +1,8 @@
 error[E0119]: conflicting implementations of trait `pin_project::__private::PinnedDrop` for type `S`:
-  --> $DIR/pinned-drop-no-attr-arg.rs:11:1
+  --> $DIR/pinned-drop-no-attr-arg.rs:12:1
    |
-4  | #[pin_project]
+5  | #[pin_project]
    | -------------- first implementation here
 ...
-11 | impl PinnedDrop for S {
+12 | impl PinnedDrop for S {
    | ^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `S`

--- a/tests/ui/pinned_drop/self.rs
+++ b/tests/ui/pinned_drop/self.rs
@@ -1,6 +1,7 @@
 pub mod self_in_macro_def {
-    use pin_project::{pin_project, pinned_drop};
     use std::pin::Pin;
+
+    use pin_project::{pin_project, pinned_drop};
 
     #[pin_project(PinnedDrop)]
     pub struct S {
@@ -23,8 +24,9 @@ pub mod self_in_macro_def {
 }
 
 pub mod self_span {
-    use pin_project::{pin_project, pinned_drop};
     use std::pin::Pin;
+
+    use pin_project::{pin_project, pinned_drop};
 
     #[pin_project(PinnedDrop)]
     pub struct S {

--- a/tests/ui/pinned_drop/self.stderr
+++ b/tests/ui/pinned_drop/self.stderr
@@ -1,42 +1,42 @@
 error: `self` parameter is only allowed in associated functions
-  --> $DIR/self.rs:17:26
+  --> $DIR/self.rs:18:26
    |
-17 |                     fn f(self: ()) {} //~ ERROR `self` parameter is only allowed in associated functions
+18 |                     fn f(self: ()) {} //~ ERROR `self` parameter is only allowed in associated functions
    |                          ^^^^ not semantically valid as function parameter
 ...
-20 |             t!();
+21 |             t!();
    |             ----- in this macro invocation
    |
    = note: associated functions are those in `impl` or `trait` definitions
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0434]: can't capture dynamic environment in a fn item
-  --> $DIR/self.rs:15:29
+  --> $DIR/self.rs:16:29
    |
-15 |                     let _ = self; //~ ERROR E0434
+16 |                     let _ = self; //~ ERROR E0434
    |                             ^^^^
 ...
-20 |             t!();
+21 |             t!();
    |             ----- in this macro invocation
    |
    = help: use the `|| { ... }` closure form instead
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0423]: expected value, found struct `S`
-  --> $DIR/self.rs:38:27
+  --> $DIR/self.rs:40:27
    |
-30 | /     pub struct S {
-31 | |         f: (),
-32 | |     }
+32 | /     pub struct S {
+33 | |         f: (),
+34 | |     }
    | |_____- `S` defined here
 ...
-38 |               let _: Self = Self; //~ ERROR E0423
+40 |               let _: Self = Self; //~ ERROR E0423
    |                             ^^^^ help: use struct literal syntax instead: `S { f: val }`
 
 error[E0308]: mismatched types
-  --> $DIR/self.rs:37:25
+  --> $DIR/self.rs:39:25
    |
-37 |             let _: () = self; //~ ERROR E0308
+39 |             let _: () = self; //~ ERROR E0308
    |                    --   ^^^^ expected `()`, found struct `Pin`
    |                    |
    |                    expected due to this
@@ -45,9 +45,9 @@ error[E0308]: mismatched types
                  found struct `Pin<&mut self_span::S>`
 
 error[E0308]: mismatched types
-  --> $DIR/self.rs:50:25
+  --> $DIR/self.rs:52:25
    |
-50 |             let _: () = self; //~ ERROR E0308
+52 |             let _: () = self; //~ ERROR E0308
    |                    --   ^^^^ expected `()`, found struct `Pin`
    |                    |
    |                    expected due to this
@@ -56,7 +56,7 @@ error[E0308]: mismatched types
                  found struct `Pin<&mut E>`
 
 error[E0533]: expected unit struct, unit variant or constant, found struct variant `Self::V`
-  --> $DIR/self.rs:51:27
+  --> $DIR/self.rs:53:27
    |
-51 |             let _: Self = Self::V; //~ ERROR E0533
+53 |             let _: Self = Self::V; //~ ERROR E0533
    |                           ^^^^^^^

--- a/tests/ui/pinned_drop/unsafe-call.rs
+++ b/tests/ui/pinned_drop/unsafe-call.rs
@@ -1,5 +1,6 @@
-use pin_project::{pin_project, pinned_drop};
 use std::pin::Pin;
+
+use pin_project::{pin_project, pinned_drop};
 
 #[pin_project(PinnedDrop)]
 struct S {

--- a/tests/ui/pinned_drop/unsafe-call.stderr
+++ b/tests/ui/pinned_drop/unsafe-call.stderr
@@ -1,7 +1,7 @@
 error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-call.rs:13:9
+  --> $DIR/unsafe-call.rs:14:9
    |
-13 |         self.project().f.get_unchecked_mut(); //~ ERROR call to unsafe function is unsafe and requires unsafe function or block [E0133]
+14 |         self.project().f.get_unchecked_mut(); //~ ERROR call to unsafe function is unsafe and requires unsafe function or block [E0133]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior

--- a/tests/ui/unstable-features/marker_trait_attr-feature-gate.rs
+++ b/tests/ui/unstable-features/marker_trait_attr-feature-gate.rs
@@ -1,7 +1,8 @@
 // Note: If you change this test, change 'marker_trait_attr.rs' at the same time.
 
-use pin_project::pin_project;
 use std::marker::PhantomPinned;
+
+use pin_project::pin_project;
 
 #[pin_project] //~ ERROR E0119
 struct Struct<T> {

--- a/tests/ui/unstable-features/marker_trait_attr-feature-gate.stderr
+++ b/tests/ui/unstable-features/marker_trait_attr-feature-gate.stderr
@@ -1,10 +1,10 @@
 error[E0119]: conflicting implementations of trait `std::marker::Unpin` for type `Struct<_>`:
-  --> $DIR/marker_trait_attr-feature-gate.rs:6:1
+  --> $DIR/marker_trait_attr-feature-gate.rs:7:1
    |
-6  | #[pin_project] //~ ERROR E0119
+7  | #[pin_project] //~ ERROR E0119
    | ^^^^^^^^^^^^^^ conflicting implementation for `Struct<_>`
 ...
-13 | impl<T> Unpin for Struct<T> {}
+14 | impl<T> Unpin for Struct<T> {}
    | --------------------------- first implementation here
    |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/unstable-features/marker_trait_attr.rs
+++ b/tests/ui/unstable-features/marker_trait_attr.rs
@@ -6,8 +6,9 @@
 
 // See https://github.com/taiki-e/pin-project/issues/105#issuecomment-535355974
 
-use pin_project::pin_project;
 use std::marker::PhantomPinned;
+
+use pin_project::pin_project;
 
 #[pin_project] //~ ERROR E0119
 struct Struct<T> {

--- a/tests/ui/unstable-features/marker_trait_attr.stderr
+++ b/tests/ui/unstable-features/marker_trait_attr.stderr
@@ -1,10 +1,10 @@
 error[E0119]: conflicting implementations of trait `std::marker::Unpin` for type `Struct<_>`:
-  --> $DIR/marker_trait_attr.rs:12:1
+  --> $DIR/marker_trait_attr.rs:13:1
    |
-12 | #[pin_project] //~ ERROR E0119
+13 | #[pin_project] //~ ERROR E0119
    | ^^^^^^^^^^^^^^ conflicting implementation for `Struct<_>`
 ...
-19 | impl<T> Unpin for Struct<T> {}
+20 | impl<T> Unpin for Struct<T> {}
    | --------------------------- first implementation here
    |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/unstable-features/overlapping_marker_traits-feature-gate.rs
+++ b/tests/ui/unstable-features/overlapping_marker_traits-feature-gate.rs
@@ -1,7 +1,8 @@
 // Note: If you change this test, change 'overlapping_marker_traits.rs' at the same time.
 
-use pin_project::pin_project;
 use std::marker::PhantomPinned;
+
+use pin_project::pin_project;
 
 #[pin_project] //~ ERROR E0119
 struct Struct<T> {

--- a/tests/ui/unstable-features/overlapping_marker_traits-feature-gate.stderr
+++ b/tests/ui/unstable-features/overlapping_marker_traits-feature-gate.stderr
@@ -1,10 +1,10 @@
 error[E0119]: conflicting implementations of trait `std::marker::Unpin` for type `Struct<_>`:
-  --> $DIR/overlapping_marker_traits-feature-gate.rs:6:1
+  --> $DIR/overlapping_marker_traits-feature-gate.rs:7:1
    |
-6  | #[pin_project] //~ ERROR E0119
+7  | #[pin_project] //~ ERROR E0119
    | ^^^^^^^^^^^^^^ conflicting implementation for `Struct<_>`
 ...
-13 | impl<T> Unpin for Struct<T> {}
+14 | impl<T> Unpin for Struct<T> {}
    | --------------------------- first implementation here
    |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/unstable-features/overlapping_marker_traits.rs
+++ b/tests/ui/unstable-features/overlapping_marker_traits.rs
@@ -3,15 +3,16 @@
 // This feature could break the guarantee for Unpin provided by pin-project,
 // but was removed in https://github.com/rust-lang/rust/pull/68544 (nightly-2020-02-06).
 // Refs:
-// * https://github.com/rust-lang/rust/issues/29864#issuecomment-515780867.
-// * https://github.com/taiki-e/pin-project/issues/105
+// - https://github.com/rust-lang/rust/issues/29864#issuecomment-515780867
+// - https://github.com/taiki-e/pin-project/issues/105
 
 // overlapping_marker_traits
 // Tracking issue: https://github.com/rust-lang/rust/issues/29864
 #![feature(overlapping_marker_traits)]
 
-use pin_project::pin_project;
 use std::marker::PhantomPinned;
+
+use pin_project::pin_project;
 
 #[pin_project]
 struct Struct<T> {

--- a/tests/ui/unstable-features/overlapping_marker_traits.stderr
+++ b/tests/ui/unstable-features/overlapping_marker_traits.stderr
@@ -7,12 +7,12 @@ error[E0557]: feature has been removed
    = note: removed in favor of `#![feature(marker_trait_attr)]`
 
 error[E0119]: conflicting implementations of trait `std::marker::Unpin` for type `Struct<_>`:
-  --> $DIR/overlapping_marker_traits.rs:16:1
+  --> $DIR/overlapping_marker_traits.rs:17:1
    |
-16 | #[pin_project]
+17 | #[pin_project]
    | ^^^^^^^^^^^^^^ conflicting implementation for `Struct<_>`
 ...
-23 | impl<T> Unpin for Struct<T> {}
+24 | impl<T> Unpin for Struct<T> {}
    | --------------------------- first implementation here
    |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Same as https://github.com/taiki-e/pin-project-lite/pull/55, but, pin-project's safety no longer depends on this, so there is no need to rush release. 