### PR TITLE
Hide PinnedDrop impl from docs

### DIFF
--- a/examples/pinned_drop-expanded.rs
+++ b/examples/pinned_drop-expanded.rs
@@ -135,6 +135,7 @@ const _: () = {
 // Users can implement [`Drop`] safely using `#[pinned_drop]` and can drop a
 // type that implements `PinnedDrop` using the [`drop`] function safely.
 // **Do not call or implement this trait directly.**
+#[doc(hidden)]
 impl<T> ::pin_project::__private::PinnedDrop for Struct<'_, T> {
     // Since calling it twice on the same object would be UB,
     // this method is unsafe.

--- a/pin-project-internal/src/pinned_drop.rs
+++ b/pin-project-internal/src/pinned_drop.rs
@@ -189,6 +189,9 @@ fn expand_impl(item: &mut ItemImpl) {
         None
     }
 
+    // `PinnedDrop` is a private trait and should not appear in docs.
+    item.attrs.push(parse_quote!(#[doc(hidden)]));
+
     let path = &mut item.trait_.as_mut().unwrap().1;
     *path = parse_quote_spanned! { path.span() =>
         ::pin_project::__private::PinnedDrop

--- a/tests/expand/pinned_drop/enum.expanded.rs
+++ b/tests/expand/pinned_drop/enum.expanded.rs
@@ -130,6 +130,7 @@ const _: () = {
         }
     }
 };
+#[doc(hidden)]
 impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
     unsafe fn drop(self: Pin<&mut Self>) {
         #[allow(clippy::needless_pass_by_value)]

--- a/tests/expand/pinned_drop/struct.expanded.rs
+++ b/tests/expand/pinned_drop/struct.expanded.rs
@@ -112,6 +112,7 @@ const _: () = {
         }
     }
 };
+#[doc(hidden)]
 impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
     unsafe fn drop(self: Pin<&mut Self>) {
         #[allow(clippy::needless_pass_by_value)]

--- a/tests/expand/pinned_drop/tuple_struct.expanded.rs
+++ b/tests/expand/pinned_drop/tuple_struct.expanded.rs
@@ -100,6 +100,7 @@ const _: () = {
         }
     }
 };
+#[doc(hidden)]
 impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
     unsafe fn drop(self: Pin<&mut Self>) {
         #[allow(clippy::needless_pass_by_value)]


### PR DESCRIPTION
`PinnedDrop` is a private trait and should not appear in docs.