### PR TITLE
v0.4: Fix unused_must_use warning on unused borrows

### DIFF
--- a/examples/not_unpin-expanded.rs
+++ b/examples/not_unpin-expanded.rs
@@ -117,9 +117,9 @@ const _: () = {
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
     // for details.
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
-        &val.pinned;
-        &val.unpinned;
+    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
+        let _ = &this.pinned;
+        let _ = &this.unpinned;
     }
 };
 

--- a/examples/pinned_drop-expanded.rs
+++ b/examples/pinned_drop-expanded.rs
@@ -124,9 +124,9 @@ const _: () = {
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
     // for details.
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<'a, T>(val: &Struct<'a, T>) {
-        &val.was_dropped;
-        &val.field;
+    fn __assert_not_repr_packed<'a, T>(this: &Struct<'a, T>) {
+        let _ = &this.was_dropped;
+        let _ = &this.field;
     }
 };
 

--- a/examples/project_replace-expanded.rs
+++ b/examples/project_replace-expanded.rs
@@ -156,9 +156,9 @@ const _: () = {
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
     // for details.
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
-        &val.pinned;
-        &val.unpinned;
+    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
+        let _ = &this.pinned;
+        let _ = &this.unpinned;
     }
 };
 

--- a/examples/struct-default-expanded.rs
+++ b/examples/struct-default-expanded.rs
@@ -155,9 +155,9 @@ const _: () = {
     //
     // See https://github.com/taiki-e/pin-project/pull/34 for more details.
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
-        &val.pinned;
-        &val.unpinned;
+    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
+        let _ = &this.pinned;
+        let _ = &this.unpinned;
     }
 };
 

--- a/examples/unsafe_unpin-expanded.rs
+++ b/examples/unsafe_unpin-expanded.rs
@@ -104,9 +104,9 @@ const _: () = {
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/34
     // for details.
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
-        &val.pinned;
-        &val.unpinned;
+    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
+        let _ = &this.pinned;
+        let _ = &this.unpinned;
     }
 };
 

--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -1208,13 +1208,13 @@ impl<'a> Context<'a> {
         match fields {
             Fields::Named(FieldsNamed { named, .. }) => {
                 for Field { ident, .. } in named {
-                    field_refs.push(quote!(&val.#ident;));
+                    field_refs.push(quote!(&this.#ident));
                 }
             }
             Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => {
                 for (index, _) in unnamed.iter().enumerate() {
                     let index = Index::from(index);
-                    field_refs.push(quote!(&val.#index;));
+                    field_refs.push(quote!(&this.#index));
                 }
             }
             Fields::Unit => {}
@@ -1224,8 +1224,8 @@ impl<'a> Context<'a> {
         let ident = self.orig.ident;
         Ok(quote! {
             #[forbid(safe_packed_borrows)]
-            fn __assert_not_repr_packed #impl_generics (val: &#ident #ty_generics) #where_clause {
-                #(#field_refs)*
+            fn __assert_not_repr_packed #impl_generics (this: &#ident #ty_generics) #where_clause {
+                #(let _ = #field_refs;)*
             }
         })
     }

--- a/tests/expand/tests/expand/default-struct.expanded.rs
+++ b/tests/expand/tests/expand/default-struct.expanded.rs
@@ -80,9 +80,9 @@ const _: () = {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
-        &val.pinned;
-        &val.unpinned;
+    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
+        let _ = &this.pinned;
+        let _ = &this.unpinned;
     }
 };
 fn main() {}

--- a/tests/expand/tests/expand/default-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/default-tuple_struct.expanded.rs
@@ -65,9 +65,9 @@ const _: () = {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
-        &val.0;
-        &val.1;
+    fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
+        let _ = &this.0;
+        let _ = &this.1;
     }
 };
 fn main() {}

--- a/tests/expand/tests/expand/multifields-struct.expanded.rs
+++ b/tests/expand/tests/expand/multifields-struct.expanded.rs
@@ -141,11 +141,11 @@ const _: () = {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
-        &val.pinned1;
-        &val.pinned2;
-        &val.unpinned1;
-        &val.unpinned2;
+    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
+        let _ = &this.pinned1;
+        let _ = &this.pinned2;
+        let _ = &this.unpinned1;
+        let _ = &this.unpinned2;
     }
 };
 fn main() {}

--- a/tests/expand/tests/expand/multifields-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/multifields-tuple_struct.expanded.rs
@@ -117,11 +117,11 @@ const _: () = {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
-        &val.0;
-        &val.1;
-        &val.2;
-        &val.3;
+    fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
+        let _ = &this.0;
+        let _ = &this.1;
+        let _ = &this.2;
+        let _ = &this.3;
     }
 };
 fn main() {}

--- a/tests/expand/tests/expand/naming-struct.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct.expanded.rs
@@ -104,9 +104,9 @@ const _: () = {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
-        &val.pinned;
-        &val.unpinned;
+    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
+        let _ = &this.pinned;
+        let _ = &this.unpinned;
     }
 };
 fn main() {}

--- a/tests/expand/tests/expand/naming-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/naming-tuple_struct.expanded.rs
@@ -83,9 +83,9 @@ const _: () = {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
-        &val.0;
-        &val.1;
+    fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
+        let _ = &this.0;
+        let _ = &this.1;
     }
 };
 fn main() {}

--- a/tests/expand/tests/expand/not_unpin-struct.expanded.rs
+++ b/tests/expand/tests/expand/not_unpin-struct.expanded.rs
@@ -71,9 +71,9 @@ const _: () = {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
-        &val.pinned;
-        &val.unpinned;
+    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
+        let _ = &this.pinned;
+        let _ = &this.unpinned;
     }
 };
 fn main() {}

--- a/tests/expand/tests/expand/not_unpin-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/not_unpin-tuple_struct.expanded.rs
@@ -56,9 +56,9 @@ const _: () = {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
-        &val.0;
-        &val.1;
+    fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
+        let _ = &this.0;
+        let _ = &this.1;
     }
 };
 fn main() {}

--- a/tests/expand/tests/expand/pinned_drop-struct.expanded.rs
+++ b/tests/expand/tests/expand/pinned_drop-struct.expanded.rs
@@ -82,9 +82,9 @@ const _: () = {
         }
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
-        &val.pinned;
-        &val.unpinned;
+    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
+        let _ = &this.pinned;
+        let _ = &this.unpinned;
     }
 };
 impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {

--- a/tests/expand/tests/expand/pinned_drop-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/pinned_drop-tuple_struct.expanded.rs
@@ -67,9 +67,9 @@ const _: () = {
         }
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
-        &val.0;
-        &val.1;
+    fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
+        let _ = &this.0;
+        let _ = &this.1;
     }
 };
 impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {

--- a/tests/expand/tests/expand/project_replace-struct.expanded.rs
+++ b/tests/expand/tests/expand/project_replace-struct.expanded.rs
@@ -109,9 +109,9 @@ const _: () = {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
-        &val.pinned;
-        &val.unpinned;
+    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
+        let _ = &this.pinned;
+        let _ = &this.unpinned;
     }
 };
 fn main() {}

--- a/tests/expand/tests/expand/project_replace-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/project_replace-tuple_struct.expanded.rs
@@ -91,9 +91,9 @@ const _: () = {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
-        &val.0;
-        &val.1;
+    fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
+        let _ = &this.0;
+        let _ = &this.1;
     }
 };
 fn main() {}

--- a/tests/expand/tests/expand/pub-struct.expanded.rs
+++ b/tests/expand/tests/expand/pub-struct.expanded.rs
@@ -80,9 +80,9 @@ const _: () = {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
-        &val.pinned;
-        &val.unpinned;
+    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
+        let _ = &this.pinned;
+        let _ = &this.unpinned;
     }
 };
 fn main() {}

--- a/tests/expand/tests/expand/pub-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/pub-tuple_struct.expanded.rs
@@ -68,9 +68,9 @@ const _: () = {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
-        &val.0;
-        &val.1;
+    fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
+        let _ = &this.0;
+        let _ = &this.1;
     }
 };
 fn main() {}

--- a/tests/expand/tests/expand/unsafe_unpin-struct.expanded.rs
+++ b/tests/expand/tests/expand/unsafe_unpin-struct.expanded.rs
@@ -69,9 +69,9 @@ const _: () = {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &Struct<T, U>) {
-        &val.pinned;
-        &val.unpinned;
+    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
+        let _ = &this.pinned;
+        let _ = &this.unpinned;
     }
 };
 unsafe impl<T: Unpin, U> UnsafeUnpin for Struct<T, U> {}

--- a/tests/expand/tests/expand/unsafe_unpin-tuple_struct.expanded.rs
+++ b/tests/expand/tests/expand/unsafe_unpin-tuple_struct.expanded.rs
@@ -54,9 +54,9 @@ const _: () = {
         unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
     }
     #[forbid(safe_packed_borrows)]
-    fn __assert_not_repr_packed<T, U>(val: &TupleStruct<T, U>) {
-        &val.0;
-        &val.1;
+    fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
+        let _ = &this.0;
+        let _ = &this.1;
     }
 };
 unsafe impl<T: Unpin, U> UnsafeUnpin for Struct<T, U> {}


### PR DESCRIPTION
This fixes `unused_must_use` warning on unused borrows, which will be added to rustc in the future.

See https://github.com/rust-lang/rust/pull/76894 fore more.

(Note: pin-project 1.0 does not have this problem.)
