### PR TITLE
Prevent abuse of private module

### DIFF
--- a/tests/expand/default/enum.expanded.rs
+++ b/tests/expand/default/enum.expanded.rs
@@ -62,22 +62,25 @@ where
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
             unsafe {
                 match self.get_unchecked_mut() {
                     Self::Struct { pinned, unpinned } => EnumProj::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                        pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
                     Self::Tuple(_0, _1) => {
-                        EnumProj::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                        EnumProj::Tuple(_pin_project::__private::Pin::new_unchecked(_0), _1)
                     }
                     Self::Unit => EnumProj::Unit,
                 }
@@ -85,16 +88,16 @@ const _: () = {
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {
             unsafe {
                 match self.get_ref() {
                     Self::Struct { pinned, unpinned } => EnumProjRef::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                        pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
                     Self::Tuple(_0, _1) => {
-                        EnumProjRef::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                        EnumProjRef::Tuple(_pin_project::__private::Pin::new_unchecked(_0), _1)
                     }
                     Self::Unit => EnumProjRef::Unit,
                 }
@@ -103,32 +106,32 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> EnumMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> EnumMustNotImplDrop for T {}
     impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Enum<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/default/struct.expanded.rs
+++ b/tests/expand/default/struct.expanded.rs
@@ -14,10 +14,13 @@ struct Struct<T, U> {
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __StructProjection<'pin, T, U>
@@ -38,24 +41,24 @@ const _: () = {
     }
     impl<T, U> Struct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_unchecked_mut();
                 __StructProjection {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_ref();
                 __StructProjectionRef {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
@@ -68,31 +71,31 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> StructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> StructMustNotImplDrop for T {}
     impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/default/tuple_struct.expanded.rs
+++ b/tests/expand/default/tuple_struct.expanded.rs
@@ -10,10 +10,13 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -32,20 +35,20 @@ const _: () = {
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_unchecked_mut();
-                __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjection(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_ref();
-                __TupleStructProjectionRef(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjectionRef(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
     }
@@ -56,31 +59,31 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
     impl<T, U> TupleStructMustNotImplDrop for TupleStruct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for TupleStruct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/multifields/enum.expanded.rs
+++ b/tests/expand/multifields/enum.expanded.rs
@@ -106,13 +106,16 @@ enum EnumProjOwn<T, U> {
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
             unsafe {
                 match self.get_unchecked_mut() {
@@ -122,14 +125,14 @@ const _: () = {
                         unpinned1,
                         unpinned2,
                     } => EnumProj::Struct {
-                        pinned1: ::pin_project::__private::Pin::new_unchecked(pinned1),
-                        pinned2: ::pin_project::__private::Pin::new_unchecked(pinned2),
+                        pinned1: _pin_project::__private::Pin::new_unchecked(pinned1),
+                        pinned2: _pin_project::__private::Pin::new_unchecked(pinned2),
                         unpinned1,
                         unpinned2,
                     },
                     Self::Tuple(_0, _1, _2, _3) => EnumProj::Tuple(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                        ::pin_project::__private::Pin::new_unchecked(_1),
+                        _pin_project::__private::Pin::new_unchecked(_0),
+                        _pin_project::__private::Pin::new_unchecked(_1),
                         _2,
                         _3,
                     ),
@@ -139,7 +142,7 @@ const _: () = {
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {
             unsafe {
                 match self.get_ref() {
@@ -149,14 +152,14 @@ const _: () = {
                         unpinned1,
                         unpinned2,
                     } => EnumProjRef::Struct {
-                        pinned1: ::pin_project::__private::Pin::new_unchecked(pinned1),
-                        pinned2: ::pin_project::__private::Pin::new_unchecked(pinned2),
+                        pinned1: _pin_project::__private::Pin::new_unchecked(pinned1),
+                        pinned2: _pin_project::__private::Pin::new_unchecked(pinned2),
                         unpinned1,
                         unpinned2,
                     },
                     Self::Tuple(_0, _1, _2, _3) => EnumProjRef::Tuple(
-                        ::pin_project::__private::Pin::new_unchecked(_0),
-                        ::pin_project::__private::Pin::new_unchecked(_1),
+                        _pin_project::__private::Pin::new_unchecked(_0),
+                        _pin_project::__private::Pin::new_unchecked(_1),
                         _2,
                         _3,
                     ),
@@ -165,14 +168,14 @@ const _: () = {
             }
         }
         fn project_replace(
-            self: ::pin_project::__private::Pin<&mut Self>,
+            self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,
         ) -> EnumProjOwn<T, U> {
             unsafe {
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
-                let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                let __guard = _pin_project::__private::UnsafeOverwriteGuard {
                     target: __self_ptr,
-                    value: ::pin_project::__private::ManuallyDrop::new(__replacement),
+                    value: _pin_project::__private::ManuallyDrop::new(__replacement),
                 };
                 match &mut *__self_ptr {
                     Self::Struct {
@@ -182,27 +185,27 @@ const _: () = {
                         unpinned2,
                     } => {
                         let __result = EnumProjOwn::Struct {
-                            pinned1: ::pin_project::__private::PhantomData,
-                            pinned2: ::pin_project::__private::PhantomData,
-                            unpinned1: ::pin_project::__private::ptr::read(unpinned1),
-                            unpinned2: ::pin_project::__private::ptr::read(unpinned2),
+                            pinned1: _pin_project::__private::PhantomData,
+                            pinned2: _pin_project::__private::PhantomData,
+                            unpinned1: _pin_project::__private::ptr::read(unpinned1),
+                            unpinned2: _pin_project::__private::ptr::read(unpinned2),
                         };
                         {
-                            let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned2);
-                            let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned1);
+                            let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(pinned2);
+                            let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(pinned1);
                         }
                         __result
                     }
                     Self::Tuple(_0, _1, _2, _3) => {
                         let __result = EnumProjOwn::Tuple(
-                            ::pin_project::__private::PhantomData,
-                            ::pin_project::__private::PhantomData,
-                            ::pin_project::__private::ptr::read(_2),
-                            ::pin_project::__private::ptr::read(_3),
+                            _pin_project::__private::PhantomData,
+                            _pin_project::__private::PhantomData,
+                            _pin_project::__private::ptr::read(_2),
+                            _pin_project::__private::ptr::read(_3),
                         );
                         {
-                            let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(_1);
-                            let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(_0);
+                            let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(_1);
+                            let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(_0);
                         }
                         __result
                     }
@@ -217,11 +220,11 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
@@ -229,22 +232,22 @@ const _: () = {
         __field2: T,
         __field3: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> EnumMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> EnumMustNotImplDrop for T {}
     impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Enum<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/multifields/struct.expanded.rs
+++ b/tests/expand/multifields/struct.expanded.rs
@@ -17,10 +17,13 @@ struct Struct<T, U> {
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __StructProjection<'pin, T, U>
@@ -52,7 +55,7 @@ const _: () = {
     }
     impl<T, U> Struct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
             unsafe {
                 let Self {
@@ -62,8 +65,8 @@ const _: () = {
                     unpinned2,
                 } = self.get_unchecked_mut();
                 __StructProjection {
-                    pinned1: ::pin_project::__private::Pin::new_unchecked(pinned1),
-                    pinned2: ::pin_project::__private::Pin::new_unchecked(pinned2),
+                    pinned1: _pin_project::__private::Pin::new_unchecked(pinned1),
+                    pinned2: _pin_project::__private::Pin::new_unchecked(pinned2),
                     unpinned1,
                     unpinned2,
                 }
@@ -71,7 +74,7 @@ const _: () = {
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self {
@@ -81,22 +84,22 @@ const _: () = {
                     unpinned2,
                 } = self.get_ref();
                 __StructProjectionRef {
-                    pinned1: ::pin_project::__private::Pin::new_unchecked(pinned1),
-                    pinned2: ::pin_project::__private::Pin::new_unchecked(pinned2),
+                    pinned1: _pin_project::__private::Pin::new_unchecked(pinned1),
+                    pinned2: _pin_project::__private::Pin::new_unchecked(pinned2),
                     unpinned1,
                     unpinned2,
                 }
             }
         }
         fn project_replace(
-            self: ::pin_project::__private::Pin<&mut Self>,
+            self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,
         ) -> __StructProjectionOwned<T, U> {
             unsafe {
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
-                let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                let __guard = _pin_project::__private::UnsafeOverwriteGuard {
                     target: __self_ptr,
-                    value: ::pin_project::__private::ManuallyDrop::new(__replacement),
+                    value: _pin_project::__private::ManuallyDrop::new(__replacement),
                 };
                 let Self {
                     pinned1,
@@ -105,14 +108,14 @@ const _: () = {
                     unpinned2,
                 } = &mut *__self_ptr;
                 let __result = __StructProjectionOwned {
-                    pinned1: ::pin_project::__private::PhantomData,
-                    pinned2: ::pin_project::__private::PhantomData,
-                    unpinned1: ::pin_project::__private::ptr::read(unpinned1),
-                    unpinned2: ::pin_project::__private::ptr::read(unpinned2),
+                    pinned1: _pin_project::__private::PhantomData,
+                    pinned2: _pin_project::__private::PhantomData,
+                    unpinned1: _pin_project::__private::ptr::read(unpinned1),
+                    unpinned2: _pin_project::__private::ptr::read(unpinned2),
                 };
                 {
-                    let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned2);
-                    let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned1);
+                    let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(pinned2);
+                    let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(pinned1);
                 }
                 __result
             }
@@ -127,32 +130,32 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> StructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> StructMustNotImplDrop for T {}
     impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/multifields/tuple_struct.expanded.rs
+++ b/tests/expand/multifields/tuple_struct.expanded.rs
@@ -10,10 +10,13 @@ struct TupleStruct<T, U>(#[pin] T, #[pin] T, U, U);
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -43,13 +46,13 @@ const _: () = {
     );
     impl<T, U> TupleStruct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
             unsafe {
                 let Self(_0, _1, _2, _3) = self.get_unchecked_mut();
                 __TupleStructProjection(
-                    ::pin_project::__private::Pin::new_unchecked(_0),
-                    ::pin_project::__private::Pin::new_unchecked(_1),
+                    _pin_project::__private::Pin::new_unchecked(_0),
+                    _pin_project::__private::Pin::new_unchecked(_1),
                     _2,
                     _3,
                 )
@@ -57,38 +60,38 @@ const _: () = {
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self(_0, _1, _2, _3) = self.get_ref();
                 __TupleStructProjectionRef(
-                    ::pin_project::__private::Pin::new_unchecked(_0),
-                    ::pin_project::__private::Pin::new_unchecked(_1),
+                    _pin_project::__private::Pin::new_unchecked(_0),
+                    _pin_project::__private::Pin::new_unchecked(_1),
                     _2,
                     _3,
                 )
             }
         }
         fn project_replace(
-            self: ::pin_project::__private::Pin<&mut Self>,
+            self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,
         ) -> __TupleStructProjectionOwned<T, U> {
             unsafe {
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
-                let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                let __guard = _pin_project::__private::UnsafeOverwriteGuard {
                     target: __self_ptr,
-                    value: ::pin_project::__private::ManuallyDrop::new(__replacement),
+                    value: _pin_project::__private::ManuallyDrop::new(__replacement),
                 };
                 let Self(_0, _1, _2, _3) = &mut *__self_ptr;
                 let __result = __TupleStructProjectionOwned(
-                    ::pin_project::__private::PhantomData,
-                    ::pin_project::__private::PhantomData,
-                    ::pin_project::__private::ptr::read(_2),
-                    ::pin_project::__private::ptr::read(_3),
+                    _pin_project::__private::PhantomData,
+                    _pin_project::__private::PhantomData,
+                    _pin_project::__private::ptr::read(_2),
+                    _pin_project::__private::ptr::read(_3),
                 );
                 {
-                    let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(_1);
-                    let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(_0);
+                    let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(_1);
+                    let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(_0);
                 }
                 __result
             }
@@ -103,32 +106,32 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
     impl<T, U> TupleStructMustNotImplDrop for TupleStruct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for TupleStruct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/naming/enum-all.expanded.rs
+++ b/tests/expand/naming/enum-all.expanded.rs
@@ -82,20 +82,23 @@ enum ProjOwn<T, U> {
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
-        fn project<'pin>(self: ::pin_project::__private::Pin<&'pin mut Self>) -> Proj<'pin, T, U> {
+        fn project<'pin>(self: _pin_project::__private::Pin<&'pin mut Self>) -> Proj<'pin, T, U> {
             unsafe {
                 match self.get_unchecked_mut() {
                     Self::Struct { pinned, unpinned } => Proj::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                        pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
                     Self::Tuple(_0, _1) => {
-                        Proj::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                        Proj::Tuple(_pin_project::__private::Pin::new_unchecked(_0), _1)
                     }
                     Self::Unit => Proj::Unit,
                 }
@@ -103,49 +106,49 @@ const _: () = {
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {
             unsafe {
                 match self.get_ref() {
                     Self::Struct { pinned, unpinned } => ProjRef::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                        pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
                     Self::Tuple(_0, _1) => {
-                        ProjRef::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                        ProjRef::Tuple(_pin_project::__private::Pin::new_unchecked(_0), _1)
                     }
                     Self::Unit => ProjRef::Unit,
                 }
             }
         }
         fn project_replace(
-            self: ::pin_project::__private::Pin<&mut Self>,
+            self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,
         ) -> ProjOwn<T, U> {
             unsafe {
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
-                let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                let __guard = _pin_project::__private::UnsafeOverwriteGuard {
                     target: __self_ptr,
-                    value: ::pin_project::__private::ManuallyDrop::new(__replacement),
+                    value: _pin_project::__private::ManuallyDrop::new(__replacement),
                 };
                 match &mut *__self_ptr {
                     Self::Struct { pinned, unpinned } => {
                         let __result = ProjOwn::Struct {
-                            pinned: ::pin_project::__private::PhantomData,
-                            unpinned: ::pin_project::__private::ptr::read(unpinned),
+                            pinned: _pin_project::__private::PhantomData,
+                            unpinned: _pin_project::__private::ptr::read(unpinned),
                         };
                         {
-                            let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned);
+                            let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(pinned);
                         }
                         __result
                     }
                     Self::Tuple(_0, _1) => {
                         let __result = ProjOwn::Tuple(
-                            ::pin_project::__private::PhantomData,
-                            ::pin_project::__private::ptr::read(_1),
+                            _pin_project::__private::PhantomData,
+                            _pin_project::__private::ptr::read(_1),
                         );
                         {
-                            let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(_0);
+                            let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(_0);
                         }
                         __result
                     }
@@ -160,32 +163,32 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> EnumMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> EnumMustNotImplDrop for T {}
     impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Enum<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/naming/enum-mut.expanded.rs
+++ b/tests/expand/naming/enum-mut.expanded.rs
@@ -40,20 +40,23 @@ where
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
-        fn project<'pin>(self: ::pin_project::__private::Pin<&'pin mut Self>) -> Proj<'pin, T, U> {
+        fn project<'pin>(self: _pin_project::__private::Pin<&'pin mut Self>) -> Proj<'pin, T, U> {
             unsafe {
                 match self.get_unchecked_mut() {
                     Self::Struct { pinned, unpinned } => Proj::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                        pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
                     Self::Tuple(_0, _1) => {
-                        Proj::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                        Proj::Tuple(_pin_project::__private::Pin::new_unchecked(_0), _1)
                     }
                     Self::Unit => Proj::Unit,
                 }
@@ -62,32 +65,32 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> EnumMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> EnumMustNotImplDrop for T {}
     impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Enum<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/naming/enum-none.expanded.rs
+++ b/tests/expand/naming/enum-none.expanded.rs
@@ -18,39 +18,42 @@ enum Enum<T, U> {
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {}
     #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> EnumMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> EnumMustNotImplDrop for T {}
     impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Enum<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/naming/enum-own.expanded.rs
+++ b/tests/expand/naming/enum-own.expanded.rs
@@ -38,39 +38,42 @@ enum ProjOwn<T, U> {
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
         fn project_replace(
-            self: ::pin_project::__private::Pin<&mut Self>,
+            self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,
         ) -> ProjOwn<T, U> {
             unsafe {
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
-                let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                let __guard = _pin_project::__private::UnsafeOverwriteGuard {
                     target: __self_ptr,
-                    value: ::pin_project::__private::ManuallyDrop::new(__replacement),
+                    value: _pin_project::__private::ManuallyDrop::new(__replacement),
                 };
                 match &mut *__self_ptr {
                     Self::Struct { pinned, unpinned } => {
                         let __result = ProjOwn::Struct {
-                            pinned: ::pin_project::__private::PhantomData,
-                            unpinned: ::pin_project::__private::ptr::read(unpinned),
+                            pinned: _pin_project::__private::PhantomData,
+                            unpinned: _pin_project::__private::ptr::read(unpinned),
                         };
                         {
-                            let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned);
+                            let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(pinned);
                         }
                         __result
                     }
                     Self::Tuple(_0, _1) => {
                         let __result = ProjOwn::Tuple(
-                            ::pin_project::__private::PhantomData,
-                            ::pin_project::__private::ptr::read(_1),
+                            _pin_project::__private::PhantomData,
+                            _pin_project::__private::ptr::read(_1),
                         );
                         {
-                            let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(_0);
+                            let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(_0);
                         }
                         __result
                     }
@@ -85,32 +88,32 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> EnumMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> EnumMustNotImplDrop for T {}
     impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Enum<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/naming/enum-ref.expanded.rs
+++ b/tests/expand/naming/enum-ref.expanded.rs
@@ -40,23 +40,26 @@ where
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {
             unsafe {
                 match self.get_ref() {
                     Self::Struct { pinned, unpinned } => ProjRef::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                        pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
                     Self::Tuple(_0, _1) => {
-                        ProjRef::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                        ProjRef::Tuple(_pin_project::__private::Pin::new_unchecked(_0), _1)
                     }
                     Self::Unit => ProjRef::Unit,
                 }
@@ -65,32 +68,32 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> EnumMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> EnumMustNotImplDrop for T {}
     impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Enum<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/naming/struct-all.expanded.rs
+++ b/tests/expand/naming/struct-all.expanded.rs
@@ -64,49 +64,52 @@ struct ProjOwn<T, U> {
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     impl<T, U> Struct<T, U> {
-        fn project<'pin>(self: ::pin_project::__private::Pin<&'pin mut Self>) -> Proj<'pin, T, U> {
+        fn project<'pin>(self: _pin_project::__private::Pin<&'pin mut Self>) -> Proj<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_unchecked_mut();
                 Proj {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_ref();
                 ProjRef {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         fn project_replace(
-            self: ::pin_project::__private::Pin<&mut Self>,
+            self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,
         ) -> ProjOwn<T, U> {
             unsafe {
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
-                let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                let __guard = _pin_project::__private::UnsafeOverwriteGuard {
                     target: __self_ptr,
-                    value: ::pin_project::__private::ManuallyDrop::new(__replacement),
+                    value: _pin_project::__private::ManuallyDrop::new(__replacement),
                 };
                 let Self { pinned, unpinned } = &mut *__self_ptr;
                 let __result = ProjOwn {
-                    pinned: ::pin_project::__private::PhantomData,
-                    unpinned: ::pin_project::__private::ptr::read(unpinned),
+                    pinned: _pin_project::__private::PhantomData,
+                    unpinned: _pin_project::__private::ptr::read(unpinned),
                 };
                 {
-                    let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned);
+                    let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(pinned);
                 }
                 __result
             }
@@ -119,31 +122,31 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> StructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> StructMustNotImplDrop for T {}
     impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/naming/struct-mut.expanded.rs
+++ b/tests/expand/naming/struct-mut.expanded.rs
@@ -32,10 +32,13 @@ where
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
     struct __StructProjectionRef<'pin, T, U>
@@ -46,23 +49,23 @@ const _: () = {
         unpinned: &'pin (U),
     }
     impl<T, U> Struct<T, U> {
-        fn project<'pin>(self: ::pin_project::__private::Pin<&'pin mut Self>) -> Proj<'pin, T, U> {
+        fn project<'pin>(self: _pin_project::__private::Pin<&'pin mut Self>) -> Proj<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_unchecked_mut();
                 Proj {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_ref();
                 __StructProjectionRef {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
@@ -75,31 +78,31 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> StructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> StructMustNotImplDrop for T {}
     impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/naming/struct-none.expanded.rs
+++ b/tests/expand/naming/struct-none.expanded.rs
@@ -14,10 +14,13 @@ struct Struct<T, U> {
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __StructProjection<'pin, T, U>
@@ -38,24 +41,24 @@ const _: () = {
     }
     impl<T, U> Struct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_unchecked_mut();
                 __StructProjection {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_ref();
                 __StructProjectionRef {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
@@ -68,31 +71,31 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> StructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> StructMustNotImplDrop for T {}
     impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/naming/struct-own.expanded.rs
+++ b/tests/expand/naming/struct-own.expanded.rs
@@ -28,10 +28,13 @@ struct ProjOwn<T, U> {
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __StructProjection<'pin, T, U>
@@ -52,45 +55,45 @@ const _: () = {
     }
     impl<T, U> Struct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_unchecked_mut();
                 __StructProjection {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_ref();
                 __StructProjectionRef {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         fn project_replace(
-            self: ::pin_project::__private::Pin<&mut Self>,
+            self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,
         ) -> ProjOwn<T, U> {
             unsafe {
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
-                let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                let __guard = _pin_project::__private::UnsafeOverwriteGuard {
                     target: __self_ptr,
-                    value: ::pin_project::__private::ManuallyDrop::new(__replacement),
+                    value: _pin_project::__private::ManuallyDrop::new(__replacement),
                 };
                 let Self { pinned, unpinned } = &mut *__self_ptr;
                 let __result = ProjOwn {
-                    pinned: ::pin_project::__private::PhantomData,
-                    unpinned: ::pin_project::__private::ptr::read(unpinned),
+                    pinned: _pin_project::__private::PhantomData,
+                    unpinned: _pin_project::__private::ptr::read(unpinned),
                 };
                 {
-                    let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned);
+                    let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(pinned);
                 }
                 __result
             }
@@ -103,31 +106,31 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> StructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> StructMustNotImplDrop for T {}
     impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/naming/struct-ref.expanded.rs
+++ b/tests/expand/naming/struct-ref.expanded.rs
@@ -32,10 +32,13 @@ where
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __StructProjection<'pin, T, U>
@@ -47,24 +50,24 @@ const _: () = {
     }
     impl<T, U> Struct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_unchecked_mut();
                 __StructProjection {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_ref();
                 ProjRef {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
@@ -77,31 +80,31 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> StructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> StructMustNotImplDrop for T {}
     impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/naming/tuple_struct-all.expanded.rs
+++ b/tests/expand/naming/tuple_struct-all.expanded.rs
@@ -49,43 +49,46 @@ struct ProjOwn<T, U>(::pin_project::__private::PhantomData<T>, U);
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     impl<T, U> TupleStruct<T, U> {
-        fn project<'pin>(self: ::pin_project::__private::Pin<&'pin mut Self>) -> Proj<'pin, T, U> {
+        fn project<'pin>(self: _pin_project::__private::Pin<&'pin mut Self>) -> Proj<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_unchecked_mut();
-                Proj(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                Proj(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_ref();
-                ProjRef(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                ProjRef(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
         fn project_replace(
-            self: ::pin_project::__private::Pin<&mut Self>,
+            self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,
         ) -> ProjOwn<T, U> {
             unsafe {
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
-                let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                let __guard = _pin_project::__private::UnsafeOverwriteGuard {
                     target: __self_ptr,
-                    value: ::pin_project::__private::ManuallyDrop::new(__replacement),
+                    value: _pin_project::__private::ManuallyDrop::new(__replacement),
                 };
                 let Self(_0, _1) = &mut *__self_ptr;
                 let __result = ProjOwn(
-                    ::pin_project::__private::PhantomData,
-                    ::pin_project::__private::ptr::read(_1),
+                    _pin_project::__private::PhantomData,
+                    _pin_project::__private::ptr::read(_1),
                 );
                 {
-                    let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(_0);
+                    let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(_0);
                 }
                 __result
             }
@@ -98,31 +101,31 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
     impl<T, U> TupleStructMustNotImplDrop for TupleStruct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for TupleStruct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/naming/tuple_struct-mut.expanded.rs
+++ b/tests/expand/naming/tuple_struct-mut.expanded.rs
@@ -24,10 +24,13 @@ where
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::ref_option_ref)]
     struct __TupleStructProjectionRef<'pin, T, U>(
@@ -37,19 +40,19 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
-        fn project<'pin>(self: ::pin_project::__private::Pin<&'pin mut Self>) -> Proj<'pin, T, U> {
+        fn project<'pin>(self: _pin_project::__private::Pin<&'pin mut Self>) -> Proj<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_unchecked_mut();
-                Proj(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                Proj(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_ref();
-                __TupleStructProjectionRef(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjectionRef(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
     }
@@ -60,31 +63,31 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
     impl<T, U> TupleStructMustNotImplDrop for TupleStruct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for TupleStruct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/naming/tuple_struct-none.expanded.rs
+++ b/tests/expand/naming/tuple_struct-none.expanded.rs
@@ -10,10 +10,13 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -32,20 +35,20 @@ const _: () = {
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_unchecked_mut();
-                __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjection(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_ref();
-                __TupleStructProjectionRef(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjectionRef(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
     }
@@ -56,31 +59,31 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
     impl<T, U> TupleStructMustNotImplDrop for TupleStruct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for TupleStruct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/naming/tuple_struct-own.expanded.rs
+++ b/tests/expand/naming/tuple_struct-own.expanded.rs
@@ -21,10 +21,13 @@ struct ProjOwn<T, U>(::pin_project::__private::PhantomData<T>, U);
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -43,39 +46,39 @@ const _: () = {
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_unchecked_mut();
-                __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjection(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_ref();
-                __TupleStructProjectionRef(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjectionRef(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
         fn project_replace(
-            self: ::pin_project::__private::Pin<&mut Self>,
+            self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,
         ) -> ProjOwn<T, U> {
             unsafe {
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
-                let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                let __guard = _pin_project::__private::UnsafeOverwriteGuard {
                     target: __self_ptr,
-                    value: ::pin_project::__private::ManuallyDrop::new(__replacement),
+                    value: _pin_project::__private::ManuallyDrop::new(__replacement),
                 };
                 let Self(_0, _1) = &mut *__self_ptr;
                 let __result = ProjOwn(
-                    ::pin_project::__private::PhantomData,
-                    ::pin_project::__private::ptr::read(_1),
+                    _pin_project::__private::PhantomData,
+                    _pin_project::__private::ptr::read(_1),
                 );
                 {
-                    let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(_0);
+                    let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(_0);
                 }
                 __result
             }
@@ -88,31 +91,31 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
     impl<T, U> TupleStructMustNotImplDrop for TupleStruct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for TupleStruct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/naming/tuple_struct-ref.expanded.rs
+++ b/tests/expand/naming/tuple_struct-ref.expanded.rs
@@ -24,10 +24,13 @@ where
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -38,20 +41,20 @@ const _: () = {
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_unchecked_mut();
-                __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjection(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_ref();
-                ProjRef(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                ProjRef(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
     }
@@ -62,31 +65,31 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
     impl<T, U> TupleStructMustNotImplDrop for TupleStruct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for TupleStruct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/not_unpin/enum.expanded.rs
+++ b/tests/expand/not_unpin/enum.expanded.rs
@@ -62,22 +62,25 @@ where
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
             unsafe {
                 match self.get_unchecked_mut() {
                     Self::Struct { pinned, unpinned } => EnumProj::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                        pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
                     Self::Tuple(_0, _1) => {
-                        EnumProj::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                        EnumProj::Tuple(_pin_project::__private::Pin::new_unchecked(_0), _1)
                     }
                     Self::Unit => EnumProj::Unit,
                 }
@@ -85,40 +88,40 @@ const _: () = {
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {
             unsafe {
                 match self.get_ref() {
                     Self::Struct { pinned, unpinned } => EnumProjRef::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                        pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
                     Self::Tuple(_0, _1) => {
-                        EnumProjRef::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                        EnumProjRef::Tuple(_pin_project::__private::Pin::new_unchecked(_0), _1)
                     }
                     Self::Unit => EnumProjRef::Unit,
                 }
             }
         }
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Enum<T, U> where
-        ::pin_project::__private::Wrapper<'pin, ::pin_project::__private::PhantomPinned>:
-            ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U> where
+        _pin_project::__private::Wrapper<'pin, _pin_project::__private::PhantomPinned>:
+            _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Enum<T, U> where
-        ::pin_project::__private::Wrapper<'pin, ::pin_project::__private::PhantomPinned>:
-            ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U> where
+        _pin_project::__private::Wrapper<'pin, _pin_project::__private::PhantomPinned>:
+            _pin_project::__private::Unpin
     {
     }
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> EnumMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> EnumMustNotImplDrop for T {}
     impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Enum<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/not_unpin/struct.expanded.rs
+++ b/tests/expand/not_unpin/struct.expanded.rs
@@ -14,10 +14,13 @@ struct Struct<T, U> {
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __StructProjection<'pin, T, U>
@@ -38,24 +41,24 @@ const _: () = {
     }
     impl<T, U> Struct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_unchecked_mut();
                 __StructProjection {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_ref();
                 __StructProjectionRef {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
@@ -66,24 +69,24 @@ const _: () = {
         let _ = &this.pinned;
         let _ = &this.unpinned;
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        ::pin_project::__private::Wrapper<'pin, ::pin_project::__private::PhantomPinned>:
-            ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U> where
+        _pin_project::__private::Wrapper<'pin, _pin_project::__private::PhantomPinned>:
+            _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        ::pin_project::__private::Wrapper<'pin, ::pin_project::__private::PhantomPinned>:
-            ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U> where
+        _pin_project::__private::Wrapper<'pin, _pin_project::__private::PhantomPinned>:
+            _pin_project::__private::Unpin
     {
     }
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> StructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> StructMustNotImplDrop for T {}
     impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/not_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/not_unpin/tuple_struct.expanded.rs
@@ -10,10 +10,13 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -32,20 +35,20 @@ const _: () = {
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_unchecked_mut();
-                __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjection(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_ref();
-                __TupleStructProjectionRef(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjectionRef(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
     }
@@ -54,24 +57,24 @@ const _: () = {
         let _ = &this.0;
         let _ = &this.1;
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for TupleStruct<T, U> where
-        ::pin_project::__private::Wrapper<'pin, ::pin_project::__private::PhantomPinned>:
-            ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U> where
+        _pin_project::__private::Wrapper<'pin, _pin_project::__private::PhantomPinned>:
+            _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for TupleStruct<T, U> where
-        ::pin_project::__private::Wrapper<'pin, ::pin_project::__private::PhantomPinned>:
-            ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U> where
+        _pin_project::__private::Wrapper<'pin, _pin_project::__private::PhantomPinned>:
+            _pin_project::__private::Unpin
     {
     }
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
     impl<T, U> TupleStructMustNotImplDrop for TupleStruct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for TupleStruct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/pinned_drop/enum.expanded.rs
+++ b/tests/expand/pinned_drop/enum.expanded.rs
@@ -63,22 +63,25 @@ where
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
             unsafe {
                 match self.get_unchecked_mut() {
                     Self::Struct { pinned, unpinned } => EnumProj::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                        pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
                     Self::Tuple(_0, _1) => {
-                        EnumProj::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                        EnumProj::Tuple(_pin_project::__private::Pin::new_unchecked(_0), _1)
                     }
                     Self::Unit => EnumProj::Unit,
                 }
@@ -86,16 +89,16 @@ const _: () = {
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {
             unsafe {
                 match self.get_ref() {
                     Self::Struct { pinned, unpinned } => EnumProjRef::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                        pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
                     Self::Tuple(_0, _1) => {
-                        EnumProjRef::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                        EnumProjRef::Tuple(_pin_project::__private::Pin::new_unchecked(_0), _1)
                     }
                     Self::Unit => EnumProjRef::Unit,
                 }
@@ -104,30 +107,30 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
-    impl<T, U> ::pin_project::__private::Drop for Enum<T, U> {
+    impl<T, U> _pin_project::__private::Drop for Enum<T, U> {
         fn drop(&mut self) {
             unsafe {
-                let __pinned_self = ::pin_project::__private::Pin::new_unchecked(self);
-                ::pin_project::__private::PinnedDrop::drop(__pinned_self);
+                let __pinned_self = _pin_project::__private::Pin::new_unchecked(self);
+                _pin_project::__private::PinnedDrop::drop(__pinned_self);
             }
         }
     }

--- a/tests/expand/pinned_drop/struct.expanded.rs
+++ b/tests/expand/pinned_drop/struct.expanded.rs
@@ -15,10 +15,13 @@ struct Struct<T, U> {
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __StructProjection<'pin, T, U>
@@ -39,24 +42,24 @@ const _: () = {
     }
     impl<T, U> Struct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_unchecked_mut();
                 __StructProjection {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_ref();
                 __StructProjectionRef {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
@@ -69,29 +72,29 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
-    impl<T, U> ::pin_project::__private::Drop for Struct<T, U> {
+    impl<T, U> _pin_project::__private::Drop for Struct<T, U> {
         fn drop(&mut self) {
             unsafe {
-                let __pinned_self = ::pin_project::__private::Pin::new_unchecked(self);
-                ::pin_project::__private::PinnedDrop::drop(__pinned_self);
+                let __pinned_self = _pin_project::__private::Pin::new_unchecked(self);
+                _pin_project::__private::PinnedDrop::drop(__pinned_self);
             }
         }
     }

--- a/tests/expand/pinned_drop/tuple_struct.expanded.rs
+++ b/tests/expand/pinned_drop/tuple_struct.expanded.rs
@@ -11,10 +11,13 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -33,20 +36,20 @@ const _: () = {
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_unchecked_mut();
-                __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjection(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_ref();
-                __TupleStructProjectionRef(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjectionRef(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
     }
@@ -57,29 +60,29 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
-    impl<T, U> ::pin_project::__private::Drop for TupleStruct<T, U> {
+    impl<T, U> _pin_project::__private::Drop for TupleStruct<T, U> {
         fn drop(&mut self) {
             unsafe {
-                let __pinned_self = ::pin_project::__private::Pin::new_unchecked(self);
-                ::pin_project::__private::PinnedDrop::drop(__pinned_self);
+                let __pinned_self = _pin_project::__private::Pin::new_unchecked(self);
+                _pin_project::__private::PinnedDrop::drop(__pinned_self);
             }
         }
     }

--- a/tests/expand/project_replace/enum.expanded.rs
+++ b/tests/expand/project_replace/enum.expanded.rs
@@ -38,39 +38,42 @@ enum EnumProjOwn<T, U> {
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
         fn project_replace(
-            self: ::pin_project::__private::Pin<&mut Self>,
+            self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,
         ) -> EnumProjOwn<T, U> {
             unsafe {
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
-                let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                let __guard = _pin_project::__private::UnsafeOverwriteGuard {
                     target: __self_ptr,
-                    value: ::pin_project::__private::ManuallyDrop::new(__replacement),
+                    value: _pin_project::__private::ManuallyDrop::new(__replacement),
                 };
                 match &mut *__self_ptr {
                     Self::Struct { pinned, unpinned } => {
                         let __result = EnumProjOwn::Struct {
-                            pinned: ::pin_project::__private::PhantomData,
-                            unpinned: ::pin_project::__private::ptr::read(unpinned),
+                            pinned: _pin_project::__private::PhantomData,
+                            unpinned: _pin_project::__private::ptr::read(unpinned),
                         };
                         {
-                            let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned);
+                            let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(pinned);
                         }
                         __result
                     }
                     Self::Tuple(_0, _1) => {
                         let __result = EnumProjOwn::Tuple(
-                            ::pin_project::__private::PhantomData,
-                            ::pin_project::__private::ptr::read(_1),
+                            _pin_project::__private::PhantomData,
+                            _pin_project::__private::ptr::read(_1),
                         );
                         {
-                            let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(_0);
+                            let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(_0);
                         }
                         __result
                     }
@@ -85,32 +88,32 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __Enum<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> EnumMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> EnumMustNotImplDrop for T {}
     impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Enum<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/project_replace/struct.expanded.rs
+++ b/tests/expand/project_replace/struct.expanded.rs
@@ -14,10 +14,13 @@ struct Struct<T, U> {
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __StructProjection<'pin, T, U>
@@ -43,45 +46,45 @@ const _: () = {
     }
     impl<T, U> Struct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_unchecked_mut();
                 __StructProjection {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_ref();
                 __StructProjectionRef {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         fn project_replace(
-            self: ::pin_project::__private::Pin<&mut Self>,
+            self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,
         ) -> __StructProjectionOwned<T, U> {
             unsafe {
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
-                let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                let __guard = _pin_project::__private::UnsafeOverwriteGuard {
                     target: __self_ptr,
-                    value: ::pin_project::__private::ManuallyDrop::new(__replacement),
+                    value: _pin_project::__private::ManuallyDrop::new(__replacement),
                 };
                 let Self { pinned, unpinned } = &mut *__self_ptr;
                 let __result = __StructProjectionOwned {
-                    pinned: ::pin_project::__private::PhantomData,
-                    unpinned: ::pin_project::__private::ptr::read(unpinned),
+                    pinned: _pin_project::__private::PhantomData,
+                    unpinned: _pin_project::__private::ptr::read(unpinned),
                 };
                 {
-                    let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(pinned);
+                    let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(pinned);
                 }
                 __result
             }
@@ -94,31 +97,31 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __Struct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> StructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> StructMustNotImplDrop for T {}
     impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/project_replace/tuple_struct.expanded.rs
+++ b/tests/expand/project_replace/tuple_struct.expanded.rs
@@ -10,10 +10,13 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -34,39 +37,39 @@ const _: () = {
     struct __TupleStructProjectionOwned<T, U>(::pin_project::__private::PhantomData<T>, U);
     impl<T, U> TupleStruct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_unchecked_mut();
-                __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjection(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_ref();
-                __TupleStructProjectionRef(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjectionRef(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
         fn project_replace(
-            self: ::pin_project::__private::Pin<&mut Self>,
+            self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,
         ) -> __TupleStructProjectionOwned<T, U> {
             unsafe {
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
-                let __guard = ::pin_project::__private::UnsafeOverwriteGuard {
+                let __guard = _pin_project::__private::UnsafeOverwriteGuard {
                     target: __self_ptr,
-                    value: ::pin_project::__private::ManuallyDrop::new(__replacement),
+                    value: _pin_project::__private::ManuallyDrop::new(__replacement),
                 };
                 let Self(_0, _1) = &mut *__self_ptr;
                 let __result = __TupleStructProjectionOwned(
-                    ::pin_project::__private::PhantomData,
-                    ::pin_project::__private::ptr::read(_1),
+                    _pin_project::__private::PhantomData,
+                    _pin_project::__private::ptr::read(_1),
                 );
                 {
-                    let __guard = ::pin_project::__private::UnsafeDropInPlaceGuard(_0);
+                    let __guard = _pin_project::__private::UnsafeDropInPlaceGuard(_0);
                 }
                 __result
             }
@@ -79,31 +82,31 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     struct __TupleStruct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
     impl<T, U> TupleStructMustNotImplDrop for TupleStruct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for TupleStruct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/pub/enum.expanded.rs
+++ b/tests/expand/pub/enum.expanded.rs
@@ -62,22 +62,25 @@ where
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
         pub(crate) fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
             unsafe {
                 match self.get_unchecked_mut() {
                     Self::Struct { pinned, unpinned } => EnumProj::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                        pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
                     Self::Tuple(_0, _1) => {
-                        EnumProj::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                        EnumProj::Tuple(_pin_project::__private::Pin::new_unchecked(_0), _1)
                     }
                     Self::Unit => EnumProj::Unit,
                 }
@@ -85,16 +88,16 @@ const _: () = {
         }
         #[allow(clippy::missing_const_for_fn)]
         pub(crate) fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {
             unsafe {
                 match self.get_ref() {
                     Self::Struct { pinned, unpinned } => EnumProjRef::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                        pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
                     Self::Tuple(_0, _1) => {
-                        EnumProjRef::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                        EnumProjRef::Tuple(_pin_project::__private::Pin::new_unchecked(_0), _1)
                     }
                     Self::Unit => EnumProjRef::Unit,
                 }
@@ -103,32 +106,32 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     pub struct __Enum<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U> where
+        __Enum<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> EnumMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> EnumMustNotImplDrop for T {}
     impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Enum<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/pub/struct.expanded.rs
+++ b/tests/expand/pub/struct.expanded.rs
@@ -14,10 +14,13 @@ pub struct Struct<T, U> {
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     pub(crate) struct __StructProjection<'pin, T, U>
@@ -38,24 +41,24 @@ const _: () = {
     }
     impl<T, U> Struct<T, U> {
         pub(crate) fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_unchecked_mut();
                 __StructProjection {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         pub(crate) fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_ref();
                 __StructProjectionRef {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
@@ -68,31 +71,31 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     pub struct __Struct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U> where
+        __Struct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> StructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> StructMustNotImplDrop for T {}
     impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/pub/tuple_struct.expanded.rs
+++ b/tests/expand/pub/tuple_struct.expanded.rs
@@ -10,10 +10,13 @@ pub struct TupleStruct<T, U>(#[pin] pub T, pub U);
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     pub(crate) struct __TupleStructProjection<'pin, T, U>(
@@ -32,20 +35,20 @@ const _: () = {
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
         pub(crate) fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_unchecked_mut();
-                __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjection(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         pub(crate) fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_ref();
-                __TupleStructProjectionRef(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjectionRef(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
     }
@@ -56,31 +59,31 @@ const _: () = {
     }
     #[allow(missing_debug_implementations)]
     pub struct __TupleStruct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
             'pin,
             (
-                ::pin_project::__private::PhantomData<T>,
-                ::pin_project::__private::PhantomData<U>,
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
             ),
         >,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for TupleStruct<T, U> where
-        __TupleStruct<'pin, T, U>: ::pin_project::__private::Unpin
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U> where
+        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin
     {
     }
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
     impl<T, U> TupleStructMustNotImplDrop for TupleStruct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for TupleStruct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 fn main() {}

--- a/tests/expand/unsafe_unpin/enum.expanded.rs
+++ b/tests/expand/unsafe_unpin/enum.expanded.rs
@@ -62,22 +62,25 @@ where
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
             unsafe {
                 match self.get_unchecked_mut() {
                     Self::Struct { pinned, unpinned } => EnumProj::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                        pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
                     Self::Tuple(_0, _1) => {
-                        EnumProj::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                        EnumProj::Tuple(_pin_project::__private::Pin::new_unchecked(_0), _1)
                     }
                     Self::Unit => EnumProj::Unit,
                 }
@@ -85,33 +88,33 @@ const _: () = {
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {
             unsafe {
                 match self.get_ref() {
                     Self::Struct { pinned, unpinned } => EnumProjRef::Struct {
-                        pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                        pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                         unpinned,
                     },
                     Self::Tuple(_0, _1) => {
-                        EnumProjRef::Tuple(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                        EnumProjRef::Tuple(_pin_project::__private::Pin::new_unchecked(_0), _1)
                     }
                     Self::Unit => EnumProjRef::Unit,
                 }
             }
         }
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Enum<T, U> where
-        ::pin_project::__private::Wrapper<'pin, Self>: ::pin_project::UnsafeUnpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U> where
+        _pin_project::__private::Wrapper<'pin, Self>: _pin_project::UnsafeUnpin
     {
     }
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> EnumMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> EnumMustNotImplDrop for T {}
     impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Enum<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Enum<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 unsafe impl<T: Unpin, U> UnsafeUnpin for Enum<T, U> {}

--- a/tests/expand/unsafe_unpin/struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/struct.expanded.rs
@@ -14,10 +14,13 @@ struct Struct<T, U> {
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __StructProjection<'pin, T, U>
@@ -38,24 +41,24 @@ const _: () = {
     }
     impl<T, U> Struct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_unchecked_mut();
                 __StructProjection {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self { pinned, unpinned } = self.get_ref();
                 __StructProjectionRef {
-                    pinned: ::pin_project::__private::Pin::new_unchecked(pinned),
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
                     unpinned,
                 }
             }
@@ -66,17 +69,17 @@ const _: () = {
         let _ = &this.pinned;
         let _ = &this.unpinned;
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        ::pin_project::__private::Wrapper<'pin, Self>: ::pin_project::UnsafeUnpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U> where
+        _pin_project::__private::Wrapper<'pin, Self>: _pin_project::UnsafeUnpin
     {
     }
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> StructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> StructMustNotImplDrop for T {}
     impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for Struct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 unsafe impl<T: Unpin, U> UnsafeUnpin for Struct<T, U> {}

--- a/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
@@ -10,10 +10,13 @@ struct TupleStruct<T, U>(#[pin] T, U);
 #[allow(clippy::pattern_type_mismatch)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
+#[allow(unused_qualifications)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::use_self)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
     #[allow(dead_code)]
     #[allow(clippy::mut_mut)]
     struct __TupleStructProjection<'pin, T, U>(
@@ -32,20 +35,20 @@ const _: () = {
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
         fn project<'pin>(
-            self: ::pin_project::__private::Pin<&'pin mut Self>,
+            self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_unchecked_mut();
-                __TupleStructProjection(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjection(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
-            self: ::pin_project::__private::Pin<&'pin Self>,
+            self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
             unsafe {
                 let Self(_0, _1) = self.get_ref();
-                __TupleStructProjectionRef(::pin_project::__private::Pin::new_unchecked(_0), _1)
+                __TupleStructProjectionRef(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
     }
@@ -54,17 +57,17 @@ const _: () = {
         let _ = &this.0;
         let _ = &this.1;
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for TupleStruct<T, U> where
-        ::pin_project::__private::Wrapper<'pin, Self>: ::pin_project::UnsafeUnpin
+    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U> where
+        _pin_project::__private::Wrapper<'pin, Self>: _pin_project::UnsafeUnpin
     {
     }
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]
-    impl<T: ::pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
+    impl<T: _pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
     impl<T, U> TupleStructMustNotImplDrop for TupleStruct<T, U> {}
     #[doc(hidden)]
-    impl<T, U> ::pin_project::__private::PinnedDrop for TupleStruct<T, U> {
-        unsafe fn drop(self: ::pin_project::__private::Pin<&mut Self>) {}
+    impl<T, U> _pin_project::__private::PinnedDrop for TupleStruct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
     }
 };
 unsafe impl<T: Unpin, U> UnsafeUnpin for Struct<T, U> {}

--- a/tests/ui/not_unpin/impl-unsafe-unpin.stderr
+++ b/tests/ui/not_unpin/impl-unsafe-unpin.stderr
@@ -1,4 +1,4 @@
-error[E0119]: conflicting implementations of trait `pin_project::UnsafeUnpin` for type `Foo<_, _>`
+error[E0119]: conflicting implementations of trait `_::_pin_project::UnsafeUnpin` for type `Foo<_, _>`
   --> tests/ui/not_unpin/impl-unsafe-unpin.rs:3:1
    |
 3  | #[pin_project(!Unpin)] //~ ERROR E0119
@@ -9,7 +9,7 @@ error[E0119]: conflicting implementations of trait `pin_project::UnsafeUnpin` fo
    |
    = note: this error originates in the derive macro `::pin_project::__private::__PinProjectInternalDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0119]: conflicting implementations of trait `pin_project::UnsafeUnpin` for type `Bar<_, _>`
+error[E0119]: conflicting implementations of trait `_::_pin_project::UnsafeUnpin` for type `Bar<_, _>`
   --> tests/ui/not_unpin/impl-unsafe-unpin.rs:12:1
    |
 12 | #[pin_project(!Unpin)] //~ ERROR E0119
@@ -20,7 +20,7 @@ error[E0119]: conflicting implementations of trait `pin_project::UnsafeUnpin` fo
    |
    = note: this error originates in the derive macro `::pin_project::__private::__PinProjectInternalDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0119]: conflicting implementations of trait `pin_project::UnsafeUnpin` for type `Baz<_, _>`
+error[E0119]: conflicting implementations of trait `_::_pin_project::UnsafeUnpin` for type `Baz<_, _>`
   --> tests/ui/not_unpin/impl-unsafe-unpin.rs:21:1
    |
 21 | #[pin_project(!Unpin)] //~ ERROR E0119

--- a/tests/ui/pin_project/impl-unsafe-unpin.stderr
+++ b/tests/ui/pin_project/impl-unsafe-unpin.stderr
@@ -1,4 +1,4 @@
-error[E0119]: conflicting implementations of trait `pin_project::UnsafeUnpin` for type `Foo<_, _>`
+error[E0119]: conflicting implementations of trait `_::_pin_project::UnsafeUnpin` for type `Foo<_, _>`
   --> tests/ui/pin_project/impl-unsafe-unpin.rs:3:1
    |
 3  | #[pin_project] //~ ERROR E0119
@@ -9,7 +9,7 @@ error[E0119]: conflicting implementations of trait `pin_project::UnsafeUnpin` fo
    |
    = note: this error originates in the derive macro `::pin_project::__private::__PinProjectInternalDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0119]: conflicting implementations of trait `pin_project::UnsafeUnpin` for type `Bar<_, _>`
+error[E0119]: conflicting implementations of trait `_::_pin_project::UnsafeUnpin` for type `Bar<_, _>`
   --> tests/ui/pin_project/impl-unsafe-unpin.rs:12:1
    |
 12 | #[pin_project] //~ ERROR E0119
@@ -20,7 +20,7 @@ error[E0119]: conflicting implementations of trait `pin_project::UnsafeUnpin` fo
    |
    = note: this error originates in the derive macro `::pin_project::__private::__PinProjectInternalDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0119]: conflicting implementations of trait `pin_project::UnsafeUnpin` for type `Baz<_, _>`
+error[E0119]: conflicting implementations of trait `_::_pin_project::UnsafeUnpin` for type `Baz<_, _>`
   --> tests/ui/pin_project/impl-unsafe-unpin.rs:21:1
    |
 21 | #[pin_project] //~ ERROR E0119

--- a/tests/ui/pin_project/override-priv-mod.rs
+++ b/tests/ui/pin_project/override-priv-mod.rs
@@ -1,0 +1,32 @@
+// https://discord.com/channels/273534239310479360/512792629516173323/870075511009857617
+
+extern crate pin_project as pin_project_orig;
+extern crate self as pin_project;
+
+pub use ::pin_project_orig::*;
+mod __private {
+    pub use ::pin_project_orig::__private::*;
+    pub trait Drop {}
+}
+
+use std::{marker::PhantomPinned, mem};
+
+#[pin_project] //~ ERROR conflicting implementations of trait `_::FooMustNotImplDrop`
+struct S {
+    #[pin]
+    f: (u8, PhantomPinned),
+}
+
+impl Drop for S {
+    fn drop(&mut self) {
+        let prev = &self.f.0 as *const _ as usize;
+        let moved = mem::take(&mut self.f); // move pinned field
+        let moved = &moved.0 as *const _ as usize;
+        assert_eq!(prev, moved); // panic
+    }
+}
+
+fn main() {
+    let mut x = Box::pin(S { f: (1, PhantomPinned) });
+    let _f = x.as_mut().project().f; // first mutable access
+}

--- a/tests/ui/pin_project/override-priv-mod.stderr
+++ b/tests/ui/pin_project/override-priv-mod.stderr
@@ -1,0 +1,10 @@
+error[E0119]: conflicting implementations of trait `_::SMustNotImplDrop` for type `S`
+  --> tests/ui/pin_project/override-priv-mod.rs:14:1
+   |
+14 | #[pin_project] //~ ERROR conflicting implementations of trait `_::FooMustNotImplDrop`
+   | ^^^^^^^^^^^^^^
+   | |
+   | first implementation here
+   | conflicting implementation for `S`
+   |
+   = note: this error originates in the derive macro `::pin_project::__private::__PinProjectInternalDerive` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/pinned_drop/pinned-drop-no-attr-arg.stderr
+++ b/tests/ui/pinned_drop/pinned-drop-no-attr-arg.stderr
@@ -1,4 +1,4 @@
-error[E0119]: conflicting implementations of trait `pin_project::__private::PinnedDrop` for type `S`
+error[E0119]: conflicting implementations of trait `_::_pin_project::__private::PinnedDrop` for type `S`
   --> tests/ui/pinned_drop/pinned-drop-no-attr-arg.rs:12:1
    |
 5  | #[pin_project]

--- a/tests/ui/unsafe_unpin/conflict-unpin.stderr
+++ b/tests/ui/unsafe_unpin/conflict-unpin.stderr
@@ -7,7 +7,7 @@ error[E0119]: conflicting implementations of trait `std::marker::Unpin` for type
 10 | impl<T, U> Unpin for Foo<T, U> where T: Unpin {}
    | --------------------------------------------- first implementation here
    |
-   = note: upstream crates may add a new impl of trait `pin_project::UnsafeUnpin` for type `pin_project::__private::Wrapper<'_, Foo<_, _>>` in future versions
+   = note: upstream crates may add a new impl of trait `_::_pin_project::UnsafeUnpin` for type `_::_pin_project::__private::Wrapper<'_, Foo<_, _>>` in future versions
 
 error[E0119]: conflicting implementations of trait `std::marker::Unpin` for type `Bar<_, _>`
   --> tests/ui/unsafe_unpin/conflict-unpin.rs:12:15
@@ -18,7 +18,7 @@ error[E0119]: conflicting implementations of trait `std::marker::Unpin` for type
 19 | impl<T, U> Unpin for Bar<T, U> {}
    | ------------------------------ first implementation here
    |
-   = note: upstream crates may add a new impl of trait `pin_project::UnsafeUnpin` for type `pin_project::__private::Wrapper<'_, Bar<_, _>>` in future versions
+   = note: upstream crates may add a new impl of trait `_::_pin_project::UnsafeUnpin` for type `_::_pin_project::__private::Wrapper<'_, Bar<_, _>>` in future versions
 
 error[E0119]: conflicting implementations of trait `std::marker::Unpin` for type `Baz<_, _>`
   --> tests/ui/unsafe_unpin/conflict-unpin.rs:21:15
@@ -29,4 +29,4 @@ error[E0119]: conflicting implementations of trait `std::marker::Unpin` for type
 28 | impl<T: Unpin, U: Unpin> Unpin for Baz<T, U> {}
    | -------------------------------------------- first implementation here
    |
-   = note: upstream crates may add a new impl of trait `pin_project::UnsafeUnpin` for type `pin_project::__private::Wrapper<'_, Baz<_, _>>` in future versions
+   = note: upstream crates may add a new impl of trait `_::_pin_project::UnsafeUnpin` for type `_::_pin_project::__private::Wrapper<'_, Baz<_, _>>` in future versions


### PR DESCRIPTION
*This was originally reported by @danielhenrymantilla in https://discord.com/channels/273534239310479360/512792629516173323/870075511009857617*.

Currently, you can break the soundness of the pin-project by overriding the private module as follows.
Considering that it uses a hidden private API that is not guaranteed to be stable, I don't think this will actually happen except in cases where users intentionally abuse it or use a malicious crate. Also, in such a case, fixing this would not help much because the attacker can do anything.
That said, it seems relatively easy to fix this, so I'm going to fix this.

```rust
extern crate pin_project as pin_project_orig;
extern crate self as pin_project;

pub use ::pin_project_orig::*;
mod __private {
    pub use ::pin_project_orig::__private::*;
    pub trait Drop {}
}

use std::{marker::PhantomPinned, mem};

#[pin_project]
struct S {
    #[pin]
    f: (u8, PhantomPinned),
}

impl Drop for S {
    fn drop(&mut self) {
        let prev = &self.f.0 as *const _ as usize;
        let moved = mem::take(&mut self.f); // move pinned field
        let moved = &moved.0 as *const _ as usize;
        assert_eq!(prev, moved); // panic
    }
}

fn main() {
    let mut x = Box::pin(S { f: (1, PhantomPinned) });
    let _f = x.as_mut().project().f; // first mutable access
}
```

[playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=faf882d7f20845d992817a21ce444463)

---

This patch forces the macro to refer to the `pin-project` crate by referring to the `_pin_project` imported into the `const _` scope instead of `::pin_project`.

https://github.com/taiki-e/pin-project/blob/74444360566ccef04da2bde8f0273469df6ad67b/tests/expand/pub/struct.expanded.rs#L21-L23

https://github.com/taiki-e/pin-project/blob/74444360566ccef04da2bde8f0273469df6ad67b/tests/expand/pub/struct.expanded.rs#L49

In the above example, a user-implemented Drop is detected, resulting in an error.

https://github.com/taiki-e/pin-project/blob/74444360566ccef04da2bde8f0273469df6ad67b/tests/ui/pin_project/override-priv-mod.stderr#L1-L10

If other items (e.g., `PinnedDrop`) are replaced in the same way, either nothing happens (nothing is affected), or `#[pin_project]` and `#[pinned_drop]` refer to different items, resulting in an error.