### PR TITLE
Clean up lint-related code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- [Suppress `clippy::use_self` and `clippy::type_repetition_in_bounds` lints in generated code.](https://github.com/taiki-e/pin-project/pull/331)
+
 ## [1.0.7] - 2021-04-16
 
 - [Fix compile error when using `self::` as prefix of path inside `#[pinned_drop]` impl.](https://github.com/taiki-e/pin-project/pull/326)

--- a/examples/enum-default-expanded.rs
+++ b/examples/enum-default-expanded.rs
@@ -15,7 +15,11 @@
 // ```
 
 #![allow(dead_code, unused_imports, unused_parens, unknown_lints, renamed_and_removed_lints)]
-#![allow(clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
+#![allow(
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits,
+    clippy::used_underscore_binding
+)]
 
 use pin_project::pin_project;
 

--- a/examples/pinned_drop-expanded.rs
+++ b/examples/pinned_drop-expanded.rs
@@ -23,7 +23,7 @@
 // ```
 
 #![allow(dead_code, unused_imports, unused_parens, unknown_lints, renamed_and_removed_lints)]
-#![allow(clippy::needless_lifetimes)]
+#![allow(clippy::needless_lifetimes, clippy::mut_mut)]
 
 use std::pin::Pin;
 

--- a/tests/auxiliary/macro/lib.rs
+++ b/tests/auxiliary/macro/lib.rs
@@ -1,5 +1,6 @@
 #![cfg(nightly)]
 #![warn(rust_2018_idioms, single_use_lifetimes)]
+#![allow(clippy::pedantic)]
 
 use proc_macro::TokenStream;
 use quote::{format_ident, quote, ToTokens};

--- a/tests/expand/default/enum.expanded.rs
+++ b/tests/expand/default/enum.expanded.rs
@@ -17,9 +17,9 @@ enum Enum<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
 enum EnumProj<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -39,9 +39,9 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::ref_option_ref)]
-#[allow(clippy::type_repetition_in_bounds)]
 enum EnumProjRef<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -61,7 +61,9 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {

--- a/tests/expand/default/struct.expanded.rs
+++ b/tests/expand/default/struct.expanded.rs
@@ -13,20 +13,13 @@ struct Struct<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -34,17 +27,8 @@ const _: () = {
         pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
         unpinned: &'pin mut (U),
     }
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,

--- a/tests/expand/default/tuple_struct.expanded.rs
+++ b/tests/expand/default/tuple_struct.expanded.rs
@@ -9,37 +9,21 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
     )
     where
         TupleStruct<T, U>: 'pin;
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),

--- a/tests/expand/multifields/enum.expanded.rs
+++ b/tests/expand/multifields/enum.expanded.rs
@@ -20,9 +20,9 @@ enum Enum<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
 enum EnumProj<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -49,9 +49,9 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::ref_option_ref)]
-#[allow(clippy::type_repetition_in_bounds)]
 enum EnumProjRef<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -78,6 +78,7 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(variant_size_differences)]
 #[allow(clippy::large_enum_variant)]
@@ -104,7 +105,9 @@ enum EnumProjOwn<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {

--- a/tests/expand/multifields/struct.expanded.rs
+++ b/tests/expand/multifields/struct.expanded.rs
@@ -16,20 +16,13 @@ struct Struct<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -39,17 +32,8 @@ const _: () = {
         unpinned1: &'pin mut (U),
         unpinned2: &'pin mut (U),
     }
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -59,14 +43,6 @@ const _: () = {
         unpinned1: &'pin (U),
         unpinned2: &'pin (U),
     }
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     struct __StructProjectionOwned<T, U> {
         pinned1: ::pin_project::__private::PhantomData<T>,

--- a/tests/expand/multifields/tuple_struct.expanded.rs
+++ b/tests/expand/multifields/tuple_struct.expanded.rs
@@ -9,20 +9,13 @@ struct TupleStruct<T, U>(#[pin] T, #[pin] T, U, U);
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         ::pin_project::__private::Pin<&'pin mut (T)>,
@@ -31,17 +24,8 @@ const _: () = {
     )
     where
         TupleStruct<T, U>: 'pin;
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         ::pin_project::__private::Pin<&'pin (T)>,
@@ -50,14 +34,6 @@ const _: () = {
     )
     where
         TupleStruct<T, U>: 'pin;
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     struct __TupleStructProjectionOwned<T, U>(
         ::pin_project::__private::PhantomData<T>,

--- a/tests/expand/naming/enum-all.expanded.rs
+++ b/tests/expand/naming/enum-all.expanded.rs
@@ -17,9 +17,9 @@ enum Enum<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
 enum Proj<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -39,9 +39,9 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::ref_option_ref)]
-#[allow(clippy::type_repetition_in_bounds)]
 enum ProjRef<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -61,6 +61,7 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(variant_size_differences)]
 #[allow(clippy::large_enum_variant)]
@@ -80,7 +81,9 @@ enum ProjOwn<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {

--- a/tests/expand/naming/enum-mut.expanded.rs
+++ b/tests/expand/naming/enum-mut.expanded.rs
@@ -17,9 +17,9 @@ enum Enum<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
 enum Proj<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -39,7 +39,9 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {

--- a/tests/expand/naming/enum-none.expanded.rs
+++ b/tests/expand/naming/enum-none.expanded.rs
@@ -17,7 +17,9 @@ enum Enum<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {}

--- a/tests/expand/naming/enum-own.expanded.rs
+++ b/tests/expand/naming/enum-own.expanded.rs
@@ -17,6 +17,7 @@ enum Enum<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(variant_size_differences)]
 #[allow(clippy::large_enum_variant)]
@@ -36,7 +37,9 @@ enum ProjOwn<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {

--- a/tests/expand/naming/enum-ref.expanded.rs
+++ b/tests/expand/naming/enum-ref.expanded.rs
@@ -17,9 +17,9 @@ enum Enum<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::ref_option_ref)]
-#[allow(clippy::type_repetition_in_bounds)]
 enum ProjRef<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -39,7 +39,9 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {

--- a/tests/expand/naming/struct-all.expanded.rs
+++ b/tests/expand/naming/struct-all.expanded.rs
@@ -13,9 +13,9 @@ struct Struct<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
 struct Proj<'pin, T, U>
 where
     Struct<T, U>: 'pin,
@@ -31,9 +31,9 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::ref_option_ref)]
-#[allow(clippy::type_repetition_in_bounds)]
 struct ProjRef<'pin, T, U>
 where
     Struct<T, U>: 'pin,
@@ -49,6 +49,7 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 struct ProjOwn<T, U> {
     pinned: ::pin_project::__private::PhantomData<T>,
@@ -62,7 +63,9 @@ struct ProjOwn<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Struct<T, U> {

--- a/tests/expand/naming/struct-mut.expanded.rs
+++ b/tests/expand/naming/struct-mut.expanded.rs
@@ -13,9 +13,9 @@ struct Struct<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
 struct Proj<'pin, T, U>
 where
     Struct<T, U>: 'pin,
@@ -31,20 +31,13 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,

--- a/tests/expand/naming/struct-none.expanded.rs
+++ b/tests/expand/naming/struct-none.expanded.rs
@@ -13,20 +13,13 @@ struct Struct<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -34,17 +27,8 @@ const _: () = {
         pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
         unpinned: &'pin mut (U),
     }
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,

--- a/tests/expand/naming/struct-own.expanded.rs
+++ b/tests/expand/naming/struct-own.expanded.rs
@@ -13,6 +13,7 @@ struct Struct<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 struct ProjOwn<T, U> {
     pinned: ::pin_project::__private::PhantomData<T>,
@@ -26,20 +27,13 @@ struct ProjOwn<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -47,17 +41,8 @@ const _: () = {
         pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
         unpinned: &'pin mut (U),
     }
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,

--- a/tests/expand/naming/struct-ref.expanded.rs
+++ b/tests/expand/naming/struct-ref.expanded.rs
@@ -13,9 +13,9 @@ struct Struct<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::ref_option_ref)]
-#[allow(clippy::type_repetition_in_bounds)]
 struct ProjRef<'pin, T, U>
 where
     Struct<T, U>: 'pin,
@@ -31,20 +31,13 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,

--- a/tests/expand/naming/tuple_struct-all.expanded.rs
+++ b/tests/expand/naming/tuple_struct-all.expanded.rs
@@ -9,9 +9,9 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
 struct Proj<'pin, T, U>(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U))
 where
     TupleStruct<T, U>: 'pin;
@@ -23,9 +23,9 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::ref_option_ref)]
-#[allow(clippy::type_repetition_in_bounds)]
 struct ProjRef<'pin, T, U>(::pin_project::__private::Pin<&'pin (T)>, &'pin (U))
 where
     TupleStruct<T, U>: 'pin;
@@ -37,6 +37,7 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 struct ProjOwn<T, U>(::pin_project::__private::PhantomData<T>, U);
 #[allow(box_pointers)]
@@ -47,7 +48,9 @@ struct ProjOwn<T, U>(::pin_project::__private::PhantomData<T>, U);
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> TupleStruct<T, U> {

--- a/tests/expand/naming/tuple_struct-mut.expanded.rs
+++ b/tests/expand/naming/tuple_struct-mut.expanded.rs
@@ -9,9 +9,9 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
 struct Proj<'pin, T, U>(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U))
 where
     TupleStruct<T, U>: 'pin;
@@ -23,20 +23,13 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),

--- a/tests/expand/naming/tuple_struct-none.expanded.rs
+++ b/tests/expand/naming/tuple_struct-none.expanded.rs
@@ -9,37 +9,21 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
     )
     where
         TupleStruct<T, U>: 'pin;
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),

--- a/tests/expand/naming/tuple_struct-own.expanded.rs
+++ b/tests/expand/naming/tuple_struct-own.expanded.rs
@@ -9,6 +9,7 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 struct ProjOwn<T, U>(::pin_project::__private::PhantomData<T>, U);
 #[allow(box_pointers)]
@@ -19,37 +20,21 @@ struct ProjOwn<T, U>(::pin_project::__private::PhantomData<T>, U);
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
     )
     where
         TupleStruct<T, U>: 'pin;
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),

--- a/tests/expand/naming/tuple_struct-ref.expanded.rs
+++ b/tests/expand/naming/tuple_struct-ref.expanded.rs
@@ -9,9 +9,9 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::ref_option_ref)]
-#[allow(clippy::type_repetition_in_bounds)]
 struct ProjRef<'pin, T, U>(::pin_project::__private::Pin<&'pin (T)>, &'pin (U))
 where
     TupleStruct<T, U>: 'pin;
@@ -23,20 +23,13 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),

--- a/tests/expand/not_unpin/enum.expanded.rs
+++ b/tests/expand/not_unpin/enum.expanded.rs
@@ -17,9 +17,9 @@ enum Enum<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
 enum EnumProj<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -39,9 +39,9 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::ref_option_ref)]
-#[allow(clippy::type_repetition_in_bounds)]
 enum EnumProjRef<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -61,7 +61,9 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {

--- a/tests/expand/not_unpin/struct.expanded.rs
+++ b/tests/expand/not_unpin/struct.expanded.rs
@@ -13,20 +13,13 @@ struct Struct<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -34,17 +27,8 @@ const _: () = {
         pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
         unpinned: &'pin mut (U),
     }
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,

--- a/tests/expand/not_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/not_unpin/tuple_struct.expanded.rs
@@ -9,37 +9,21 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
     )
     where
         TupleStruct<T, U>: 'pin;
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),

--- a/tests/expand/pinned_drop/enum.expanded.rs
+++ b/tests/expand/pinned_drop/enum.expanded.rs
@@ -18,9 +18,9 @@ enum Enum<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
 enum EnumProj<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -40,9 +40,9 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::ref_option_ref)]
-#[allow(clippy::type_repetition_in_bounds)]
 enum EnumProjRef<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -62,7 +62,9 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {

--- a/tests/expand/pinned_drop/struct.expanded.rs
+++ b/tests/expand/pinned_drop/struct.expanded.rs
@@ -14,20 +14,13 @@ struct Struct<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -35,17 +28,8 @@ const _: () = {
         pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
         unpinned: &'pin mut (U),
     }
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,

--- a/tests/expand/pinned_drop/tuple_struct.expanded.rs
+++ b/tests/expand/pinned_drop/tuple_struct.expanded.rs
@@ -10,37 +10,21 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
     )
     where
         TupleStruct<T, U>: 'pin;
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),

--- a/tests/expand/project_replace/enum.expanded.rs
+++ b/tests/expand/project_replace/enum.expanded.rs
@@ -17,6 +17,7 @@ enum Enum<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(variant_size_differences)]
 #[allow(clippy::large_enum_variant)]
@@ -36,7 +37,9 @@ enum EnumProjOwn<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {

--- a/tests/expand/project_replace/struct.expanded.rs
+++ b/tests/expand/project_replace/struct.expanded.rs
@@ -13,20 +13,13 @@ struct Struct<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -34,17 +27,8 @@ const _: () = {
         pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
         unpinned: &'pin mut (U),
     }
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -52,14 +36,6 @@ const _: () = {
         pinned: ::pin_project::__private::Pin<&'pin (T)>,
         unpinned: &'pin (U),
     }
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     struct __StructProjectionOwned<T, U> {
         pinned: ::pin_project::__private::PhantomData<T>,

--- a/tests/expand/project_replace/tuple_struct.expanded.rs
+++ b/tests/expand/project_replace/tuple_struct.expanded.rs
@@ -9,51 +9,27 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
     )
     where
         TupleStruct<T, U>: 'pin;
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),
     )
     where
         TupleStruct<T, U>: 'pin;
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     struct __TupleStructProjectionOwned<T, U>(::pin_project::__private::PhantomData<T>, U);
     impl<T, U> TupleStruct<T, U> {

--- a/tests/expand/pub/enum.expanded.rs
+++ b/tests/expand/pub/enum.expanded.rs
@@ -17,9 +17,9 @@ pub enum Enum<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
 pub(crate) enum EnumProj<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -39,9 +39,9 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::ref_option_ref)]
-#[allow(clippy::type_repetition_in_bounds)]
 pub(crate) enum EnumProjRef<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -61,7 +61,9 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {

--- a/tests/expand/pub/struct.expanded.rs
+++ b/tests/expand/pub/struct.expanded.rs
@@ -13,20 +13,13 @@ pub struct Struct<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     pub(crate) struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -34,17 +27,8 @@ const _: () = {
         pub pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
         pub unpinned: &'pin mut (U),
     }
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     pub(crate) struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,

--- a/tests/expand/pub/tuple_struct.expanded.rs
+++ b/tests/expand/pub/tuple_struct.expanded.rs
@@ -9,37 +9,21 @@ pub struct TupleStruct<T, U>(#[pin] pub T, pub U);
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     pub(crate) struct __TupleStructProjection<'pin, T, U>(
         pub ::pin_project::__private::Pin<&'pin mut (T)>,
         pub &'pin mut (U),
     )
     where
         TupleStruct<T, U>: 'pin;
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     pub(crate) struct __TupleStructProjectionRef<'pin, T, U>(
         pub ::pin_project::__private::Pin<&'pin (T)>,
         pub &'pin (U),

--- a/tests/expand/unsafe_unpin/enum.expanded.rs
+++ b/tests/expand/unsafe_unpin/enum.expanded.rs
@@ -17,9 +17,9 @@ enum Enum<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::mut_mut)]
-#[allow(clippy::type_repetition_in_bounds)]
 enum EnumProj<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -39,9 +39,9 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(dead_code)]
 #[allow(clippy::ref_option_ref)]
-#[allow(clippy::type_repetition_in_bounds)]
 enum EnumProjRef<'pin, T, U>
 where
     Enum<T, U>: 'pin,
@@ -61,7 +61,9 @@ where
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {

--- a/tests/expand/unsafe_unpin/struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/struct.expanded.rs
@@ -13,20 +13,13 @@ struct Struct<T, U> {
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -34,17 +27,8 @@ const _: () = {
         pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
         unpinned: &'pin mut (U),
     }
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,

--- a/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
@@ -9,37 +9,21 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
 #[allow(clippy::semicolon_if_nothing_returned)]
+#[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
     )
     where
         TupleStruct<T, U>: 'pin;
-    #[allow(box_pointers)]
-    #[allow(deprecated)]
-    #[allow(explicit_outlives_requirements)]
-    #[allow(single_use_lifetimes)]
-    #[allow(unreachable_pub)]
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::pattern_type_mismatch)]
-    #[allow(clippy::redundant_pub_crate)]
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
-    #[allow(clippy::type_repetition_in_bounds)]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -1077,6 +1077,45 @@ pub mod clippy_type_repetition_in_bounds {
     }
 }
 
+pub mod clippy_use_self {
+    use pin_project::pin_project;
+
+    pub trait Trait {
+        type Assoc;
+    }
+
+    #[pin_project(project_replace)]
+    #[derive(Debug)]
+    pub struct Generics<T: Trait<Assoc = Self>>
+    where
+        Self: Trait<Assoc = Self>,
+    {
+        _f: T,
+    }
+
+    pub mod inside_macro {
+        use pin_project::pin_project;
+
+        use super::Trait;
+
+        #[rustfmt::skip]
+        macro_rules! mac {
+            () => {
+                #[pin_project(project_replace)]
+                #[derive(Debug)]
+                pub struct Generics<T: Trait<Assoc = Self>>
+                where
+                    Self: Trait<Assoc = Self>,
+                {
+                    _f: T,
+                }
+            };
+        }
+
+        mac!();
+    }
+}
+
 pub mod clippy_used_underscore_binding {
     use pin_project::pin_project;
 

--- a/tests/pin_project.rs
+++ b/tests/pin_project.rs
@@ -94,7 +94,7 @@ fn projection() {
         EnumProj::Struct { f1, f2 } => {
             let _: Pin<&mut i32> = f1;
             let _: &mut i32 = f2;
-            unreachable!()
+            unreachable!();
         }
         EnumProj::Unit => unreachable!(),
     }
@@ -108,7 +108,7 @@ fn projection() {
         EnumProj::Tuple(x, y) => {
             let _: Pin<&mut i32> = x;
             let _: &mut i32 = y;
-            unreachable!()
+            unreachable!();
         }
         EnumProj::Struct { f1, f2 } => {
             let _: Pin<&mut i32> = f1;
@@ -723,6 +723,7 @@ fn parse_self() {
         type Assoc;
     }
 
+    #[allow(clippy::type_repetition_in_bounds)]
     #[pin_project(project_replace)]
     pub struct Generics<T: Trait<Assoc = Self>>
     where

--- a/tests/pinned_drop.rs
+++ b/tests/pinned_drop.rs
@@ -70,10 +70,10 @@ fn self_ty() {
 
             // pat
             match *self {
-                Self { f: _ } => {}
+                Self { f: () } => {}
             }
-            if let Self { f: _ } = *self {}
-            let Self { f: _ } = *self;
+            if let Self { f: () } = *self {}
+            let Self { f: () } = *self;
         }
     }
 
@@ -113,11 +113,11 @@ fn self_ty() {
 
             // pat
             match *self {
-                Self::Struct { f: _ } => {}
+                Self::Struct { f: () } => {}
                 Self::Tuple(_) => {}
                 Self::Unit => {}
             }
-            if let Self::Struct { f: _ } = *self {}
+            if let Self::Struct { f: () } = *self {}
             if let Self::Tuple(_) = *self {}
             if let Self::Unit = *self {}
         }
@@ -138,7 +138,7 @@ fn self_inside_macro_containing_fn() {
     #[pinned_drop]
     impl PinnedDrop for S {
         fn drop(self: Pin<&mut Self>) {
-            let _ = mac!({
+            mac!({
                 impl S {
                     pub fn _f(self) -> Self {
                         self
@@ -213,7 +213,7 @@ fn self_ty_inside_macro_call() {
     }
 
     impl<T: Send> Trait for Struct<T> {
-        type Assoc2 = ();
+        type Assoc2 = u8;
         const ASSOC2: usize = 2;
         fn assoc2() {}
     }


### PR DESCRIPTION
- Suppress `clippy::use_self` and `clippy::type_repetition_in_bounds` lints in generated code.
- Reduce the amount of code generated.