### PR TITLE
Remove lifetime from wrapper types and impl generics

### DIFF
--- a/examples/enum-default-expanded.rs
+++ b/examples/enum-default-expanded.rs
@@ -69,22 +69,22 @@ const _: () = {
     //
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/53.
     // for details.
-    struct __Enum<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
-            'pin,
-            (::pin_project::__private::PhantomData<T>, ::pin_project::__private::PhantomData<U>),
-        >,
+    struct __Enum<T, U> {
+        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<(
+            ::pin_project::__private::PhantomData<T>,
+            ::pin_project::__private::PhantomData<U>,
+        )>,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Enum<T, U> where
-        ::pin_project::__private::PinnedFieldsOf<__Enum<'pin, T, U>>:
+    impl<T, U> ::pin_project::__private::Unpin for Enum<T, U> where
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<__Enum<T, U>>:
             ::pin_project::__private::Unpin
     {
     }
     // A dummy impl of `UnsafeUnpin`, to ensure that the user cannot implement it.
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Enum<T, U> where
-        ::pin_project::__private::PinnedFieldsOf<__Enum<'pin, T, U>>:
+    unsafe impl<T, U> ::pin_project::UnsafeUnpin for Enum<T, U> where
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<__Enum<T, U>>:
             ::pin_project::__private::Unpin
     {
     }

--- a/examples/not_unpin-expanded.rs
+++ b/examples/not_unpin-expanded.rs
@@ -96,9 +96,9 @@ const _: () = {
     // See https://github.com/taiki-e/pin-project/issues/102#issuecomment-540472282
     // for details.
     #[doc(hidden)]
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        ::pin_project::__private::PinnedFieldsOf<
-            ::pin_project::__private::Wrapper<'pin, ::pin_project::__private::PhantomPinned>,
+    impl<T, U> ::pin_project::__private::Unpin for Struct<T, U> where
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            ::pin_project::__private::Wrapper<::pin_project::__private::PhantomPinned>,
         >: ::pin_project::__private::Unpin
     {
     }
@@ -109,9 +109,9 @@ const _: () = {
     // impl, they'll get a "conflicting implementations of trait" error when
     // coherence checks are run.
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        ::pin_project::__private::PinnedFieldsOf<
-            ::pin_project::__private::Wrapper<'pin, ::pin_project::__private::PhantomPinned>,
+    unsafe impl<T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            ::pin_project::__private::Wrapper<::pin_project::__private::PhantomPinned>,
         >: ::pin_project::__private::Unpin
     {
     }

--- a/examples/pinned_drop-expanded.rs
+++ b/examples/pinned_drop-expanded.rs
@@ -117,20 +117,20 @@ const _: () = {
     //
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/53.
     // for details.
-    pub struct __Struct<'pin, 'a, T> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<'pin, (T)>,
+    pub struct __Struct<'a, T> {
+        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<(T)>,
         __field0: T,
         __lifetime0: &'a (),
     }
-    impl<'pin, 'a, T> ::pin_project::__private::Unpin for Struct<'a, T> where
-        ::pin_project::__private::PinnedFieldsOf<__Struct<'pin, 'a, T>>:
+    impl<'a, T> ::pin_project::__private::Unpin for Struct<'a, T> where
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<__Struct<'a, T>>:
             ::pin_project::__private::Unpin
     {
     }
     // A dummy impl of `UnsafeUnpin`, to ensure that the user cannot implement it.
     #[doc(hidden)]
-    unsafe impl<'pin, 'a, T> ::pin_project::UnsafeUnpin for Struct<'a, T> where
-        ::pin_project::__private::PinnedFieldsOf<__Struct<'pin, 'a, T>>:
+    unsafe impl<'a, T> ::pin_project::UnsafeUnpin for Struct<'a, T> where
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<__Struct<'a, T>>:
             ::pin_project::__private::Unpin
     {
     }

--- a/examples/project_replace-expanded.rs
+++ b/examples/project_replace-expanded.rs
@@ -129,22 +129,22 @@ const _: () = {
     //
     // See ./struct-default-expanded.rs and https://github.com/taiki-e/pin-project/pull/53.
     // for details.
-    struct __Struct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
-            'pin,
-            (::pin_project::__private::PhantomData<T>, ::pin_project::__private::PhantomData<U>),
-        >,
+    struct __Struct<T, U> {
+        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<(
+            ::pin_project::__private::PhantomData<T>,
+            ::pin_project::__private::PhantomData<U>,
+        )>,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        ::pin_project::__private::PinnedFieldsOf<__Struct<'pin, T, U>>:
+    impl<T, U> ::pin_project::__private::Unpin for Struct<T, U> where
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<__Struct<T, U>>:
             ::pin_project::__private::Unpin
     {
     }
     // A dummy impl of `UnsafeUnpin`, to ensure that the user cannot implement it.
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        ::pin_project::__private::PinnedFieldsOf<__Struct<'pin, T, U>>:
+    unsafe impl<T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<__Struct<T, U>>:
             ::pin_project::__private::Unpin
     {
     }

--- a/examples/struct-default-expanded.rs
+++ b/examples/struct-default-expanded.rs
@@ -121,15 +121,15 @@ const _: () = {
     // regardless of the privacy of the types of their fields.
     //
     // See also https://github.com/taiki-e/pin-project/pull/53.
-    struct __Struct<'pin, T, U> {
-        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<
-            'pin,
-            (::pin_project::__private::PhantomData<T>, ::pin_project::__private::PhantomData<U>),
-        >,
+    struct __Struct<T, U> {
+        __pin_project_use_generics: ::pin_project::__private::AlwaysUnpin<(
+            ::pin_project::__private::PhantomData<T>,
+            ::pin_project::__private::PhantomData<U>,
+        )>,
         __field0: T,
     }
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        ::pin_project::__private::PinnedFieldsOf<__Struct<'pin, T, U>>:
+    impl<T, U> ::pin_project::__private::Unpin for Struct<T, U> where
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<__Struct<T, U>>:
             ::pin_project::__private::Unpin
     {
     }
@@ -140,8 +140,8 @@ const _: () = {
     // impl, they'll get a "conflicting implementations of trait" error when
     // coherence checks are run.
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
-        ::pin_project::__private::PinnedFieldsOf<__Struct<'pin, T, U>>:
+    unsafe impl<T, U> ::pin_project::UnsafeUnpin for Struct<T, U> where
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<__Struct<T, U>>:
             ::pin_project::__private::Unpin
     {
     }

--- a/examples/unsafe_unpin-expanded.rs
+++ b/examples/unsafe_unpin-expanded.rs
@@ -91,8 +91,8 @@ const _: () = {
     }
 
     // Implement `Unpin` via `UnsafeUnpin`.
-    impl<'pin, T, U> ::pin_project::__private::Unpin for Struct<T, U> where
-        ::pin_project::__private::PinnedFieldsOf<::pin_project::__private::Wrapper<'pin, Self>>:
+    impl<T, U> ::pin_project::__private::Unpin for Struct<T, U> where
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<::pin_project::__private::Wrapper<Self>>:
             ::pin_project::UnsafeUnpin
     {
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,9 +275,9 @@ pub mod __private {
     // provide an impl of `Unpin`
     #[doc(hidden)]
     #[allow(dead_code)]
-    pub struct Wrapper<'a, T: ?Sized>(PhantomData<&'a ()>, T);
+    pub struct Wrapper<T: ?Sized>(T);
     // SAFETY: `T` implements UnsafeUnpin.
-    unsafe impl<T: ?Sized + UnsafeUnpin> UnsafeUnpin for Wrapper<'_, T> {}
+    unsafe impl<T: ?Sized + UnsafeUnpin> UnsafeUnpin for Wrapper<T> {}
 
     // Workaround for issue on unstable negative_impls feature that allows unsound overlapping Unpin
     // implementations and rustc bug that leaks unstable negative_impls into stable.
@@ -300,8 +300,8 @@ pub mod __private {
     //
     // See https://github.com/taiki-e/pin-project/pull/53 for more details.
     #[doc(hidden)]
-    pub struct AlwaysUnpin<'a, T>(PhantomData<&'a ()>, PhantomData<T>);
-    impl<T> Unpin for AlwaysUnpin<'_, T> {}
+    pub struct AlwaysUnpin<T>(PhantomData<T>);
+    impl<T> Unpin for AlwaysUnpin<T> {}
 
     // This is an internal helper used to ensure a value is dropped.
     #[doc(hidden)]

--- a/tests/expand/default/enum.expanded.rs
+++ b/tests/expand/default/enum.expanded.rs
@@ -118,9 +118,8 @@ const _: () = {
         }
     }
     #[allow(missing_debug_implementations)]
-    struct __Enum<'pin, T, U> {
+    struct __Enum<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -129,17 +128,17 @@ const _: () = {
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}

--- a/tests/expand/default/struct.expanded.rs
+++ b/tests/expand/default/struct.expanded.rs
@@ -78,9 +78,8 @@ const _: () = {
         let _ = &this.unpinned;
     }
     #[allow(missing_debug_implementations)]
-    struct __Struct<'pin, T, U> {
+    struct __Struct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -88,17 +87,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}

--- a/tests/expand/default/tuple_struct.expanded.rs
+++ b/tests/expand/default/tuple_struct.expanded.rs
@@ -72,9 +72,8 @@ const _: () = {
         let _ = &this.1;
     }
     #[allow(missing_debug_implementations)]
-    struct __TupleStruct<'pin, T, U> {
+    struct __TupleStruct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -82,17 +81,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}

--- a/tests/expand/multifields/enum.expanded.rs
+++ b/tests/expand/multifields/enum.expanded.rs
@@ -241,9 +241,8 @@ const _: () = {
         }
     }
     #[allow(missing_debug_implementations)]
-    struct __Enum<'pin, T, U> {
+    struct __Enum<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -254,17 +253,17 @@ const _: () = {
         __field2: T,
         __field3: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}

--- a/tests/expand/multifields/struct.expanded.rs
+++ b/tests/expand/multifields/struct.expanded.rs
@@ -130,9 +130,8 @@ const _: () = {
         let _ = &this.unpinned2;
     }
     #[allow(missing_debug_implementations)]
-    struct __Struct<'pin, T, U> {
+    struct __Struct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -141,17 +140,17 @@ const _: () = {
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}

--- a/tests/expand/multifields/tuple_struct.expanded.rs
+++ b/tests/expand/multifields/tuple_struct.expanded.rs
@@ -120,9 +120,8 @@ const _: () = {
         let _ = &this.3;
     }
     #[allow(missing_debug_implementations)]
-    struct __TupleStruct<'pin, T, U> {
+    struct __TupleStruct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -131,17 +130,17 @@ const _: () = {
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}

--- a/tests/expand/naming/enum-all.expanded.rs
+++ b/tests/expand/naming/enum-all.expanded.rs
@@ -179,9 +179,8 @@ const _: () = {
         }
     }
     #[allow(missing_debug_implementations)]
-    struct __Enum<'pin, T, U> {
+    struct __Enum<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -190,17 +189,17 @@ const _: () = {
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}

--- a/tests/expand/naming/enum-mut.expanded.rs
+++ b/tests/expand/naming/enum-mut.expanded.rs
@@ -70,9 +70,8 @@ const _: () = {
         }
     }
     #[allow(missing_debug_implementations)]
-    struct __Enum<'pin, T, U> {
+    struct __Enum<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -81,17 +80,17 @@ const _: () = {
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}

--- a/tests/expand/naming/enum-none.expanded.rs
+++ b/tests/expand/naming/enum-none.expanded.rs
@@ -25,9 +25,8 @@ const _: () = {
     extern crate pin_project as _pin_project;
     impl<T, U> Enum<T, U> {}
     #[allow(missing_debug_implementations)]
-    struct __Enum<'pin, T, U> {
+    struct __Enum<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -36,17 +35,17 @@ const _: () = {
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}

--- a/tests/expand/naming/enum-own.expanded.rs
+++ b/tests/expand/naming/enum-own.expanded.rs
@@ -90,9 +90,8 @@ const _: () = {
         }
     }
     #[allow(missing_debug_implementations)]
-    struct __Enum<'pin, T, U> {
+    struct __Enum<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -101,17 +100,17 @@ const _: () = {
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}

--- a/tests/expand/naming/enum-ref.expanded.rs
+++ b/tests/expand/naming/enum-ref.expanded.rs
@@ -71,9 +71,8 @@ const _: () = {
         }
     }
     #[allow(missing_debug_implementations)]
-    struct __Enum<'pin, T, U> {
+    struct __Enum<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -82,17 +81,17 @@ const _: () = {
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}

--- a/tests/expand/naming/struct-all.expanded.rs
+++ b/tests/expand/naming/struct-all.expanded.rs
@@ -139,9 +139,8 @@ const _: () = {
         let _ = &this.unpinned;
     }
     #[allow(missing_debug_implementations)]
-    struct __Struct<'pin, T, U> {
+    struct __Struct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -149,17 +148,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}

--- a/tests/expand/naming/struct-mut.expanded.rs
+++ b/tests/expand/naming/struct-mut.expanded.rs
@@ -88,9 +88,8 @@ const _: () = {
         let _ = &this.unpinned;
     }
     #[allow(missing_debug_implementations)]
-    struct __Struct<'pin, T, U> {
+    struct __Struct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -98,17 +97,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}

--- a/tests/expand/naming/struct-none.expanded.rs
+++ b/tests/expand/naming/struct-none.expanded.rs
@@ -78,9 +78,8 @@ const _: () = {
         let _ = &this.unpinned;
     }
     #[allow(missing_debug_implementations)]
-    struct __Struct<'pin, T, U> {
+    struct __Struct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -88,17 +87,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}

--- a/tests/expand/naming/struct-own.expanded.rs
+++ b/tests/expand/naming/struct-own.expanded.rs
@@ -119,9 +119,8 @@ const _: () = {
         let _ = &this.unpinned;
     }
     #[allow(missing_debug_implementations)]
-    struct __Struct<'pin, T, U> {
+    struct __Struct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -129,17 +128,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}

--- a/tests/expand/naming/struct-ref.expanded.rs
+++ b/tests/expand/naming/struct-ref.expanded.rs
@@ -88,9 +88,8 @@ const _: () = {
         let _ = &this.unpinned;
     }
     #[allow(missing_debug_implementations)]
-    struct __Struct<'pin, T, U> {
+    struct __Struct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -98,17 +97,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}

--- a/tests/expand/naming/tuple_struct-all.expanded.rs
+++ b/tests/expand/naming/tuple_struct-all.expanded.rs
@@ -124,9 +124,8 @@ const _: () = {
         let _ = &this.1;
     }
     #[allow(missing_debug_implementations)]
-    struct __TupleStruct<'pin, T, U> {
+    struct __TupleStruct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -134,17 +133,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}

--- a/tests/expand/naming/tuple_struct-mut.expanded.rs
+++ b/tests/expand/naming/tuple_struct-mut.expanded.rs
@@ -79,9 +79,8 @@ const _: () = {
         let _ = &this.1;
     }
     #[allow(missing_debug_implementations)]
-    struct __TupleStruct<'pin, T, U> {
+    struct __TupleStruct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -89,17 +88,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}

--- a/tests/expand/naming/tuple_struct-none.expanded.rs
+++ b/tests/expand/naming/tuple_struct-none.expanded.rs
@@ -72,9 +72,8 @@ const _: () = {
         let _ = &this.1;
     }
     #[allow(missing_debug_implementations)]
-    struct __TupleStruct<'pin, T, U> {
+    struct __TupleStruct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -82,17 +81,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}

--- a/tests/expand/naming/tuple_struct-own.expanded.rs
+++ b/tests/expand/naming/tuple_struct-own.expanded.rs
@@ -110,9 +110,8 @@ const _: () = {
         let _ = &this.1;
     }
     #[allow(missing_debug_implementations)]
-    struct __TupleStruct<'pin, T, U> {
+    struct __TupleStruct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -120,17 +119,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}

--- a/tests/expand/naming/tuple_struct-ref.expanded.rs
+++ b/tests/expand/naming/tuple_struct-ref.expanded.rs
@@ -79,9 +79,8 @@ const _: () = {
         let _ = &this.1;
     }
     #[allow(missing_debug_implementations)]
-    struct __TupleStruct<'pin, T, U> {
+    struct __TupleStruct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -89,17 +88,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}

--- a/tests/expand/not_unpin/enum.expanded.rs
+++ b/tests/expand/not_unpin/enum.expanded.rs
@@ -118,23 +118,17 @@ const _: () = {
         }
     }
     #[doc(hidden)]
-    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            _pin_project::__private::Wrapper<
-                'pin,
-                _pin_project::__private::PhantomPinned,
-            >,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<_pin_project::__private::PhantomPinned>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            _pin_project::__private::Wrapper<
-                'pin,
-                _pin_project::__private::PhantomPinned,
-            >,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<_pin_project::__private::PhantomPinned>,
         >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}

--- a/tests/expand/not_unpin/struct.expanded.rs
+++ b/tests/expand/not_unpin/struct.expanded.rs
@@ -78,23 +78,17 @@ const _: () = {
         let _ = &this.unpinned;
     }
     #[doc(hidden)]
-    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            _pin_project::__private::Wrapper<
-                'pin,
-                _pin_project::__private::PhantomPinned,
-            >,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<_pin_project::__private::PhantomPinned>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            _pin_project::__private::Wrapper<
-                'pin,
-                _pin_project::__private::PhantomPinned,
-            >,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<_pin_project::__private::PhantomPinned>,
         >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}

--- a/tests/expand/not_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/not_unpin/tuple_struct.expanded.rs
@@ -72,23 +72,17 @@ const _: () = {
         let _ = &this.1;
     }
     #[doc(hidden)]
-    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            _pin_project::__private::Wrapper<
-                'pin,
-                _pin_project::__private::PhantomPinned,
-            >,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<_pin_project::__private::PhantomPinned>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            _pin_project::__private::Wrapper<
-                'pin,
-                _pin_project::__private::PhantomPinned,
-            >,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<_pin_project::__private::PhantomPinned>,
         >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}

--- a/tests/expand/pinned_drop/enum.expanded.rs
+++ b/tests/expand/pinned_drop/enum.expanded.rs
@@ -119,9 +119,8 @@ const _: () = {
         }
     }
     #[allow(missing_debug_implementations)]
-    struct __Enum<'pin, T, U> {
+    struct __Enum<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -130,17 +129,17 @@ const _: () = {
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     impl<T, U> _pin_project::__private::Drop for Enum<T, U> {

--- a/tests/expand/pinned_drop/struct.expanded.rs
+++ b/tests/expand/pinned_drop/struct.expanded.rs
@@ -79,9 +79,8 @@ const _: () = {
         let _ = &this.unpinned;
     }
     #[allow(missing_debug_implementations)]
-    struct __Struct<'pin, T, U> {
+    struct __Struct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -89,17 +88,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     impl<T, U> _pin_project::__private::Drop for Struct<T, U> {

--- a/tests/expand/pinned_drop/tuple_struct.expanded.rs
+++ b/tests/expand/pinned_drop/tuple_struct.expanded.rs
@@ -73,9 +73,8 @@ const _: () = {
         let _ = &this.1;
     }
     #[allow(missing_debug_implementations)]
-    struct __TupleStruct<'pin, T, U> {
+    struct __TupleStruct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -83,17 +82,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     impl<T, U> _pin_project::__private::Drop for TupleStruct<T, U> {

--- a/tests/expand/project_replace/enum.expanded.rs
+++ b/tests/expand/project_replace/enum.expanded.rs
@@ -90,9 +90,8 @@ const _: () = {
         }
     }
     #[allow(missing_debug_implementations)]
-    struct __Enum<'pin, T, U> {
+    struct __Enum<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -101,17 +100,17 @@ const _: () = {
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}

--- a/tests/expand/project_replace/struct.expanded.rs
+++ b/tests/expand/project_replace/struct.expanded.rs
@@ -109,9 +109,8 @@ const _: () = {
         let _ = &this.unpinned;
     }
     #[allow(missing_debug_implementations)]
-    struct __Struct<'pin, T, U> {
+    struct __Struct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -119,17 +118,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}

--- a/tests/expand/project_replace/tuple_struct.expanded.rs
+++ b/tests/expand/project_replace/tuple_struct.expanded.rs
@@ -103,9 +103,8 @@ const _: () = {
         let _ = &this.1;
     }
     #[allow(missing_debug_implementations)]
-    struct __TupleStruct<'pin, T, U> {
+    struct __TupleStruct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -113,17 +112,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}

--- a/tests/expand/pub/enum.expanded.rs
+++ b/tests/expand/pub/enum.expanded.rs
@@ -118,9 +118,8 @@ const _: () = {
         }
     }
     #[allow(missing_debug_implementations)]
-    pub struct __Enum<'pin, T, U> {
+    pub struct __Enum<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -129,17 +128,17 @@ const _: () = {
         __field0: T,
         __field1: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Enum<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Enum<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait EnumMustNotImplDrop {}

--- a/tests/expand/pub/struct.expanded.rs
+++ b/tests/expand/pub/struct.expanded.rs
@@ -78,9 +78,8 @@ const _: () = {
         let _ = &this.unpinned;
     }
     #[allow(missing_debug_implementations)]
-    pub struct __Struct<'pin, T, U> {
+    pub struct __Struct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -88,17 +87,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait StructMustNotImplDrop {}

--- a/tests/expand/pub/tuple_struct.expanded.rs
+++ b/tests/expand/pub/tuple_struct.expanded.rs
@@ -72,9 +72,8 @@ const _: () = {
         let _ = &this.1;
     }
     #[allow(missing_debug_implementations)]
-    pub struct __TupleStruct<'pin, T, U> {
+    pub struct __TupleStruct<T, U> {
         __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
-            'pin,
             (
                 _pin_project::__private::PhantomData<T>,
                 _pin_project::__private::PhantomData<U>,
@@ -82,17 +81,17 @@ const _: () = {
         >,
         __field0: T,
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     #[doc(hidden)]
-    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
+    unsafe impl<T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __TupleStruct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
     trait TupleStructMustNotImplDrop {}

--- a/tests/expand/unsafe_unpin/enum.expanded.rs
+++ b/tests/expand/unsafe_unpin/enum.expanded.rs
@@ -117,10 +117,10 @@ const _: () = {
             }
         }
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Enum<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            _pin_project::__private::Wrapper<'pin, Self>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<Self>,
         >: _pin_project::UnsafeUnpin,
     {}
     trait EnumMustNotImplDrop {}

--- a/tests/expand/unsafe_unpin/struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/struct.expanded.rs
@@ -77,10 +77,10 @@ const _: () = {
         let _ = &this.pinned;
         let _ = &this.unpinned;
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            _pin_project::__private::Wrapper<'pin, Self>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<Self>,
         >: _pin_project::UnsafeUnpin,
     {}
     trait StructMustNotImplDrop {}

--- a/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
@@ -71,10 +71,10 @@ const _: () = {
         let _ = &this.0;
         let _ = &this.1;
     }
-    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
+    impl<T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            _pin_project::__private::Wrapper<'pin, Self>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+            _pin_project::__private::Wrapper<Self>,
         >: _pin_project::UnsafeUnpin,
     {}
     trait TupleStructMustNotImplDrop {}

--- a/tests/ui/not_unpin/negative_impls_stable.rs
+++ b/tests/ui/not_unpin/negative_impls_stable.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// https://github.com/taiki-e/pin-project/issues/340#issuecomment-2428002670
+
+#[pin_project::pin_project(!Unpin)]
+struct Foo<Pinned, Unpinned> {
+    #[pin]
+    pinned: Pinned,
+    unpinned: Unpinned,
+}
+
+struct MyPhantomPinned(::core::marker::PhantomPinned);
+impl Unpin for MyPhantomPinned where for<'cursed> str: Sized {}
+impl Unpin for Foo<MyPhantomPinned, ()> {}
+
+fn is_unpin<T: Unpin>() {}
+
+fn main() {
+    is_unpin::<Foo<MyPhantomPinned, ()>>()
+}

--- a/tests/ui/not_unpin/negative_impls_stable.stderr
+++ b/tests/ui/not_unpin/negative_impls_stable.stderr
@@ -1,0 +1,8 @@
+error[E0119]: conflicting implementations of trait `Unpin` for type `Foo<MyPhantomPinned, ()>`
+  --> tests/ui/not_unpin/negative_impls_stable.rs:5:28
+   |
+5  | #[pin_project::pin_project(!Unpin)]
+   |                            ^^^^^^ conflicting implementation for `Foo<MyPhantomPinned, ()>`
+...
+14 | impl Unpin for Foo<MyPhantomPinned, ()> {}
+   | --------------------------------------- first implementation here

--- a/tests/ui/pin_project/add-pinned-field.stderr
+++ b/tests/ui/pin_project/add-pinned-field.stderr
@@ -2,11 +2,11 @@ error[E0277]: `PhantomPinned` cannot be unpinned
   --> tests/ui/pin_project/add-pinned-field.rs:23:16
    |
 23 |     is_unpin::<Foo>(); //~ ERROR E0277
-   |                ^^^ within `__Foo<'_>`, the trait `Unpin` is not implemented for `PhantomPinned`, which is required by `Foo: Unpin`
+   |                ^^^ within `__Foo`, the trait `Unpin` is not implemented for `PhantomPinned`, which is required by `Foo: Unpin`
    |
    = note: consider using the `pin!` macro
            consider using `Box::pin` if you need to access the pinned value outside of the current scope
-note: required because it appears within the type `__Foo<'_>`
+note: required because it appears within the type `__Foo`
   --> tests/ui/pin_project/add-pinned-field.rs:10:8
    |
 10 | struct Foo {
@@ -30,11 +30,11 @@ error[E0277]: `PhantomPinned` cannot be unpinned
   --> tests/ui/pin_project/add-pinned-field.rs:24:16
    |
 24 |     is_unpin::<Bar>(); //~ ERROR E0277
-   |                ^^^ within `__Bar<'_>`, the trait `Unpin` is not implemented for `PhantomPinned`, which is required by `Bar: Unpin`
+   |                ^^^ within `__Bar`, the trait `Unpin` is not implemented for `PhantomPinned`, which is required by `Bar: Unpin`
    |
    = note: consider using the `pin!` macro
            consider using `Box::pin` if you need to access the pinned value outside of the current scope
-note: required because it appears within the type `__Bar<'_>`
+note: required because it appears within the type `__Bar`
   --> tests/ui/pin_project/add-pinned-field.rs:17:8
    |
 17 | struct Bar {

--- a/tests/ui/pin_project/overlapping_unpin_struct.stderr
+++ b/tests/ui/pin_project/overlapping_unpin_struct.stderr
@@ -2,11 +2,11 @@ error[E0277]: `PhantomPinned` cannot be unpinned
   --> tests/ui/pin_project/overlapping_unpin_struct.rs:20:16
    |
 20 |     is_unpin::<S<PhantomPinned>>(); //~ ERROR E0277
-   |                ^^^^^^^^^^^^^^^^ within `_::__S<'_, PhantomPinned>`, the trait `Unpin` is not implemented for `PhantomPinned`, which is required by `S<PhantomPinned>: Unpin`
+   |                ^^^^^^^^^^^^^^^^ within `_::__S<PhantomPinned>`, the trait `Unpin` is not implemented for `PhantomPinned`, which is required by `S<PhantomPinned>: Unpin`
    |
    = note: consider using the `pin!` macro
            consider using `Box::pin` if you need to access the pinned value outside of the current scope
-note: required because it appears within the type `_::__S<'_, PhantomPinned>`
+note: required because it appears within the type `_::__S<PhantomPinned>`
   --> tests/ui/pin_project/overlapping_unpin_struct.rs:8:8
    |
 8  | struct S<T> {

--- a/tests/ui/unsafe_unpin/negative_impls_stable.rs
+++ b/tests/ui/unsafe_unpin/negative_impls_stable.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// https://github.com/taiki-e/pin-project/issues/340#issuecomment-2428002670
+
+#[pin_project::pin_project(UnsafeUnpin)]
+struct Foo<Pinned, Unpinned> {
+    #[pin]
+    pinned: Pinned,
+    unpinned: Unpinned,
+}
+
+unsafe impl<Pinned: Unpin, Unpinned> pin_project::UnsafeUnpin for Foo<Pinned, Unpinned> {}
+
+struct MyPhantomPinned(::core::marker::PhantomPinned);
+impl Unpin for MyPhantomPinned where for<'cursed> str: Sized {}
+impl Unpin for Foo<MyPhantomPinned, ()> {}
+
+fn is_unpin<T: Unpin>() {}
+
+fn main() {
+    is_unpin::<Foo<MyPhantomPinned, ()>>()
+}

--- a/tests/ui/unsafe_unpin/negative_impls_stable.stderr
+++ b/tests/ui/unsafe_unpin/negative_impls_stable.stderr
@@ -1,0 +1,8 @@
+error[E0119]: conflicting implementations of trait `Unpin` for type `Foo<MyPhantomPinned, ()>`
+  --> tests/ui/unsafe_unpin/negative_impls_stable.rs:5:28
+   |
+5  | #[pin_project::pin_project(UnsafeUnpin)]
+   |                            ^^^^^^^^^^^ conflicting implementation for `Foo<MyPhantomPinned, ()>`
+...
+16 | impl Unpin for Foo<MyPhantomPinned, ()> {}
+   | --------------------------------------- first implementation here


### PR DESCRIPTION
Context: https://github.com/taiki-e/pin-project/pull/357#issuecomment-2435085549
I'm not worried about the compiler making changes that break the current code in the future since the compiler depends on pin-project-lite, but ~~I do like reducing the generated code by this~~ EDIT: .

```diff
-impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
+impl<T, U> _pin_project::__private::Unpin for Struct<T, U>
     where
-        ::pin_project::__private::PinnedFieldsOf<
-            __Struct<'pin, T, U>,
+        for<'pin> ::pin_project::__private::PinnedFieldsOf<
+           __Struct<T, U>,
         >: _pin_project::__private::Unpin,
     {}
```

FYI @danielhenrymantilla 