### PR TITLE
Hide documentation of the `Unpin` implementation for `!Unpin`

### DIFF
--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -718,6 +718,7 @@ fn make_unpin_impl(cx: &Context<'_>) -> TokenStream {
             // call-site span.
             let unsafety = <Token![unsafe]>::default();
             quote_spanned! { span =>
+                #[doc(hidden)]
                 impl #proj_impl_generics _pin_project::__private::Unpin
                     for #orig_ident #ty_generics
                 #proj_where_clause

--- a/tests/expand/not_unpin/enum.expanded.rs
+++ b/tests/expand/not_unpin/enum.expanded.rs
@@ -114,6 +114,7 @@ const _: () = {
             }
         }
     }
+    #[doc(hidden)]
     impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
         _pin_project::__private::Wrapper<

--- a/tests/expand/not_unpin/struct.expanded.rs
+++ b/tests/expand/not_unpin/struct.expanded.rs
@@ -74,6 +74,7 @@ const _: () = {
         let _ = &this.pinned;
         let _ = &this.unpinned;
     }
+    #[doc(hidden)]
     impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
         _pin_project::__private::Wrapper<

--- a/tests/expand/not_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/not_unpin/tuple_struct.expanded.rs
@@ -68,6 +68,7 @@ const _: () = {
         let _ = &this.0;
         let _ = &this.1;
     }
+    #[doc(hidden)]
     impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
         _pin_project::__private::Wrapper<


### PR DESCRIPTION
Hide the documentation of the `Unpin` implementation that guarantees `!Unpin` to avoid confusion.

Before:
![image](https://github.com/taiki-e/pin-project/assets/27595790/90bea257-a852-4d48-b625-87aad882a745)

After:
![image](https://github.com/taiki-e/pin-project/assets/27595790/0a527320-480e-47aa-8333-5d1f13b49f47)
