### PR TITLE
Work around negative_impls that allows unsound overlapping Unpin impls

### DIFF
--- a/examples/enum-default-expanded.rs
+++ b/examples/enum-default-expanded.rs
@@ -77,13 +77,15 @@ const _: () = {
         __field0: T,
     }
     impl<'pin, T, U> ::pin_project::__private::Unpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+        ::pin_project::__private::PinnedFieldsOf<__Enum<'pin, T, U>>:
+            ::pin_project::__private::Unpin
     {
     }
     // A dummy impl of `UnsafeUnpin`, to ensure that the user cannot implement it.
     #[doc(hidden)]
     unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Enum<T, U> where
-        __Enum<'pin, T, U>: ::pin_project::__private::Unpin
+        ::pin_project::__private::PinnedFieldsOf<__Enum<'pin, T, U>>:
+            ::pin_project::__private::Unpin
     {
     }
 

--- a/examples/not_unpin-expanded.rs
+++ b/examples/not_unpin-expanded.rs
@@ -95,9 +95,11 @@ const _: () = {
     //
     // See https://github.com/taiki-e/pin-project/issues/102#issuecomment-540472282
     // for details.
+    #[doc(hidden)]
     impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        ::pin_project::__private::Wrapper<'pin, ::pin_project::__private::PhantomPinned>:
-            ::pin_project::__private::Unpin
+        ::pin_project::__private::PinnedFieldsOf<
+            ::pin_project::__private::Wrapper<'pin, ::pin_project::__private::PhantomPinned>,
+        >: ::pin_project::__private::Unpin
     {
     }
     // A dummy impl of `UnsafeUnpin`, to ensure that the user cannot implement it.
@@ -108,8 +110,9 @@ const _: () = {
     // coherence checks are run.
     #[doc(hidden)]
     unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        ::pin_project::__private::Wrapper<'pin, ::pin_project::__private::PhantomPinned>:
-            ::pin_project::__private::Unpin
+        ::pin_project::__private::PinnedFieldsOf<
+            ::pin_project::__private::Wrapper<'pin, ::pin_project::__private::PhantomPinned>,
+        >: ::pin_project::__private::Unpin
     {
     }
 

--- a/examples/pinned_drop-expanded.rs
+++ b/examples/pinned_drop-expanded.rs
@@ -123,13 +123,15 @@ const _: () = {
         __lifetime0: &'a (),
     }
     impl<'pin, 'a, T> ::pin_project::__private::Unpin for Struct<'a, T> where
-        __Struct<'pin, 'a, T>: ::pin_project::__private::Unpin
+        ::pin_project::__private::PinnedFieldsOf<__Struct<'pin, 'a, T>>:
+            ::pin_project::__private::Unpin
     {
     }
     // A dummy impl of `UnsafeUnpin`, to ensure that the user cannot implement it.
     #[doc(hidden)]
     unsafe impl<'pin, 'a, T> ::pin_project::UnsafeUnpin for Struct<'a, T> where
-        __Struct<'pin, 'a, T>: ::pin_project::__private::Unpin
+        ::pin_project::__private::PinnedFieldsOf<__Struct<'pin, 'a, T>>:
+            ::pin_project::__private::Unpin
     {
     }
 };

--- a/examples/project_replace-expanded.rs
+++ b/examples/project_replace-expanded.rs
@@ -137,13 +137,15 @@ const _: () = {
         __field0: T,
     }
     impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+        ::pin_project::__private::PinnedFieldsOf<__Struct<'pin, T, U>>:
+            ::pin_project::__private::Unpin
     {
     }
     // A dummy impl of `UnsafeUnpin`, to ensure that the user cannot implement it.
     #[doc(hidden)]
     unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+        ::pin_project::__private::PinnedFieldsOf<__Struct<'pin, T, U>>:
+            ::pin_project::__private::Unpin
     {
     }
 

--- a/examples/struct-default-expanded.rs
+++ b/examples/struct-default-expanded.rs
@@ -129,7 +129,8 @@ const _: () = {
         __field0: T,
     }
     impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+        ::pin_project::__private::PinnedFieldsOf<__Struct<'pin, T, U>>:
+            ::pin_project::__private::Unpin
     {
     }
     // A dummy impl of `UnsafeUnpin`, to ensure that the user cannot implement it.
@@ -140,7 +141,8 @@ const _: () = {
     // coherence checks are run.
     #[doc(hidden)]
     unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        __Struct<'pin, T, U>: ::pin_project::__private::Unpin
+        ::pin_project::__private::PinnedFieldsOf<__Struct<'pin, T, U>>:
+            ::pin_project::__private::Unpin
     {
     }
 

--- a/examples/unsafe_unpin-expanded.rs
+++ b/examples/unsafe_unpin-expanded.rs
@@ -92,7 +92,8 @@ const _: () = {
 
     // Implement `Unpin` via `UnsafeUnpin`.
     impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        ::pin_project::__private::Wrapper<'pin, Self>: ::pin_project::UnsafeUnpin
+        ::pin_project::__private::PinnedFieldsOf<::pin_project::__private::Wrapper<'pin, Self>>:
+            ::pin_project::UnsafeUnpin
     {
     }
 

--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -693,7 +693,9 @@ fn make_unpin_impl(cx: &Context<'_>) -> TokenStream {
 
             // Make the error message highlight `UnsafeUnpin` argument.
             proj_generics.make_where_clause().predicates.push(parse_quote_spanned! { span =>
-                _pin_project::__private::Wrapper<#lifetime, Self>: _pin_project::UnsafeUnpin
+                ::pin_project::__private::PinnedFieldsOf<
+                    _pin_project::__private::Wrapper<#lifetime, Self>
+                >: _pin_project::UnsafeUnpin
             });
 
             let (impl_generics, _, where_clause) = proj_generics.split_for_impl();
@@ -712,9 +714,9 @@ fn make_unpin_impl(cx: &Context<'_>) -> TokenStream {
             let lifetime = &cx.proj.lifetime;
 
             proj_generics.make_where_clause().predicates.push(parse_quote! {
-                _pin_project::__private::Wrapper<
+                ::pin_project::__private::PinnedFieldsOf<_pin_project::__private::Wrapper<
                     #lifetime, _pin_project::__private::PhantomPinned
-                >: _pin_project::__private::Unpin
+                >>: _pin_project::__private::Unpin
             });
 
             let (proj_impl_generics, _, proj_where_clause) = proj_generics.split_for_impl();
@@ -793,7 +795,8 @@ fn make_unpin_impl(cx: &Context<'_>) -> TokenStream {
             let (_, ty_generics, where_clause) = cx.orig.generics.split_for_impl();
 
             full_where_clause.predicates.push(parse_quote! {
-                #struct_ident #proj_ty_generics: _pin_project::__private::Unpin
+                ::pin_project::__private::PinnedFieldsOf<#struct_ident #proj_ty_generics>:
+                    _pin_project::__private::Unpin
             });
 
             quote! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,29 +276,42 @@ pub mod __private {
     #[doc(hidden)]
     #[allow(dead_code)]
     pub struct Wrapper<'a, T: ?Sized>(PhantomData<&'a ()>, T);
-
     // SAFETY: `T` implements UnsafeUnpin.
     unsafe impl<T: ?Sized + UnsafeUnpin> UnsafeUnpin for Wrapper<'_, T> {}
+
+    // Workaround for issue on unstable negative_impls feature that allows unsound overlapping Unpin
+    // implementations and rustc bug that leaks unstable negative_impls into stable.
+    // See https://github.com/taiki-e/pin-project/issues/340#issuecomment-2432146009 for details.
+    #[doc(hidden)]
+    pub type PinnedFieldsOf<T> =
+        <PinnedFieldsOfHelperStruct<T> as PinnedFieldsOfHelperTrait>::Actual;
+    // We cannot use <Option<T> as IntoIterator>::Item or similar since we should allow ?Sized in T.
+    #[doc(hidden)]
+    pub trait PinnedFieldsOfHelperTrait {
+        type Actual: ?Sized;
+    }
+    #[doc(hidden)]
+    pub struct PinnedFieldsOfHelperStruct<T: ?Sized>(T);
+    impl<T: ?Sized> PinnedFieldsOfHelperTrait for PinnedFieldsOfHelperStruct<T> {
+        type Actual = T;
+    }
 
     // This is an internal helper struct used by `pin-project-internal`.
     //
     // See https://github.com/taiki-e/pin-project/pull/53 for more details.
     #[doc(hidden)]
     pub struct AlwaysUnpin<'a, T>(PhantomData<&'a ()>, PhantomData<T>);
-
     impl<T> Unpin for AlwaysUnpin<'_, T> {}
 
     // This is an internal helper used to ensure a value is dropped.
     #[doc(hidden)]
     pub struct UnsafeDropInPlaceGuard<T: ?Sized>(*mut T);
-
     impl<T: ?Sized> UnsafeDropInPlaceGuard<T> {
         #[doc(hidden)]
         pub unsafe fn new(ptr: *mut T) -> Self {
             Self(ptr)
         }
     }
-
     impl<T: ?Sized> Drop for UnsafeDropInPlaceGuard<T> {
         fn drop(&mut self) {
             // SAFETY: the caller of `UnsafeDropInPlaceGuard::new` must guarantee
@@ -316,14 +329,12 @@ pub mod __private {
         target: *mut T,
         value: ManuallyDrop<T>,
     }
-
     impl<T> UnsafeOverwriteGuard<T> {
         #[doc(hidden)]
         pub unsafe fn new(target: *mut T, value: T) -> Self {
             Self { target, value: ManuallyDrop::new(value) }
         }
     }
-
     impl<T> Drop for UnsafeOverwriteGuard<T> {
         fn drop(&mut self) {
             // SAFETY: the caller of `UnsafeOverwriteGuard::new` must guarantee

--- a/tests/expand/default/enum.expanded.rs
+++ b/tests/expand/default/enum.expanded.rs
@@ -131,12 +131,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/default/struct.expanded.rs
+++ b/tests/expand/default/struct.expanded.rs
@@ -90,12 +90,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/default/tuple_struct.expanded.rs
+++ b/tests/expand/default/tuple_struct.expanded.rs
@@ -84,12 +84,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/multifields/enum.expanded.rs
+++ b/tests/expand/multifields/enum.expanded.rs
@@ -256,12 +256,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/multifields/struct.expanded.rs
+++ b/tests/expand/multifields/struct.expanded.rs
@@ -143,12 +143,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/multifields/tuple_struct.expanded.rs
+++ b/tests/expand/multifields/tuple_struct.expanded.rs
@@ -133,12 +133,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/naming/enum-all.expanded.rs
+++ b/tests/expand/naming/enum-all.expanded.rs
@@ -192,12 +192,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/naming/enum-mut.expanded.rs
+++ b/tests/expand/naming/enum-mut.expanded.rs
@@ -83,12 +83,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/naming/enum-none.expanded.rs
+++ b/tests/expand/naming/enum-none.expanded.rs
@@ -38,12 +38,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/naming/enum-own.expanded.rs
+++ b/tests/expand/naming/enum-own.expanded.rs
@@ -103,12 +103,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/naming/enum-ref.expanded.rs
+++ b/tests/expand/naming/enum-ref.expanded.rs
@@ -84,12 +84,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/naming/struct-all.expanded.rs
+++ b/tests/expand/naming/struct-all.expanded.rs
@@ -151,12 +151,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/naming/struct-mut.expanded.rs
+++ b/tests/expand/naming/struct-mut.expanded.rs
@@ -100,12 +100,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/naming/struct-none.expanded.rs
+++ b/tests/expand/naming/struct-none.expanded.rs
@@ -90,12 +90,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/naming/struct-own.expanded.rs
+++ b/tests/expand/naming/struct-own.expanded.rs
@@ -131,12 +131,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/naming/struct-ref.expanded.rs
+++ b/tests/expand/naming/struct-ref.expanded.rs
@@ -100,12 +100,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/naming/tuple_struct-all.expanded.rs
+++ b/tests/expand/naming/tuple_struct-all.expanded.rs
@@ -136,12 +136,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/naming/tuple_struct-mut.expanded.rs
+++ b/tests/expand/naming/tuple_struct-mut.expanded.rs
@@ -91,12 +91,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/naming/tuple_struct-none.expanded.rs
+++ b/tests/expand/naming/tuple_struct-none.expanded.rs
@@ -84,12 +84,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/naming/tuple_struct-own.expanded.rs
+++ b/tests/expand/naming/tuple_struct-own.expanded.rs
@@ -122,12 +122,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/naming/tuple_struct-ref.expanded.rs
+++ b/tests/expand/naming/tuple_struct-ref.expanded.rs
@@ -91,12 +91,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/not_unpin/enum.expanded.rs
+++ b/tests/expand/not_unpin/enum.expanded.rs
@@ -120,17 +120,21 @@ const _: () = {
     #[doc(hidden)]
     impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        _pin_project::__private::Wrapper<
-            'pin,
-            _pin_project::__private::PhantomPinned,
+        ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<
+                'pin,
+                _pin_project::__private::PhantomPinned,
+            >,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        _pin_project::__private::Wrapper<
-            'pin,
-            _pin_project::__private::PhantomPinned,
+        ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<
+                'pin,
+                _pin_project::__private::PhantomPinned,
+            >,
         >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}

--- a/tests/expand/not_unpin/struct.expanded.rs
+++ b/tests/expand/not_unpin/struct.expanded.rs
@@ -80,17 +80,21 @@ const _: () = {
     #[doc(hidden)]
     impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        _pin_project::__private::Wrapper<
-            'pin,
-            _pin_project::__private::PhantomPinned,
+        ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<
+                'pin,
+                _pin_project::__private::PhantomPinned,
+            >,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        _pin_project::__private::Wrapper<
-            'pin,
-            _pin_project::__private::PhantomPinned,
+        ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<
+                'pin,
+                _pin_project::__private::PhantomPinned,
+            >,
         >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}

--- a/tests/expand/not_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/not_unpin/tuple_struct.expanded.rs
@@ -74,17 +74,21 @@ const _: () = {
     #[doc(hidden)]
     impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        _pin_project::__private::Wrapper<
-            'pin,
-            _pin_project::__private::PhantomPinned,
+        ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<
+                'pin,
+                _pin_project::__private::PhantomPinned,
+            >,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        _pin_project::__private::Wrapper<
-            'pin,
-            _pin_project::__private::PhantomPinned,
+        ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<
+                'pin,
+                _pin_project::__private::PhantomPinned,
+            >,
         >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}

--- a/tests/expand/pinned_drop/enum.expanded.rs
+++ b/tests/expand/pinned_drop/enum.expanded.rs
@@ -132,12 +132,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     impl<T, U> _pin_project::__private::Drop for Enum<T, U> {
         #[allow(clippy::missing_inline_in_public_items)]

--- a/tests/expand/pinned_drop/struct.expanded.rs
+++ b/tests/expand/pinned_drop/struct.expanded.rs
@@ -91,12 +91,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     impl<T, U> _pin_project::__private::Drop for Struct<T, U> {
         #[allow(clippy::missing_inline_in_public_items)]

--- a/tests/expand/pinned_drop/tuple_struct.expanded.rs
+++ b/tests/expand/pinned_drop/tuple_struct.expanded.rs
@@ -85,12 +85,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     impl<T, U> _pin_project::__private::Drop for TupleStruct<T, U> {
         #[allow(clippy::missing_inline_in_public_items)]

--- a/tests/expand/project_replace/enum.expanded.rs
+++ b/tests/expand/project_replace/enum.expanded.rs
@@ -103,12 +103,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/project_replace/struct.expanded.rs
+++ b/tests/expand/project_replace/struct.expanded.rs
@@ -121,12 +121,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/project_replace/tuple_struct.expanded.rs
+++ b/tests/expand/project_replace/tuple_struct.expanded.rs
@@ -115,12 +115,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/pub/enum.expanded.rs
+++ b/tests/expand/pub/enum.expanded.rs
@@ -131,12 +131,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        __Enum<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/pub/struct.expanded.rs
+++ b/tests/expand/pub/struct.expanded.rs
@@ -90,12 +90,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        __Struct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/pub/tuple_struct.expanded.rs
+++ b/tests/expand/pub/tuple_struct.expanded.rs
@@ -84,12 +84,16 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
     unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        __TupleStruct<'pin, T, U>: _pin_project::__private::Unpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/unsafe_unpin/enum.expanded.rs
+++ b/tests/expand/unsafe_unpin/enum.expanded.rs
@@ -119,7 +119,9 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        _pin_project::__private::Wrapper<'pin, Self>: _pin_project::UnsafeUnpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<'pin, Self>,
+        >: _pin_project::UnsafeUnpin,
     {}
     trait EnumMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/unsafe_unpin/struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/struct.expanded.rs
@@ -79,7 +79,9 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        _pin_project::__private::Wrapper<'pin, Self>: _pin_project::UnsafeUnpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<'pin, Self>,
+        >: _pin_project::UnsafeUnpin,
     {}
     trait StructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
@@ -73,7 +73,9 @@ const _: () = {
     }
     impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        _pin_project::__private::Wrapper<'pin, Self>: _pin_project::UnsafeUnpin,
+        ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<'pin, Self>,
+        >: _pin_project::UnsafeUnpin,
     {}
     trait TupleStructMustNotImplDrop {}
     #[allow(clippy::drop_bounds, drop_bounds)]

--- a/tests/ui/not_unpin/conflict-unpin.stderr
+++ b/tests/ui/not_unpin/conflict-unpin.stderr
@@ -6,8 +6,6 @@ error[E0119]: conflicting implementations of trait `Unpin` for type `Foo<_, _>`
 ...
 12 | impl<T, U> Unpin for Foo<T, U> where T: Unpin {}
    | --------------------------------------------- first implementation here
-   |
-   = note: upstream crates may add a new impl of trait `std::marker::Unpin` for type `_::_pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>` in future versions
 
 error[E0119]: conflicting implementations of trait `Unpin` for type `Bar<_, _>`
   --> tests/ui/not_unpin/conflict-unpin.rs:14:15
@@ -17,8 +15,6 @@ error[E0119]: conflicting implementations of trait `Unpin` for type `Bar<_, _>`
 ...
 21 | impl<T, U> Unpin for Bar<T, U> {}
    | ------------------------------ first implementation here
-   |
-   = note: upstream crates may add a new impl of trait `std::marker::Unpin` for type `_::_pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>` in future versions
 
 error[E0119]: conflicting implementations of trait `Unpin` for type `Baz<_, _>`
   --> tests/ui/not_unpin/conflict-unpin.rs:23:15
@@ -28,5 +24,3 @@ error[E0119]: conflicting implementations of trait `Unpin` for type `Baz<_, _>`
 ...
 30 | impl<T: Unpin, U: Unpin> Unpin for Baz<T, U> {}
    | -------------------------------------------- first implementation here
-   |
-   = note: upstream crates may add a new impl of trait `std::marker::Unpin` for type `_::_pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>` in future versions

--- a/tests/ui/not_unpin/impl-unsafe-unpin.stderr
+++ b/tests/ui/not_unpin/impl-unsafe-unpin.stderr
@@ -7,7 +7,6 @@ error[E0119]: conflicting implementations of trait `UnsafeUnpin` for type `Foo<_
 12 | unsafe impl<T, U> UnsafeUnpin for Foo<T, U> where T: Unpin {}
    | ---------------------------------------------------------- first implementation here
    |
-   = note: upstream crates may add a new impl of trait `std::marker::Unpin` for type `_::_pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>` in future versions
    = note: this error originates in the derive macro `::pin_project::__private::__PinProjectInternalDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `UnsafeUnpin` for type `Bar<_, _>`
@@ -19,7 +18,6 @@ error[E0119]: conflicting implementations of trait `UnsafeUnpin` for type `Bar<_
 21 | unsafe impl<T, U> UnsafeUnpin for Bar<T, U> {}
    | ------------------------------------------- first implementation here
    |
-   = note: upstream crates may add a new impl of trait `std::marker::Unpin` for type `_::_pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>` in future versions
    = note: this error originates in the derive macro `::pin_project::__private::__PinProjectInternalDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `UnsafeUnpin` for type `Baz<_, _>`
@@ -31,5 +29,4 @@ error[E0119]: conflicting implementations of trait `UnsafeUnpin` for type `Baz<_
 30 | unsafe impl<T: Unpin, U: Unpin> UnsafeUnpin for Baz<T, U> {}
    | --------------------------------------------------------- first implementation here
    |
-   = note: upstream crates may add a new impl of trait `std::marker::Unpin` for type `_::_pin_project::__private::Wrapper<'_, std::marker::PhantomPinned>` in future versions
    = note: this error originates in the derive macro `::pin_project::__private::__PinProjectInternalDerive` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/pin_project/negative_impls_stable.rs
+++ b/tests/ui/pin_project/negative_impls_stable.rs
@@ -1,20 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![feature(negative_impls)]
-
-// https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/design.20meeting.3A.20backlog.20bonanza/near/269471299
-// https://github.com/taiki-e/pin-project/issues/340
+// https://github.com/taiki-e/pin-project/issues/340#issuecomment-2428002670
 
 #[pin_project::pin_project]
 struct Foo<Pinned, Unpinned> {
     #[pin]
     pinned: Pinned,
-
     unpinned: Unpinned,
 }
 
-struct MyPhantomPinned {}
-impl !Unpin for MyPhantomPinned {}
+struct MyPhantomPinned(::core::marker::PhantomPinned);
+impl Unpin for MyPhantomPinned where for<'cursed> str: Sized {}
 impl Unpin for Foo<MyPhantomPinned, ()> {}
 
 fn is_unpin<T: Unpin>() {}

--- a/tests/ui/pin_project/negative_impls_stable.stderr
+++ b/tests/ui/pin_project/negative_impls_stable.stderr
@@ -1,0 +1,10 @@
+error[E0119]: conflicting implementations of trait `Unpin` for type `Foo<MyPhantomPinned, ()>`
+  --> tests/ui/pin_project/negative_impls_stable.rs:5:1
+   |
+5  | #[pin_project::pin_project]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Foo<MyPhantomPinned, ()>`
+...
+14 | impl Unpin for Foo<MyPhantomPinned, ()> {}
+   | --------------------------------------- first implementation here
+   |
+   = note: this error originates in the derive macro `::pin_project::__private::__PinProjectInternalDerive` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/unsafe_unpin/conflict-unpin.stderr
+++ b/tests/ui/unsafe_unpin/conflict-unpin.stderr
@@ -6,8 +6,6 @@ error[E0119]: conflicting implementations of trait `Unpin` for type `Foo<_, _>`
 ...
 12 | impl<T, U> Unpin for Foo<T, U> where T: Unpin {}
    | --------------------------------------------- first implementation here
-   |
-   = note: upstream crates may add a new impl of trait `_::_pin_project::UnsafeUnpin` for type `_::_pin_project::__private::Wrapper<'_, Foo<_, _>>` in future versions
 
 error[E0119]: conflicting implementations of trait `Unpin` for type `Bar<_, _>`
   --> tests/ui/unsafe_unpin/conflict-unpin.rs:14:15
@@ -17,8 +15,6 @@ error[E0119]: conflicting implementations of trait `Unpin` for type `Bar<_, _>`
 ...
 21 | impl<T, U> Unpin for Bar<T, U> {}
    | ------------------------------ first implementation here
-   |
-   = note: upstream crates may add a new impl of trait `_::_pin_project::UnsafeUnpin` for type `_::_pin_project::__private::Wrapper<'_, Bar<_, _>>` in future versions
 
 error[E0119]: conflicting implementations of trait `Unpin` for type `Baz<_, _>`
   --> tests/ui/unsafe_unpin/conflict-unpin.rs:23:15
@@ -28,5 +24,3 @@ error[E0119]: conflicting implementations of trait `Unpin` for type `Baz<_, _>`
 ...
 30 | impl<T: Unpin, U: Unpin> Unpin for Baz<T, U> {}
    | -------------------------------------------- first implementation here
-   |
-   = note: upstream crates may add a new impl of trait `_::_pin_project::UnsafeUnpin` for type `_::_pin_project::__private::Wrapper<'_, Baz<_, _>>` in future versions

--- a/tests/ui/unstable-features/negative_impls.rs
+++ b/tests/ui/unstable-features/negative_impls.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#![feature(negative_impls)]
+
+// https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/design.20meeting.3A.20backlog.20bonanza/near/269471299
+// https://github.com/taiki-e/pin-project/issues/340
+
+#[pin_project::pin_project]
+struct Foo<Pinned, Unpinned> {
+    #[pin]
+    pinned: Pinned,
+    unpinned: Unpinned,
+}
+
+struct MyPhantomPinned {}
+impl !Unpin for MyPhantomPinned {}
+impl Unpin for Foo<MyPhantomPinned, ()> {}
+
+fn is_unpin<T: Unpin>() {}
+
+fn main() {
+    is_unpin::<Foo<MyPhantomPinned, ()>>()
+}

--- a/tests/ui/unstable-features/negative_impls.stderr
+++ b/tests/ui/unstable-features/negative_impls.stderr
@@ -1,0 +1,10 @@
+error[E0119]: conflicting implementations of trait `Unpin` for type `Foo<MyPhantomPinned, ()>`
+  --> tests/ui/unstable-features/negative_impls.rs:8:1
+   |
+8  | #[pin_project::pin_project]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Foo<MyPhantomPinned, ()>`
+...
+17 | impl Unpin for Foo<MyPhantomPinned, ()> {}
+   | --------------------------------------- first implementation here
+   |
+   = note: this error originates in the derive macro `::pin_project::__private::__PinProjectInternalDerive` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
See https://github.com/taiki-e/pin-project/issues/340#issuecomment-2432146009 for details of the workaround.

(Btw, lifetime to workaround trivial_bounds is still needed.)

Fixes #340