### PR TITLE
Suppress dead_code lint in generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- [Suppress `dead_code` lint in generated code.](https://github.com/taiki-e/pin-project/pull/346)
+
 ## [1.0.10] - 2021-12-31
 
 - Revert the increase of the minimal version of `syn` that was done in 1.0.9.

--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -933,8 +933,14 @@ fn make_proj_impl(
     let orig_ty_generics = cx.orig.generics.split_for_impl().1;
     let proj_ty_generics = cx.proj.generics.split_for_impl().1;
     let (impl_generics, ty_generics, where_clause) = cx.orig.generics.split_for_impl();
+    // TODO: For enums and project_replace, dead_code warnings should not be
+    // allowed because methods are not generated unless explicitly specified.
+    // However, there is currently no good way to allow warnings for generated
+    // code, so we allow warnings for all methods for now.
+    let allow_dead_code = quote! { #[allow(dead_code)] };
 
     let mut project = Some(quote! {
+        #allow_dead_code
         #vis fn project<#lifetime>(
             self: _pin_project::__private::Pin<&#lifetime mut Self>,
         ) -> #proj_ident #proj_ty_generics {
@@ -944,6 +950,7 @@ fn make_proj_impl(
         }
     });
     let mut project_ref = Some(quote! {
+        #allow_dead_code
         #[allow(clippy::missing_const_for_fn)]
         #vis fn project_ref<#lifetime>(
             self: _pin_project::__private::Pin<&#lifetime Self>,
@@ -956,6 +963,7 @@ fn make_proj_impl(
     let mut project_replace = cx.project_replace.span().map(|span| {
         // It is enough to only set the span of the signature.
         let sig = quote_spanned! { span =>
+            #allow_dead_code
             #vis fn project_replace(
                 self: _pin_project::__private::Pin<&mut Self>,
                 __replacement: Self,

--- a/tests/expand/default/enum.expanded.rs
+++ b/tests/expand/default/enum.expanded.rs
@@ -63,6 +63,7 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
@@ -84,6 +85,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/default/struct.expanded.rs
+++ b/tests/expand/default/struct.expanded.rs
@@ -40,6 +40,7 @@ const _: () = {
         unpinned: &'pin (U),
     }
     impl<T, U> Struct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -51,6 +52,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/default/tuple_struct.expanded.rs
+++ b/tests/expand/default/tuple_struct.expanded.rs
@@ -34,6 +34,7 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -45,6 +46,7 @@ const _: () = {
                 )
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/multifields/enum.expanded.rs
+++ b/tests/expand/multifields/enum.expanded.rs
@@ -113,6 +113,7 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
@@ -142,6 +143,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
@@ -172,6 +174,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/multifields/struct.expanded.rs
+++ b/tests/expand/multifields/struct.expanded.rs
@@ -54,6 +54,7 @@ const _: () = {
         unpinned2: U,
     }
     impl<T, U> Struct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -68,6 +69,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
@@ -82,6 +84,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/multifields/tuple_struct.expanded.rs
+++ b/tests/expand/multifields/tuple_struct.expanded.rs
@@ -45,6 +45,7 @@ const _: () = {
         U,
     );
     impl<T, U> TupleStruct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -58,6 +59,7 @@ const _: () = {
                 )
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
@@ -72,6 +74,7 @@ const _: () = {
                 )
             }
         }
+        #[allow(dead_code)]
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/naming/enum-all.expanded.rs
+++ b/tests/expand/naming/enum-all.expanded.rs
@@ -80,6 +80,7 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {
@@ -98,6 +99,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
@@ -120,6 +122,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/naming/enum-mut.expanded.rs
+++ b/tests/expand/naming/enum-mut.expanded.rs
@@ -44,6 +44,7 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {

--- a/tests/expand/naming/enum-own.expanded.rs
+++ b/tests/expand/naming/enum-own.expanded.rs
@@ -39,6 +39,7 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
+        #[allow(dead_code)]
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/naming/enum-ref.expanded.rs
+++ b/tests/expand/naming/enum-ref.expanded.rs
@@ -41,6 +41,7 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/naming/struct-all.expanded.rs
+++ b/tests/expand/naming/struct-all.expanded.rs
@@ -72,6 +72,7 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     impl<T, U> Struct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {
@@ -83,6 +84,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
@@ -95,6 +97,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/naming/struct-mut.expanded.rs
+++ b/tests/expand/naming/struct-mut.expanded.rs
@@ -49,6 +49,7 @@ const _: () = {
         unpinned: &'pin (U),
     }
     impl<T, U> Struct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {
@@ -60,6 +61,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/naming/struct-none.expanded.rs
+++ b/tests/expand/naming/struct-none.expanded.rs
@@ -40,6 +40,7 @@ const _: () = {
         unpinned: &'pin (U),
     }
     impl<T, U> Struct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -51,6 +52,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/naming/struct-own.expanded.rs
+++ b/tests/expand/naming/struct-own.expanded.rs
@@ -54,6 +54,7 @@ const _: () = {
         unpinned: &'pin (U),
     }
     impl<T, U> Struct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -65,6 +66,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
@@ -77,6 +79,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/naming/struct-ref.expanded.rs
+++ b/tests/expand/naming/struct-ref.expanded.rs
@@ -49,6 +49,7 @@ const _: () = {
         unpinned: &'pin mut (U),
     }
     impl<T, U> Struct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -60,6 +61,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/naming/tuple_struct-all.expanded.rs
+++ b/tests/expand/naming/tuple_struct-all.expanded.rs
@@ -63,6 +63,7 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     impl<T, U> TupleStruct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {
@@ -71,6 +72,7 @@ const _: () = {
                 Proj(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
@@ -80,6 +82,7 @@ const _: () = {
                 ProjRef(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
+        #[allow(dead_code)]
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/naming/tuple_struct-mut.expanded.rs
+++ b/tests/expand/naming/tuple_struct-mut.expanded.rs
@@ -43,6 +43,7 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {
@@ -51,6 +52,7 @@ const _: () = {
                 Proj(_pin_project::__private::Pin::new_unchecked(_0), _1)
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/naming/tuple_struct-none.expanded.rs
+++ b/tests/expand/naming/tuple_struct-none.expanded.rs
@@ -34,6 +34,7 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -45,6 +46,7 @@ const _: () = {
                 )
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/naming/tuple_struct-own.expanded.rs
+++ b/tests/expand/naming/tuple_struct-own.expanded.rs
@@ -45,6 +45,7 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -56,6 +57,7 @@ const _: () = {
                 )
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
@@ -68,6 +70,7 @@ const _: () = {
                 )
             }
         }
+        #[allow(dead_code)]
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/naming/tuple_struct-ref.expanded.rs
+++ b/tests/expand/naming/tuple_struct-ref.expanded.rs
@@ -43,6 +43,7 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -54,6 +55,7 @@ const _: () = {
                 )
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/not_unpin/enum.expanded.rs
+++ b/tests/expand/not_unpin/enum.expanded.rs
@@ -63,6 +63,7 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
@@ -84,6 +85,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/not_unpin/struct.expanded.rs
+++ b/tests/expand/not_unpin/struct.expanded.rs
@@ -40,6 +40,7 @@ const _: () = {
         unpinned: &'pin (U),
     }
     impl<T, U> Struct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -51,6 +52,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/not_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/not_unpin/tuple_struct.expanded.rs
@@ -34,6 +34,7 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -45,6 +46,7 @@ const _: () = {
                 )
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/pinned_drop/enum.expanded.rs
+++ b/tests/expand/pinned_drop/enum.expanded.rs
@@ -64,6 +64,7 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
@@ -85,6 +86,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/pinned_drop/struct.expanded.rs
+++ b/tests/expand/pinned_drop/struct.expanded.rs
@@ -41,6 +41,7 @@ const _: () = {
         unpinned: &'pin (U),
     }
     impl<T, U> Struct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -52,6 +53,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/pinned_drop/tuple_struct.expanded.rs
+++ b/tests/expand/pinned_drop/tuple_struct.expanded.rs
@@ -35,6 +35,7 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -46,6 +47,7 @@ const _: () = {
                 )
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/project_replace/enum.expanded.rs
+++ b/tests/expand/project_replace/enum.expanded.rs
@@ -39,6 +39,7 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
+        #[allow(dead_code)]
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/project_replace/struct.expanded.rs
+++ b/tests/expand/project_replace/struct.expanded.rs
@@ -45,6 +45,7 @@ const _: () = {
         unpinned: U,
     }
     impl<T, U> Struct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -56,6 +57,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
@@ -68,6 +70,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/project_replace/tuple_struct.expanded.rs
+++ b/tests/expand/project_replace/tuple_struct.expanded.rs
@@ -39,6 +39,7 @@ const _: () = {
         U,
     );
     impl<T, U> TupleStruct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -50,6 +51,7 @@ const _: () = {
                 )
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
@@ -62,6 +64,7 @@ const _: () = {
                 )
             }
         }
+        #[allow(dead_code)]
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/pub/enum.expanded.rs
+++ b/tests/expand/pub/enum.expanded.rs
@@ -63,6 +63,7 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
+        #[allow(dead_code)]
         pub(crate) fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
@@ -84,6 +85,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         pub(crate) fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/pub/struct.expanded.rs
+++ b/tests/expand/pub/struct.expanded.rs
@@ -40,6 +40,7 @@ const _: () = {
         pub unpinned: &'pin (U),
     }
     impl<T, U> Struct<T, U> {
+        #[allow(dead_code)]
         pub(crate) fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -51,6 +52,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         pub(crate) fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/pub/tuple_struct.expanded.rs
+++ b/tests/expand/pub/tuple_struct.expanded.rs
@@ -34,6 +34,7 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
+        #[allow(dead_code)]
         pub(crate) fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -45,6 +46,7 @@ const _: () = {
                 )
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         pub(crate) fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/unsafe_unpin/enum.expanded.rs
+++ b/tests/expand/unsafe_unpin/enum.expanded.rs
@@ -63,6 +63,7 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
@@ -84,6 +85,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/unsafe_unpin/struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/struct.expanded.rs
@@ -40,6 +40,7 @@ const _: () = {
         unpinned: &'pin (U),
     }
     impl<T, U> Struct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -51,6 +52,7 @@ const _: () = {
                 }
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
@@ -34,6 +34,7 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     impl<T, U> TupleStruct<T, U> {
+        #[allow(dead_code)]
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -45,6 +46,7 @@ const _: () = {
                 )
             }
         }
+        #[allow(dead_code)]
         #[allow(clippy::missing_const_for_fn)]
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,

--- a/tests/ui/not_unpin/conflict-unpin.stderr
+++ b/tests/ui/not_unpin/conflict-unpin.stderr
@@ -5,7 +5,7 @@ error[E0119]: conflicting implementations of trait `std::marker::Unpin` for type
    |               ^^^^^^ conflicting implementation for `Foo<_, _>`
 ...
 10 | impl<T, U> Unpin for Foo<T, U> where T: Unpin {}
-   | --------------------------------------------- first implementation here
+   | ------------------------------ first implementation here
 
 error[E0119]: conflicting implementations of trait `std::marker::Unpin` for type `Bar<_, _>`
   --> tests/ui/not_unpin/conflict-unpin.rs:12:15

--- a/tests/ui/not_unpin/impl-unsafe-unpin.stderr
+++ b/tests/ui/not_unpin/impl-unsafe-unpin.stderr
@@ -5,7 +5,7 @@ error[E0119]: conflicting implementations of trait `_::_pin_project::UnsafeUnpin
    | ^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Foo<_, _>`
 ...
 10 | unsafe impl<T, U> UnsafeUnpin for Foo<T, U> where T: Unpin {}
-   | ---------------------------------------------------------- first implementation here
+   | ------------------------------------------- first implementation here
    |
    = note: this error originates in the derive macro `::pin_project::__private::__PinProjectInternalDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/pin_project/conflict-unpin.stderr
+++ b/tests/ui/pin_project/conflict-unpin.stderr
@@ -5,7 +5,7 @@ error[E0119]: conflicting implementations of trait `std::marker::Unpin` for type
    | ^^^^^^^^^^^^^^ conflicting implementation for `Foo<_, _>`
 ...
 13 | impl<T, U> Unpin for Foo<T, U> where T: Unpin {} // Conditional Unpin impl
-   | --------------------------------------------- first implementation here
+   | ------------------------------ first implementation here
    |
    = note: this error originates in the derive macro `::pin_project::__private::__PinProjectInternalDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/pin_project/impl-unsafe-unpin.stderr
+++ b/tests/ui/pin_project/impl-unsafe-unpin.stderr
@@ -5,7 +5,7 @@ error[E0119]: conflicting implementations of trait `_::_pin_project::UnsafeUnpin
    | ^^^^^^^^^^^^^^ conflicting implementation for `Foo<_, _>`
 ...
 10 | unsafe impl<T, U> UnsafeUnpin for Foo<T, U> where T: Unpin {}
-   | ---------------------------------------------------------- first implementation here
+   | ------------------------------------------- first implementation here
    |
    = note: this error originates in the derive macro `::pin_project::__private::__PinProjectInternalDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/pinned_drop/conditional-drop-impl.stderr
+++ b/tests/ui/pinned_drop/conditional-drop-impl.stderr
@@ -7,10 +7,8 @@ error[E0367]: `Drop` impl requires `T: Unpin` but the struct it is implemented f
 note: the implementor must specify the same requirement
   --> tests/ui/pinned_drop/conditional-drop-impl.rs:7:1
    |
-7  | / struct DropImpl<T> {
-8  | |     f: T,
-9  | | }
-   | |_^
+7  | struct DropImpl<T> {
+   | ^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `T` cannot be unpinned
   --> tests/ui/pinned_drop/conditional-drop-impl.rs:16:15

--- a/tests/ui/unsafe_unpin/conflict-unpin.stderr
+++ b/tests/ui/unsafe_unpin/conflict-unpin.stderr
@@ -5,7 +5,7 @@ error[E0119]: conflicting implementations of trait `std::marker::Unpin` for type
    |               ^^^^^^^^^^^ conflicting implementation for `Foo<_, _>`
 ...
 10 | impl<T, U> Unpin for Foo<T, U> where T: Unpin {}
-   | --------------------------------------------- first implementation here
+   | ------------------------------ first implementation here
    |
    = note: upstream crates may add a new impl of trait `_::_pin_project::UnsafeUnpin` for type `_::_pin_project::__private::Wrapper<'_, Foo<_, _>>` in future versions
 

--- a/tests/ui/unstable-features/negative_impls.stderr
+++ b/tests/ui/unstable-features/negative_impls.stderr
@@ -2,7 +2,7 @@ error: cross-crate traits with a default impl, like `Unpin`, should not be speci
   --> tests/ui/unstable-features/negative_impls.rs:17:1
    |
 17 | impl Unpin for Foo<MyPhantomPinned, ()> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> tests/ui/unstable-features/negative_impls.rs:2:9
@@ -15,10 +15,5 @@ note: the lint level is defined here
 note: try using the same sequence of generic parameters as the struct definition
   --> tests/ui/unstable-features/negative_impls.rs:8:1
    |
-8  | / struct Foo<Pinned, Unpinned> {
-9  | |     #[pin]
-10 | |     pinned: Pinned,
-11 | |
-12 | |     unpinned: Unpinned,
-13 | | }
-   | |_^
+8  | struct Foo<Pinned, Unpinned> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
```
error: associated function `project` is never used
--> tests/no-core/../include/basic-safe-part.rs:3:1
|
3|#[::pin_project::pin_project]
| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
|
= note: `-D dead-code` implied by `-D warnings`
```
