### PR TITLE
Add pub prefix to args to make the method and the returned struct

### DIFF
--- a/pin-project-internal/src/lib.rs
+++ b/pin-project-internal/src/lib.rs
@@ -74,7 +74,7 @@ use proc_macro::TokenStream;
 /// (In that case, you are also required to provide a name for the returned struct)
 ///
 /// ```
-/// # use pin_project::pin_project
+/// # use pin_project::pin_project;
 /// #[pin_project(pub project = StructProj)] //force the project method and StructProj to be pub
 /// pub struct Struct<T> {
 ///     #[pin]

--- a/pin-project-internal/src/lib.rs
+++ b/pin-project-internal/src/lib.rs
@@ -68,6 +68,20 @@ use proc_macro::TokenStream;
 /// }
 /// ```
 ///
+/// By default, the visibility of the projected types and projection methods is
+/// based on the original type, except `pub` which is downgraded to `pub(crate)`.
+/// You can force `pub` visibility by passing a pub before the method name.
+/// (In that case, you are also required to provide a name for the returned struct)
+///
+/// ```
+/// # use pin_project::pin_project
+/// #[pin_project(pub project = StructProj)] //force the project method and StructProj to be pub
+/// struct Struct<T> {
+///     #[pin]
+///     field: T,
+/// }
+/// ```
+///
 /// Note that the projection types returned by `project` and `project_ref` have
 /// an additional lifetime at the beginning of generics.
 ///
@@ -75,11 +89,6 @@ use proc_macro::TokenStream;
 /// let this: EnumProj<'_, T> = self.project();
 ///                    ^^
 /// ```
-///
-/// The visibility of the projected types and projection methods is based on the
-/// original type. However, if the visibility of the original type is `pub`, the
-/// visibility of the projected types and the projection methods is downgraded
-/// to `pub(crate)`.
 ///
 /// # Safety
 ///

--- a/pin-project-internal/src/lib.rs
+++ b/pin-project-internal/src/lib.rs
@@ -76,7 +76,7 @@ use proc_macro::TokenStream;
 /// ```
 /// # use pin_project::pin_project
 /// #[pin_project(pub project = StructProj)] //force the project method and StructProj to be pub
-/// struct Struct<T> {
+/// pub struct Struct<T> {
 ///     #[pin]
 ///     field: T,
 /// }

--- a/pin-project-internal/src/pin_project/args.rs
+++ b/pin-project-internal/src/pin_project/args.rs
@@ -115,7 +115,10 @@ impl Parse for Args {
             if input.peek(Token![pub]) {
                 let pub_token: Token![pub] = input.parse()?;
                 if input.is_empty() {
-                    bail!(pub_token, "`pub` can only be used on project, project_ref or named project_replace")
+                    bail!(
+                        pub_token,
+                        "`pub` can only be used on project, project_ref or named project_replace"
+                    )
                 }
                 visibility_pub.replace(pub_token.span());
             }

--- a/pin-project-internal/src/pin_project/args.rs
+++ b/pin-project-internal/src/pin_project/args.rs
@@ -297,9 +297,6 @@ impl ProjArgs {
         }
     }
     pub(super) fn is_some(&self) -> bool {
-        match self {
-            Self::None => false,
-            _ => true,
-        }
+        !matches!(self, Self::None)
     }
 }

--- a/pin-project-internal/src/pin_project/args.rs
+++ b/pin-project-internal/src/pin_project/args.rs
@@ -214,12 +214,7 @@ impl Parse for Args {
                 (Some(span), Some(ident), false) => ProjArgs::Named { ident, span },
                 (Some(span), Some(ident), true) => ProjArgs::NamedPublic { span, ident },
                 (Some(span), None, false) => ProjArgs::Unnamed { span },
-                (Some(span), None, true) => {
-                    return Err(Error::new(
-                        span,
-                        "project_replace cannot be pub if it is not named",
-                    ));
-                }
+                (Some(_), None, true) => unreachable!(),
             };
         let project = match (project, project_pub) {
             (None, _) => ProjArgs::None,

--- a/pin-project-internal/src/pin_project/args.rs
+++ b/pin-project-internal/src/pin_project/args.rs
@@ -114,6 +114,9 @@ impl Parse for Args {
         while !input.is_empty() {
             if input.peek(Token![pub]) {
                 let pub_token: Token![pub] = input.parse()?;
+                if input.is_empty() {
+                    bail!(pub_token, "`pub` can only be used on project, project_ref or named project_replace")
+                }
                 visibility_pub.replace(pub_token.span());
             }
             if input.peek(Token![!]) {

--- a/pin-project-internal/src/pin_project/args.rs
+++ b/pin-project-internal/src/pin_project/args.rs
@@ -3,7 +3,9 @@
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{
-    parse::{Parse, ParseStream}, spanned::Spanned as _, Attribute, Error, Ident, Result, Token, Visibility
+    Attribute, Error, Ident, Result, Token, Visibility,
+    parse::{Parse, ParseStream},
+    spanned::Spanned as _,
 };
 
 use super::PIN;
@@ -288,7 +290,7 @@ impl ProjArgs {
             None
         }
     }
-    pub(super) fn vis(&self,default_vis: &Visibility) -> Visibility {
+    pub(super) fn vis(&self, default_vis: &Visibility) -> Visibility {
         match self {
             Self::NamedPublic { .. } => parse_quote_spanned!(default_vis.span() => pub),
             _ => default_vis.clone(),

--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -13,7 +13,7 @@ use super::{
     args::{Args, ProjReplace, UnpinImpl, parse_args},
 };
 use crate::utils::{
-    ReplaceReceiver, SliceExt as _, Variants, determine_lifetime_name, determine_visibility,
+    ReplaceReceiver, SliceExt as _, Variants, determine_lifetime_name,
     insert_lifetime_and_bound,
 };
 
@@ -238,7 +238,7 @@ impl<'a> Context<'a> {
             project_ref: project_ref.is_some(),
             project_replace,
             proj: ProjectedType {
-                vis: determine_visibility(vis),
+                vis: vis.clone(),
                 mut_ident: project.unwrap_or_else(|| format_ident!("__{}Projection", ident)),
                 ref_ident: project_ref.unwrap_or_else(|| format_ident!("__{}ProjectionRef", ident)),
                 own_ident,

--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -5,10 +5,7 @@ use quote::{ToTokens as _, format_ident, quote, quote_spanned};
 use syn::{
     Attribute, Error, Field, Fields, FieldsNamed, FieldsUnnamed, Generics, Ident, Index, Item,
     Lifetime, LifetimeParam, Meta, Result, Token, Type, Variant, Visibility, WhereClause,
-    parse_quote,
-    punctuated::Punctuated,
-    token::{self},
-    visit_mut::VisitMut as _,
+    parse_quote, punctuated::Punctuated, token, visit_mut::VisitMut as _,
 };
 
 use super::{

--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -411,6 +411,7 @@ You should however consider passing around a Pin<&mut {0}> directly rather than 
     generate.extend(cx.project.is_some(), quote! {
         #proj_attrs
         #[doc = #project_doc]
+        #[non_exhaustive]
         #project_vis struct #proj_ident #proj_generics #where_clause_fields
     });
 
@@ -421,6 +422,7 @@ You should consider passing around a Pin<& {0}> directly rather than this struct
     generate.extend(cx.project_ref.is_some(), quote! {
         #proj_ref_attrs
         #[doc = #project_ref_doc]
+        #[non_exhaustive]
         #project_ref_vis struct #proj_ref_ident #proj_generics #where_clause_ref_fields
     });
 
@@ -430,6 +432,7 @@ You should consider passing around a Pin<& {0}> directly rather than this struct
         generate.extend(cx.project_replace.ident().is_some(), quote! {
             #proj_own_attrs
             #[doc = #project_own_doc]
+            #[non_exhaustive]
             #project_own_vis struct #proj_own_ident #orig_generics #where_clause_own_fields
         });
     }

--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -1006,7 +1006,7 @@ fn make_proj_impl(
     let project_vis = cx.project.vis(default_vis);
     let project_doc = format!(
         "Take a Pin<&mut {0}> and project it, aka return a {0}-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self",orig_name);
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self",orig_name);
     let mut project = Some(quote! {
         #allow_dead_code
         #[inline]

--- a/pin-project-internal/src/pin_project/derive.rs
+++ b/pin-project-internal/src/pin_project/derive.rs
@@ -1020,7 +1020,7 @@ fn make_proj_impl(
     let project_ref_vis = cx.project_ref.vis(default_vis);
     let project_ref_doc = format!(
         "Take a Pin<& {0}> and project it, aka return a {0}-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self",orig_name
+        each being a (pinned if necessary) reference to the corresponding field of Self",orig_name
     );
     let mut project_ref = Some(quote! {
         #allow_dead_code

--- a/pin-project-internal/src/utils.rs
+++ b/pin-project-internal/src/utils.rs
@@ -7,7 +7,7 @@ use quote::{ToTokens, quote, quote_spanned};
 use syn::{
     Attribute, ExprPath, ExprStruct, Generics, Ident, Item, Lifetime, LifetimeParam, Macro,
     PatStruct, PatTupleStruct, Path, PathArguments, PredicateType, QSelf, Result, Token, Type,
-    TypeParamBound, TypePath, Variant, WherePredicate,
+    TypeParamBound, TypePath, Variant, Visibility, WherePredicate,
     parse::{Parse, ParseBuffer, ParseStream},
     parse_quote,
     punctuated::Punctuated,
@@ -72,6 +72,18 @@ pub(crate) fn insert_lifetime(generics: &mut Generics, lifetime: Lifetime) {
     generics.lt_token.get_or_insert_with(<Token![<]>::default);
     generics.gt_token.get_or_insert_with(<Token![>]>::default);
     generics.params.insert(0, LifetimeParam::new(lifetime).into());
+}
+
+/// Determines the default visibility of the projected types and projection methods.
+///
+/// If given visibility is `pub`, returned visibility is `pub(crate)`.
+/// Otherwise, returned visibility is the same as given visibility.
+pub(crate) fn determine_visibility(vis: &Visibility) -> Visibility {
+    if let Visibility::Public(token) = vis {
+        parse_quote_spanned!(token.span => pub(crate))
+    } else {
+        vis.clone()
+    }
 }
 
 pub(crate) fn respan<T>(node: &T, span: Span) -> T

--- a/pin-project-internal/src/utils.rs
+++ b/pin-project-internal/src/utils.rs
@@ -7,7 +7,7 @@ use quote::{ToTokens, quote, quote_spanned};
 use syn::{
     Attribute, ExprPath, ExprStruct, Generics, Ident, Item, Lifetime, LifetimeParam, Macro,
     PatStruct, PatTupleStruct, Path, PathArguments, PredicateType, QSelf, Result, Token, Type,
-    TypeParamBound, TypePath, Variant, Visibility, WherePredicate,
+    TypeParamBound, TypePath, Variant, WherePredicate,
     parse::{Parse, ParseBuffer, ParseStream},
     parse_quote,
     punctuated::Punctuated,
@@ -72,18 +72,6 @@ pub(crate) fn insert_lifetime(generics: &mut Generics, lifetime: Lifetime) {
     generics.lt_token.get_or_insert_with(<Token![<]>::default);
     generics.gt_token.get_or_insert_with(<Token![>]>::default);
     generics.params.insert(0, LifetimeParam::new(lifetime).into());
-}
-
-/// Determines the visibility of the projected types and projection methods.
-///
-/// If given visibility is `pub`, returned visibility is `pub(crate)`.
-/// Otherwise, returned visibility is the same as given visibility.
-pub(crate) fn determine_visibility(vis: &Visibility) -> Visibility {
-    if let Visibility::Public(token) = vis {
-        parse_quote_spanned!(token.span => pub(crate))
-    } else {
-        vis.clone()
-    }
 }
 
 pub(crate) fn respan<T>(node: &T, span: Span) -> T

--- a/pin-project-internal/src/utils.rs
+++ b/pin-project-internal/src/utils.rs
@@ -111,6 +111,7 @@ fn respan_tokens(tokens: TokenStream, span: Span) -> TokenStream {
 pub(crate) trait SliceExt {
     fn position_exact(&self, ident: &str) -> Result<Option<usize>>;
     fn find(&self, ident: &str) -> Option<&Attribute>;
+    fn extract_doc(&self) -> TokenStream;
 }
 
 impl SliceExt for [Attribute] {
@@ -134,6 +135,16 @@ impl SliceExt for [Attribute] {
 
     fn find(&self, ident: &str) -> Option<&Attribute> {
         self.iter().position(|attr| attr.path().is_ident(ident)).map(|i| &self[i])
+    }
+    fn extract_doc(&self) -> TokenStream {
+        let mut doc = TokenStream::new();
+        for doc_item in self.iter().filter(|attr| attr.path().is_ident("doc")) {
+            doc = quote! {
+                #doc
+                #doc_item
+            };
+        }
+        doc
     }
 }
 

--- a/tests/expand/default/enum.expanded.rs
+++ b/tests/expand/default/enum.expanded.rs
@@ -89,7 +89,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {

--- a/tests/expand/default/enum.expanded.rs
+++ b/tests/expand/default/enum.expanded.rs
@@ -88,6 +88,8 @@ const _: () = {
     impl<T, U> Enum<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
@@ -111,6 +113,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {

--- a/tests/expand/default/enum.expanded.rs
+++ b/tests/expand/default/enum.expanded.rs
@@ -114,7 +114,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {

--- a/tests/expand/default/struct.expanded.rs
+++ b/tests/expand/default/struct.expanded.rs
@@ -31,6 +31,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -39,6 +41,8 @@ const _: () = {
         unpinned: &'pin mut (U),
     }
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& Struct> directly rather than this struct*/
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -49,6 +53,8 @@ const _: () = {
     impl<T, U> Struct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -62,6 +68,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/default/struct.expanded.rs
+++ b/tests/expand/default/struct.expanded.rs
@@ -33,6 +33,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -43,6 +44,7 @@ You should however consider passing around a Pin<&mut Struct> directly rather th
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -69,7 +71,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/default/struct.expanded.rs
+++ b/tests/expand/default/struct.expanded.rs
@@ -56,7 +56,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {

--- a/tests/expand/default/tuple_struct.expanded.rs
+++ b/tests/expand/default/tuple_struct.expanded.rs
@@ -29,6 +29,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
@@ -38,6 +39,7 @@ You should however consider passing around a Pin<&mut TupleStruct> directly rath
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),
@@ -63,7 +65,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/default/tuple_struct.expanded.rs
+++ b/tests/expand/default/tuple_struct.expanded.rs
@@ -50,7 +50,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {

--- a/tests/expand/default/tuple_struct.expanded.rs
+++ b/tests/expand/default/tuple_struct.expanded.rs
@@ -27,6 +27,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
@@ -34,6 +36,8 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),
@@ -43,6 +47,8 @@ const _: () = {
     impl<T, U> TupleStruct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -56,6 +62,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/explicit_pub/enum.expanded.rs
+++ b/tests/expand/explicit_pub/enum.expanded.rs
@@ -88,6 +88,8 @@ const _: () = {
     impl<T, U> Enum<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         pub fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
@@ -111,6 +113,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         pub fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {

--- a/tests/expand/explicit_pub/enum.expanded.rs
+++ b/tests/expand/explicit_pub/enum.expanded.rs
@@ -89,7 +89,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         pub fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {

--- a/tests/expand/explicit_pub/enum.expanded.rs
+++ b/tests/expand/explicit_pub/enum.expanded.rs
@@ -114,7 +114,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         pub fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {

--- a/tests/expand/explicit_pub/enum.expanded.rs
+++ b/tests/expand/explicit_pub/enum.expanded.rs
@@ -1,0 +1,170 @@
+use pin_project::pin_project;
+#[pin(__private(pub project = EnumProj, pub project_ref = EnumProjRef))]
+pub enum Enum<T, U> {
+    Struct { #[pin] pinned: T, unpinned: U },
+    Tuple(#[pin] T, U),
+    Unit,
+}
+#[allow(
+    dead_code,
+    deprecated,
+    explicit_outlives_requirements,
+    single_use_lifetimes,
+    unreachable_pub,
+    unused_tuple_struct_fields,
+    clippy::unknown_clippy_lints,
+    clippy::absolute_paths,
+    clippy::min_ident_chars,
+    clippy::pattern_type_mismatch,
+    clippy::pub_with_shorthand,
+    clippy::redundant_pub_crate,
+    clippy::single_char_lifetime_names,
+    clippy::type_repetition_in_bounds,
+    clippy::missing_docs_in_private_items,
+    clippy::mut_mut
+)]
+pub enum EnumProj<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Struct {
+        pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        unpinned: &'pin mut (U),
+    },
+    Tuple(::pin_project::__private::Pin<&'pin mut (T)>, &'pin mut (U)),
+    Unit,
+}
+#[allow(
+    dead_code,
+    deprecated,
+    explicit_outlives_requirements,
+    single_use_lifetimes,
+    unreachable_pub,
+    unused_tuple_struct_fields,
+    clippy::unknown_clippy_lints,
+    clippy::absolute_paths,
+    clippy::min_ident_chars,
+    clippy::pattern_type_mismatch,
+    clippy::pub_with_shorthand,
+    clippy::redundant_pub_crate,
+    clippy::single_char_lifetime_names,
+    clippy::type_repetition_in_bounds,
+    clippy::missing_docs_in_private_items,
+    clippy::ref_option_ref
+)]
+pub enum EnumProjRef<'pin, T, U>
+where
+    Enum<T, U>: 'pin,
+{
+    Struct { pinned: ::pin_project::__private::Pin<&'pin (T)>, unpinned: &'pin (U) },
+    Tuple(::pin_project::__private::Pin<&'pin (T)>, &'pin (U)),
+    Unit,
+}
+#[allow(
+    unused_qualifications,
+    deprecated,
+    explicit_outlives_requirements,
+    single_use_lifetimes,
+    unreachable_pub,
+    unused_tuple_struct_fields,
+    clippy::unknown_clippy_lints,
+    clippy::absolute_paths,
+    clippy::min_ident_chars,
+    clippy::pattern_type_mismatch,
+    clippy::pub_with_shorthand,
+    clippy::redundant_pub_crate,
+    clippy::single_char_lifetime_names,
+    clippy::type_repetition_in_bounds,
+    clippy::elidable_lifetime_names,
+    clippy::missing_const_for_fn,
+    clippy::needless_lifetimes,
+    clippy::semicolon_if_nothing_returned,
+    clippy::use_self,
+    clippy::used_underscore_binding
+)]
+const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
+    impl<T, U> Enum<T, U> {
+        #[allow(dead_code)]
+        #[inline]
+        pub fn project<'pin>(
+            self: _pin_project::__private::Pin<&'pin mut Self>,
+        ) -> EnumProj<'pin, T, U> {
+            unsafe {
+                match self.get_unchecked_mut() {
+                    Self::Struct { pinned, unpinned } => {
+                        EnumProj::Struct {
+                            pinned: _pin_project::__private::Pin::new_unchecked(pinned),
+                            unpinned,
+                        }
+                    }
+                    Self::Tuple(_0, _1) => {
+                        EnumProj::Tuple(
+                            _pin_project::__private::Pin::new_unchecked(_0),
+                            _1,
+                        )
+                    }
+                    Self::Unit => EnumProj::Unit,
+                }
+            }
+        }
+        #[allow(dead_code)]
+        #[inline]
+        pub fn project_ref<'pin>(
+            self: _pin_project::__private::Pin<&'pin Self>,
+        ) -> EnumProjRef<'pin, T, U> {
+            unsafe {
+                match self.get_ref() {
+                    Self::Struct { pinned, unpinned } => {
+                        EnumProjRef::Struct {
+                            pinned: _pin_project::__private::Pin::new_unchecked(pinned),
+                            unpinned,
+                        }
+                    }
+                    Self::Tuple(_0, _1) => {
+                        EnumProjRef::Tuple(
+                            _pin_project::__private::Pin::new_unchecked(_0),
+                            _1,
+                        )
+                    }
+                    Self::Unit => EnumProjRef::Unit,
+                }
+            }
+        }
+    }
+    #[allow(missing_debug_implementations, unnameable_types)]
+    pub struct __Enum<'pin, T, U> {
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
+            'pin,
+            (
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
+            ),
+        >,
+        __field0: T,
+        __field1: T,
+    }
+    impl<'pin, T, U> _pin_project::__private::Unpin for Enum<T, U>
+    where
+        _pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
+    {}
+    #[doc(hidden)]
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Enum<T, U>
+    where
+        _pin_project::__private::PinnedFieldsOf<
+            __Enum<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
+    {}
+    trait EnumMustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: _pin_project::__private::Drop> EnumMustNotImplDrop for T {}
+    impl<T, U> EnumMustNotImplDrop for Enum<T, U> {}
+    #[doc(hidden)]
+    impl<T, U> _pin_project::__private::PinnedDrop for Enum<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
+    }
+};
+fn main() {}

--- a/tests/expand/explicit_pub/enum.rs
+++ b/tests/expand/explicit_pub/enum.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use pin_project::pin_project;
+
+#[pin_project(pub project = EnumProj, pub project_ref = EnumProjRef)]
+pub enum Enum<T, U> {
+    Struct {
+        #[pin]
+        pinned: T,
+        unpinned: U,
+    },
+    Tuple(#[pin] T, U),
+    Unit,
+}
+
+fn main() {}

--- a/tests/expand/explicit_pub/struct.expanded.rs
+++ b/tests/expand/explicit_pub/struct.expanded.rs
@@ -28,6 +28,7 @@ pub struct Struct<T, U> {
 )]
 /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
+#[non_exhaustive]
 pub struct StructProj<'pin, T, U>
 where
     Struct<T, U>: 'pin,
@@ -57,6 +58,7 @@ where
 )]
 /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& Struct> directly rather than this struct*/
+#[non_exhaustive]
 pub(crate) struct StructProjRef<'pin, T, U>
 where
     Struct<T, U>: 'pin,
@@ -110,7 +112,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         pub(crate) fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> StructProjRef<'pin, T, U> {

--- a/tests/expand/explicit_pub/struct.expanded.rs
+++ b/tests/expand/explicit_pub/struct.expanded.rs
@@ -1,0 +1,149 @@
+use pin_project::pin_project;
+#[pin(__private(pub project = StructProj, project_ref = StructProjRef))]
+pub struct Struct<T, U> {
+    #[pin]
+    pub pinned: T,
+    pub unpinned: U,
+}
+#[allow(
+    dead_code,
+    deprecated,
+    explicit_outlives_requirements,
+    single_use_lifetimes,
+    unreachable_pub,
+    unused_tuple_struct_fields,
+    clippy::unknown_clippy_lints,
+    clippy::absolute_paths,
+    clippy::min_ident_chars,
+    clippy::pattern_type_mismatch,
+    clippy::pub_with_shorthand,
+    clippy::redundant_pub_crate,
+    clippy::single_char_lifetime_names,
+    clippy::type_repetition_in_bounds,
+    clippy::missing_docs_in_private_items,
+    clippy::mut_mut
+)]
+pub struct StructProj<'pin, T, U>
+where
+    Struct<T, U>: 'pin,
+{
+    pub pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+    pub unpinned: &'pin mut (U),
+}
+#[allow(
+    dead_code,
+    deprecated,
+    explicit_outlives_requirements,
+    single_use_lifetimes,
+    unreachable_pub,
+    unused_tuple_struct_fields,
+    clippy::unknown_clippy_lints,
+    clippy::absolute_paths,
+    clippy::min_ident_chars,
+    clippy::pattern_type_mismatch,
+    clippy::pub_with_shorthand,
+    clippy::redundant_pub_crate,
+    clippy::single_char_lifetime_names,
+    clippy::type_repetition_in_bounds,
+    clippy::missing_docs_in_private_items,
+    clippy::ref_option_ref
+)]
+pub(crate) struct StructProjRef<'pin, T, U>
+where
+    Struct<T, U>: 'pin,
+{
+    pub pinned: ::pin_project::__private::Pin<&'pin (T)>,
+    pub unpinned: &'pin (U),
+}
+#[allow(
+    unused_qualifications,
+    deprecated,
+    explicit_outlives_requirements,
+    single_use_lifetimes,
+    unreachable_pub,
+    unused_tuple_struct_fields,
+    clippy::unknown_clippy_lints,
+    clippy::absolute_paths,
+    clippy::min_ident_chars,
+    clippy::pattern_type_mismatch,
+    clippy::pub_with_shorthand,
+    clippy::redundant_pub_crate,
+    clippy::single_char_lifetime_names,
+    clippy::type_repetition_in_bounds,
+    clippy::elidable_lifetime_names,
+    clippy::missing_const_for_fn,
+    clippy::needless_lifetimes,
+    clippy::semicolon_if_nothing_returned,
+    clippy::use_self,
+    clippy::used_underscore_binding
+)]
+const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
+    impl<T, U> Struct<T, U> {
+        #[allow(dead_code)]
+        #[inline]
+        pub fn project<'pin>(
+            self: _pin_project::__private::Pin<&'pin mut Self>,
+        ) -> StructProj<'pin, T, U> {
+            unsafe {
+                let Self { pinned, unpinned } = self.get_unchecked_mut();
+                StructProj {
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
+                    unpinned,
+                }
+            }
+        }
+        #[allow(dead_code)]
+        #[inline]
+        pub(crate) fn project_ref<'pin>(
+            self: _pin_project::__private::Pin<&'pin Self>,
+        ) -> StructProjRef<'pin, T, U> {
+            unsafe {
+                let Self { pinned, unpinned } = self.get_ref();
+                StructProjRef {
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
+                    unpinned,
+                }
+            }
+        }
+    }
+    #[forbid(unaligned_references, safe_packed_borrows)]
+    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
+        let _ = &this.pinned;
+        let _ = &this.unpinned;
+    }
+    #[allow(missing_debug_implementations, unnameable_types)]
+    pub struct __Struct<'pin, T, U> {
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
+            'pin,
+            (
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
+            ),
+        >,
+        __field0: T,
+    }
+    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
+    where
+        _pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
+    {}
+    #[doc(hidden)]
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
+    where
+        _pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
+    {}
+    trait StructMustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: _pin_project::__private::Drop> StructMustNotImplDrop for T {}
+    impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
+    #[doc(hidden)]
+    impl<T, U> _pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
+    }
+};
+fn main() {}

--- a/tests/expand/explicit_pub/struct.expanded.rs
+++ b/tests/expand/explicit_pub/struct.expanded.rs
@@ -1,8 +1,11 @@
 use pin_project::pin_project;
+/// Test Struct
 #[pin(__private(pub project = StructProj, project_ref = StructProjRef))]
 pub struct Struct<T, U> {
+    /// Pinned field
     #[pin]
     pub pinned: T,
+    /// UnPinned field
     pub unpinned: U,
 }
 #[allow(
@@ -23,11 +26,15 @@ pub struct Struct<T, U> {
     clippy::missing_docs_in_private_items,
     clippy::mut_mut
 )]
+/**A projected Struct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
 pub struct StructProj<'pin, T, U>
 where
     Struct<T, U>: 'pin,
 {
+    /// Pinned field
     pub pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+    /// UnPinned field
     pub unpinned: &'pin mut (U),
 }
 #[allow(
@@ -48,11 +55,15 @@ where
     clippy::missing_docs_in_private_items,
     clippy::ref_option_ref
 )]
+/**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& Struct> directly rather than this struct*/
 pub(crate) struct StructProjRef<'pin, T, U>
 where
     Struct<T, U>: 'pin,
 {
+    /// Pinned field
     pub pinned: ::pin_project::__private::Pin<&'pin (T)>,
+    /// UnPinned field
     pub unpinned: &'pin (U),
 }
 #[allow(
@@ -83,6 +94,8 @@ const _: () = {
     impl<T, U> Struct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         pub fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> StructProj<'pin, T, U> {
@@ -96,6 +109,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         pub(crate) fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> StructProjRef<'pin, T, U> {

--- a/tests/expand/explicit_pub/struct.expanded.rs
+++ b/tests/expand/explicit_pub/struct.expanded.rs
@@ -97,7 +97,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         pub fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> StructProj<'pin, T, U> {

--- a/tests/expand/explicit_pub/struct.rs
+++ b/tests/expand/explicit_pub/struct.rs
@@ -2,10 +2,13 @@
 
 use pin_project::pin_project;
 
+/// Test Struct
 #[pin_project(pub project = StructProj, project_ref = StructProjRef)]
 pub struct Struct<T, U> {
+    /// Pinned field
     #[pin]
     pub pinned: T,
+    /// UnPinned field
     pub unpinned: U,
 }
 

--- a/tests/expand/explicit_pub/struct.rs
+++ b/tests/expand/explicit_pub/struct.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use pin_project::pin_project;
+
+#[pin_project(pub project = StructProj, project_ref = StructProjRef)]
+pub struct Struct<T, U> {
+    #[pin]
+    pub pinned: T,
+    pub unpinned: U,
+}
+
+fn main() {}

--- a/tests/expand/explicit_pub/struct_replace.expanded.rs
+++ b/tests/expand/explicit_pub/struct_replace.expanded.rs
@@ -23,6 +23,7 @@ pub struct Struct<T, U> {
     clippy::missing_docs_in_private_items
 )]
 ///A projection that own a Struct.
+#[non_exhaustive]
 pub struct StructProjReplace<T, U> {
     pub pinned: ::pin_project::__private::PhantomData<T>,
     pub unpinned: U,
@@ -55,6 +56,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
+    #[non_exhaustive]
     pub(crate) struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -65,6 +67,7 @@ You should however consider passing around a Pin<&mut Struct> directly rather th
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& Struct> directly rather than this struct*/
+    #[non_exhaustive]
     pub(crate) struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -91,7 +94,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         pub(crate) fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/explicit_pub/struct_replace.expanded.rs
+++ b/tests/expand/explicit_pub/struct_replace.expanded.rs
@@ -22,6 +22,7 @@ pub struct Struct<T, U> {
     clippy::type_repetition_in_bounds,
     clippy::missing_docs_in_private_items
 )]
+///A projection that own a Struct.
 pub struct StructProjReplace<T, U> {
     pub pinned: ::pin_project::__private::PhantomData<T>,
     pub unpinned: U,
@@ -52,6 +53,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
     pub(crate) struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -60,6 +63,8 @@ const _: () = {
         pub unpinned: &'pin mut (U),
     }
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& Struct> directly rather than this struct*/
     pub(crate) struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -70,6 +75,8 @@ const _: () = {
     impl<T, U> Struct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         pub(crate) fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -83,6 +90,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         pub(crate) fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
@@ -96,6 +105,7 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        ///Take a Pin<&mut Struct>, and a replacement. Replace the pinned Struct and return an owning projection
         pub fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/explicit_pub/struct_replace.expanded.rs
+++ b/tests/expand/explicit_pub/struct_replace.expanded.rs
@@ -1,0 +1,161 @@
+use pin_project::pin_project;
+#[pin(__private(pub project_replace = StructProjReplace))]
+pub struct Struct<T, U> {
+    #[pin]
+    pub pinned: T,
+    pub unpinned: U,
+}
+#[allow(
+    dead_code,
+    deprecated,
+    explicit_outlives_requirements,
+    single_use_lifetimes,
+    unreachable_pub,
+    unused_tuple_struct_fields,
+    clippy::unknown_clippy_lints,
+    clippy::absolute_paths,
+    clippy::min_ident_chars,
+    clippy::pattern_type_mismatch,
+    clippy::pub_with_shorthand,
+    clippy::redundant_pub_crate,
+    clippy::single_char_lifetime_names,
+    clippy::type_repetition_in_bounds,
+    clippy::missing_docs_in_private_items
+)]
+pub struct StructProjReplace<T, U> {
+    pub pinned: ::pin_project::__private::PhantomData<T>,
+    pub unpinned: U,
+}
+#[allow(
+    unused_qualifications,
+    deprecated,
+    explicit_outlives_requirements,
+    single_use_lifetimes,
+    unreachable_pub,
+    unused_tuple_struct_fields,
+    clippy::unknown_clippy_lints,
+    clippy::absolute_paths,
+    clippy::min_ident_chars,
+    clippy::pattern_type_mismatch,
+    clippy::pub_with_shorthand,
+    clippy::redundant_pub_crate,
+    clippy::single_char_lifetime_names,
+    clippy::type_repetition_in_bounds,
+    clippy::elidable_lifetime_names,
+    clippy::missing_const_for_fn,
+    clippy::needless_lifetimes,
+    clippy::semicolon_if_nothing_returned,
+    clippy::use_self,
+    clippy::used_underscore_binding
+)]
+const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
+    #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    pub(crate) struct __StructProjection<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pub pinned: ::pin_project::__private::Pin<&'pin mut (T)>,
+        pub unpinned: &'pin mut (U),
+    }
+    #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    pub(crate) struct __StructProjectionRef<'pin, T, U>
+    where
+        Struct<T, U>: 'pin,
+    {
+        pub pinned: ::pin_project::__private::Pin<&'pin (T)>,
+        pub unpinned: &'pin (U),
+    }
+    impl<T, U> Struct<T, U> {
+        #[allow(dead_code)]
+        #[inline]
+        pub(crate) fn project<'pin>(
+            self: _pin_project::__private::Pin<&'pin mut Self>,
+        ) -> __StructProjection<'pin, T, U> {
+            unsafe {
+                let Self { pinned, unpinned } = self.get_unchecked_mut();
+                __StructProjection {
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
+                    unpinned,
+                }
+            }
+        }
+        #[allow(dead_code)]
+        #[inline]
+        pub(crate) fn project_ref<'pin>(
+            self: _pin_project::__private::Pin<&'pin Self>,
+        ) -> __StructProjectionRef<'pin, T, U> {
+            unsafe {
+                let Self { pinned, unpinned } = self.get_ref();
+                __StructProjectionRef {
+                    pinned: _pin_project::__private::Pin::new_unchecked(pinned),
+                    unpinned,
+                }
+            }
+        }
+        #[allow(dead_code)]
+        #[inline]
+        pub fn project_replace(
+            self: _pin_project::__private::Pin<&mut Self>,
+            __replacement: Self,
+        ) -> StructProjReplace<T, U> {
+            unsafe {
+                let __self_ptr: *mut Self = self.get_unchecked_mut();
+                let __guard = _pin_project::__private::UnsafeOverwriteGuard::new(
+                    __self_ptr,
+                    __replacement,
+                );
+                let Self { pinned, unpinned } = &mut *__self_ptr;
+                let __result = StructProjReplace {
+                    pinned: _pin_project::__private::PhantomData,
+                    unpinned: _pin_project::__private::ptr::read(unpinned),
+                };
+                {
+                    let __guard = _pin_project::__private::UnsafeDropInPlaceGuard::new(
+                        pinned,
+                    );
+                }
+                __result
+            }
+        }
+    }
+    #[forbid(unaligned_references, safe_packed_borrows)]
+    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
+        let _ = &this.pinned;
+        let _ = &this.unpinned;
+    }
+    #[allow(missing_debug_implementations, unnameable_types)]
+    pub struct __Struct<'pin, T, U> {
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
+            'pin,
+            (
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
+            ),
+        >,
+        __field0: T,
+    }
+    impl<'pin, T, U> _pin_project::__private::Unpin for Struct<T, U>
+    where
+        _pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
+    {}
+    #[doc(hidden)]
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for Struct<T, U>
+    where
+        _pin_project::__private::PinnedFieldsOf<
+            __Struct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
+    {}
+    trait StructMustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: _pin_project::__private::Drop> StructMustNotImplDrop for T {}
+    impl<T, U> StructMustNotImplDrop for Struct<T, U> {}
+    #[doc(hidden)]
+    impl<T, U> _pin_project::__private::PinnedDrop for Struct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
+    }
+};
+fn main() {}

--- a/tests/expand/explicit_pub/struct_replace.expanded.rs
+++ b/tests/expand/explicit_pub/struct_replace.expanded.rs
@@ -79,7 +79,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         pub(crate) fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {

--- a/tests/expand/explicit_pub/struct_replace.rs
+++ b/tests/expand/explicit_pub/struct_replace.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use pin_project::pin_project;
+
+#[pin_project(pub project_replace = StructProjReplace)]
+pub struct Struct<T, U> {
+    #[pin]
+    pub pinned: T,
+    pub unpinned: U,
+}
+
+fn main() {}

--- a/tests/expand/explicit_pub/tuple_struct.expanded.rs
+++ b/tests/expand/explicit_pub/tuple_struct.expanded.rs
@@ -1,0 +1,123 @@
+use pin_project::pin_project;
+#[pin(__private(pub project = TupleStructProj))]
+pub struct TupleStruct<T, U>(#[pin] pub T, pub U);
+#[allow(
+    dead_code,
+    deprecated,
+    explicit_outlives_requirements,
+    single_use_lifetimes,
+    unreachable_pub,
+    unused_tuple_struct_fields,
+    clippy::unknown_clippy_lints,
+    clippy::absolute_paths,
+    clippy::min_ident_chars,
+    clippy::pattern_type_mismatch,
+    clippy::pub_with_shorthand,
+    clippy::redundant_pub_crate,
+    clippy::single_char_lifetime_names,
+    clippy::type_repetition_in_bounds,
+    clippy::missing_docs_in_private_items,
+    clippy::mut_mut
+)]
+pub struct TupleStructProj<'pin, T, U>(
+    pub ::pin_project::__private::Pin<&'pin mut (T)>,
+    pub &'pin mut (U),
+)
+where
+    TupleStruct<T, U>: 'pin;
+#[allow(
+    unused_qualifications,
+    deprecated,
+    explicit_outlives_requirements,
+    single_use_lifetimes,
+    unreachable_pub,
+    unused_tuple_struct_fields,
+    clippy::unknown_clippy_lints,
+    clippy::absolute_paths,
+    clippy::min_ident_chars,
+    clippy::pattern_type_mismatch,
+    clippy::pub_with_shorthand,
+    clippy::redundant_pub_crate,
+    clippy::single_char_lifetime_names,
+    clippy::type_repetition_in_bounds,
+    clippy::elidable_lifetime_names,
+    clippy::missing_const_for_fn,
+    clippy::needless_lifetimes,
+    clippy::semicolon_if_nothing_returned,
+    clippy::use_self,
+    clippy::used_underscore_binding
+)]
+const _: () = {
+    #[allow(unused_extern_crates)]
+    extern crate pin_project as _pin_project;
+    #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    pub(crate) struct __TupleStructProjectionRef<'pin, T, U>(
+        pub ::pin_project::__private::Pin<&'pin (T)>,
+        pub &'pin (U),
+    )
+    where
+        TupleStruct<T, U>: 'pin;
+    impl<T, U> TupleStruct<T, U> {
+        #[allow(dead_code)]
+        #[inline]
+        pub fn project<'pin>(
+            self: _pin_project::__private::Pin<&'pin mut Self>,
+        ) -> TupleStructProj<'pin, T, U> {
+            unsafe {
+                let Self(_0, _1) = self.get_unchecked_mut();
+                TupleStructProj(_pin_project::__private::Pin::new_unchecked(_0), _1)
+            }
+        }
+        #[allow(dead_code)]
+        #[inline]
+        pub(crate) fn project_ref<'pin>(
+            self: _pin_project::__private::Pin<&'pin Self>,
+        ) -> __TupleStructProjectionRef<'pin, T, U> {
+            unsafe {
+                let Self(_0, _1) = self.get_ref();
+                __TupleStructProjectionRef(
+                    _pin_project::__private::Pin::new_unchecked(_0),
+                    _1,
+                )
+            }
+        }
+    }
+    #[forbid(unaligned_references, safe_packed_borrows)]
+    fn __assert_not_repr_packed<T, U>(this: &TupleStruct<T, U>) {
+        let _ = &this.0;
+        let _ = &this.1;
+    }
+    #[allow(missing_debug_implementations, unnameable_types)]
+    pub struct __TupleStruct<'pin, T, U> {
+        __pin_project_use_generics: _pin_project::__private::AlwaysUnpin<
+            'pin,
+            (
+                _pin_project::__private::PhantomData<T>,
+                _pin_project::__private::PhantomData<U>,
+            ),
+        >,
+        __field0: T,
+    }
+    impl<'pin, T, U> _pin_project::__private::Unpin for TupleStruct<T, U>
+    where
+        _pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
+    {}
+    #[doc(hidden)]
+    unsafe impl<'pin, T, U> _pin_project::UnsafeUnpin for TupleStruct<T, U>
+    where
+        _pin_project::__private::PinnedFieldsOf<
+            __TupleStruct<'pin, T, U>,
+        >: _pin_project::__private::Unpin,
+    {}
+    trait TupleStructMustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: _pin_project::__private::Drop> TupleStructMustNotImplDrop for T {}
+    impl<T, U> TupleStructMustNotImplDrop for TupleStruct<T, U> {}
+    #[doc(hidden)]
+    impl<T, U> _pin_project::__private::PinnedDrop for TupleStruct<T, U> {
+        unsafe fn drop(self: _pin_project::__private::Pin<&mut Self>) {}
+    }
+};
+fn main() {}

--- a/tests/expand/explicit_pub/tuple_struct.expanded.rs
+++ b/tests/expand/explicit_pub/tuple_struct.expanded.rs
@@ -67,7 +67,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         pub fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> TupleStructProj<'pin, T, U> {

--- a/tests/expand/explicit_pub/tuple_struct.expanded.rs
+++ b/tests/expand/explicit_pub/tuple_struct.expanded.rs
@@ -19,6 +19,8 @@ pub struct TupleStruct<T, U>(#[pin] pub T, pub U);
     clippy::missing_docs_in_private_items,
     clippy::mut_mut
 )]
+/**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
 pub struct TupleStructProj<'pin, T, U>(
     pub ::pin_project::__private::Pin<&'pin mut (T)>,
     pub &'pin mut (U),
@@ -51,6 +53,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
     pub(crate) struct __TupleStructProjectionRef<'pin, T, U>(
         pub ::pin_project::__private::Pin<&'pin (T)>,
         pub &'pin (U),
@@ -60,6 +64,8 @@ const _: () = {
     impl<T, U> TupleStruct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         pub fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> TupleStructProj<'pin, T, U> {
@@ -70,6 +76,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         pub(crate) fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/explicit_pub/tuple_struct.expanded.rs
+++ b/tests/expand/explicit_pub/tuple_struct.expanded.rs
@@ -21,6 +21,7 @@ pub struct TupleStruct<T, U>(#[pin] pub T, pub U);
 )]
 /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
+#[non_exhaustive]
 pub struct TupleStructProj<'pin, T, U>(
     pub ::pin_project::__private::Pin<&'pin mut (T)>,
     pub &'pin mut (U),
@@ -55,6 +56,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     pub(crate) struct __TupleStructProjectionRef<'pin, T, U>(
         pub ::pin_project::__private::Pin<&'pin (T)>,
         pub &'pin (U),
@@ -77,7 +79,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         pub(crate) fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/explicit_pub/tuple_struct.rs
+++ b/tests/expand/explicit_pub/tuple_struct.rs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use pin_project::pin_project;
+
+#[pin_project(pub project = TupleStructProj)]
+pub struct TupleStruct<T, U>(#[pin] pub T, pub U);
+
+fn main() {}

--- a/tests/expand/multifields/enum.expanded.rs
+++ b/tests/expand/multifields/enum.expanded.rs
@@ -145,6 +145,8 @@ const _: () = {
     impl<T, U> Enum<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
@@ -176,6 +178,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {
@@ -207,6 +211,7 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        ///Take a Pin<&mut Enum>, and a replacement. Replace the pinned Enum and return an owning projection
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/multifields/enum.expanded.rs
+++ b/tests/expand/multifields/enum.expanded.rs
@@ -179,7 +179,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {

--- a/tests/expand/multifields/enum.expanded.rs
+++ b/tests/expand/multifields/enum.expanded.rs
@@ -146,7 +146,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {

--- a/tests/expand/multifields/struct.expanded.rs
+++ b/tests/expand/multifields/struct.expanded.rs
@@ -72,7 +72,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {

--- a/tests/expand/multifields/struct.expanded.rs
+++ b/tests/expand/multifields/struct.expanded.rs
@@ -34,6 +34,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -44,6 +46,8 @@ const _: () = {
         unpinned2: &'pin mut (U),
     }
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& Struct> directly rather than this struct*/
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -54,6 +58,7 @@ const _: () = {
         unpinned2: &'pin (U),
     }
     #[allow(dead_code, clippy::missing_docs_in_private_items)]
+    ///A projection that own a Struct.
     struct __StructProjectionOwned<T, U> {
         pinned1: ::pin_project::__private::PhantomData<T>,
         pinned2: ::pin_project::__private::PhantomData<T>,
@@ -63,6 +68,8 @@ const _: () = {
     impl<T, U> Struct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -79,6 +86,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
@@ -94,6 +103,7 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        ///Take a Pin<&mut Struct>, and a replacement. Replace the pinned Struct and return an owning projection
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/multifields/struct.expanded.rs
+++ b/tests/expand/multifields/struct.expanded.rs
@@ -36,6 +36,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -48,6 +49,7 @@ You should however consider passing around a Pin<&mut Struct> directly rather th
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -59,6 +61,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
     }
     #[allow(dead_code, clippy::missing_docs_in_private_items)]
     ///A projection that own a Struct.
+    #[non_exhaustive]
     struct __StructProjectionOwned<T, U> {
         pinned1: ::pin_project::__private::PhantomData<T>,
         pinned2: ::pin_project::__private::PhantomData<T>,
@@ -87,7 +90,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/multifields/tuple_struct.expanded.rs
+++ b/tests/expand/multifields/tuple_struct.expanded.rs
@@ -29,6 +29,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         ::pin_project::__private::Pin<&'pin mut (T)>,
@@ -40,6 +41,7 @@ You should however consider passing around a Pin<&mut TupleStruct> directly rath
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         ::pin_project::__private::Pin<&'pin (T)>,
@@ -50,6 +52,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         TupleStruct<T, U>: 'pin;
     #[allow(dead_code, clippy::missing_docs_in_private_items)]
     ///A projection that own a TupleStruct.
+    #[non_exhaustive]
     struct __TupleStructProjectionOwned<T, U>(
         ::pin_project::__private::PhantomData<T>,
         ::pin_project::__private::PhantomData<T>,
@@ -77,7 +80,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/multifields/tuple_struct.expanded.rs
+++ b/tests/expand/multifields/tuple_struct.expanded.rs
@@ -63,7 +63,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {

--- a/tests/expand/multifields/tuple_struct.expanded.rs
+++ b/tests/expand/multifields/tuple_struct.expanded.rs
@@ -27,6 +27,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         ::pin_project::__private::Pin<&'pin mut (T)>,
@@ -36,6 +38,8 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         ::pin_project::__private::Pin<&'pin (T)>,
@@ -45,6 +49,7 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     #[allow(dead_code, clippy::missing_docs_in_private_items)]
+    ///A projection that own a TupleStruct.
     struct __TupleStructProjectionOwned<T, U>(
         ::pin_project::__private::PhantomData<T>,
         ::pin_project::__private::PhantomData<T>,
@@ -54,6 +59,8 @@ const _: () = {
     impl<T, U> TupleStruct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -69,6 +76,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
@@ -84,6 +93,7 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        ///Take a Pin<&mut TupleStruct>, and a replacement. Replace the pinned TupleStruct and return an owning projection
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/naming/enum-all.expanded.rs
+++ b/tests/expand/naming/enum-all.expanded.rs
@@ -135,7 +135,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {

--- a/tests/expand/naming/enum-all.expanded.rs
+++ b/tests/expand/naming/enum-all.expanded.rs
@@ -112,6 +112,8 @@ const _: () = {
     impl<T, U> Enum<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {
@@ -132,6 +134,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {
@@ -155,6 +159,7 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        ///Take a Pin<&mut Enum>, and a replacement. Replace the pinned Enum and return an owning projection
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/naming/enum-all.expanded.rs
+++ b/tests/expand/naming/enum-all.expanded.rs
@@ -113,7 +113,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {

--- a/tests/expand/naming/enum-mut.expanded.rs
+++ b/tests/expand/naming/enum-mut.expanded.rs
@@ -63,7 +63,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {

--- a/tests/expand/naming/enum-mut.expanded.rs
+++ b/tests/expand/naming/enum-mut.expanded.rs
@@ -62,6 +62,8 @@ const _: () = {
     impl<T, U> Enum<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {

--- a/tests/expand/naming/enum-own.expanded.rs
+++ b/tests/expand/naming/enum-own.expanded.rs
@@ -57,6 +57,7 @@ const _: () = {
     impl<T, U> Enum<T, U> {
         #[allow(dead_code)]
         #[inline]
+        ///Take a Pin<&mut Enum>, and a replacement. Replace the pinned Enum and return an owning projection
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/naming/enum-ref.expanded.rs
+++ b/tests/expand/naming/enum-ref.expanded.rs
@@ -59,6 +59,8 @@ const _: () = {
     impl<T, U> Enum<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {

--- a/tests/expand/naming/enum-ref.expanded.rs
+++ b/tests/expand/naming/enum-ref.expanded.rs
@@ -60,7 +60,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {

--- a/tests/expand/naming/struct-all.expanded.rs
+++ b/tests/expand/naming/struct-all.expanded.rs
@@ -25,6 +25,7 @@ struct Struct<T, U> {
 )]
 /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
+#[non_exhaustive]
 struct Proj<'pin, T, U>
 where
     Struct<T, U>: 'pin,
@@ -52,6 +53,7 @@ where
 )]
 /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& Struct> directly rather than this struct*/
+#[non_exhaustive]
 struct ProjRef<'pin, T, U>
 where
     Struct<T, U>: 'pin,
@@ -77,6 +79,7 @@ where
     clippy::missing_docs_in_private_items
 )]
 ///A projection that own a Struct.
+#[non_exhaustive]
 struct ProjOwn<T, U> {
     pinned: ::pin_project::__private::PhantomData<T>,
     unpinned: U,
@@ -125,7 +128,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {

--- a/tests/expand/naming/struct-all.expanded.rs
+++ b/tests/expand/naming/struct-all.expanded.rs
@@ -113,7 +113,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {

--- a/tests/expand/naming/struct-all.expanded.rs
+++ b/tests/expand/naming/struct-all.expanded.rs
@@ -23,6 +23,8 @@ struct Struct<T, U> {
     clippy::missing_docs_in_private_items,
     clippy::mut_mut
 )]
+/**A projected Struct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
 struct Proj<'pin, T, U>
 where
     Struct<T, U>: 'pin,
@@ -48,6 +50,8 @@ where
     clippy::missing_docs_in_private_items,
     clippy::ref_option_ref
 )]
+/**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& Struct> directly rather than this struct*/
 struct ProjRef<'pin, T, U>
 where
     Struct<T, U>: 'pin,
@@ -72,6 +76,7 @@ where
     clippy::type_repetition_in_bounds,
     clippy::missing_docs_in_private_items
 )]
+///A projection that own a Struct.
 struct ProjOwn<T, U> {
     pinned: ::pin_project::__private::PhantomData<T>,
     unpinned: U,
@@ -104,6 +109,8 @@ const _: () = {
     impl<T, U> Struct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {
@@ -117,6 +124,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {
@@ -130,6 +139,7 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        ///Take a Pin<&mut Struct>, and a replacement. Replace the pinned Struct and return an owning projection
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/naming/struct-mut.expanded.rs
+++ b/tests/expand/naming/struct-mut.expanded.rs
@@ -73,7 +73,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {

--- a/tests/expand/naming/struct-mut.expanded.rs
+++ b/tests/expand/naming/struct-mut.expanded.rs
@@ -23,6 +23,8 @@ struct Struct<T, U> {
     clippy::missing_docs_in_private_items,
     clippy::mut_mut
 )]
+/**A projected Struct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
 struct Proj<'pin, T, U>
 where
     Struct<T, U>: 'pin,
@@ -56,6 +58,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& Struct> directly rather than this struct*/
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -66,6 +70,8 @@ const _: () = {
     impl<T, U> Struct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {
@@ -79,6 +85,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/naming/struct-mut.expanded.rs
+++ b/tests/expand/naming/struct-mut.expanded.rs
@@ -25,6 +25,7 @@ struct Struct<T, U> {
 )]
 /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
+#[non_exhaustive]
 struct Proj<'pin, T, U>
 where
     Struct<T, U>: 'pin,
@@ -60,6 +61,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -86,7 +88,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/naming/struct-none.expanded.rs
+++ b/tests/expand/naming/struct-none.expanded.rs
@@ -31,6 +31,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -39,6 +41,8 @@ const _: () = {
         unpinned: &'pin mut (U),
     }
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& Struct> directly rather than this struct*/
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -49,6 +53,8 @@ const _: () = {
     impl<T, U> Struct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -62,6 +68,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/naming/struct-none.expanded.rs
+++ b/tests/expand/naming/struct-none.expanded.rs
@@ -33,6 +33,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -43,6 +44,7 @@ You should however consider passing around a Pin<&mut Struct> directly rather th
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -69,7 +71,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/naming/struct-none.expanded.rs
+++ b/tests/expand/naming/struct-none.expanded.rs
@@ -56,7 +56,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {

--- a/tests/expand/naming/struct-own.expanded.rs
+++ b/tests/expand/naming/struct-own.expanded.rs
@@ -22,6 +22,7 @@ struct Struct<T, U> {
     clippy::type_repetition_in_bounds,
     clippy::missing_docs_in_private_items
 )]
+///A projection that own a Struct.
 struct ProjOwn<T, U> {
     pinned: ::pin_project::__private::PhantomData<T>,
     unpinned: U,
@@ -52,6 +53,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -60,6 +63,8 @@ const _: () = {
         unpinned: &'pin mut (U),
     }
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& Struct> directly rather than this struct*/
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -70,6 +75,8 @@ const _: () = {
     impl<T, U> Struct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -83,6 +90,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
@@ -96,6 +105,7 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        ///Take a Pin<&mut Struct>, and a replacement. Replace the pinned Struct and return an owning projection
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/naming/struct-own.expanded.rs
+++ b/tests/expand/naming/struct-own.expanded.rs
@@ -79,7 +79,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {

--- a/tests/expand/naming/struct-own.expanded.rs
+++ b/tests/expand/naming/struct-own.expanded.rs
@@ -23,6 +23,7 @@ struct Struct<T, U> {
     clippy::missing_docs_in_private_items
 )]
 ///A projection that own a Struct.
+#[non_exhaustive]
 struct ProjOwn<T, U> {
     pinned: ::pin_project::__private::PhantomData<T>,
     unpinned: U,
@@ -55,6 +56,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -65,6 +67,7 @@ You should however consider passing around a Pin<&mut Struct> directly rather th
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -91,7 +94,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/naming/struct-ref.expanded.rs
+++ b/tests/expand/naming/struct-ref.expanded.rs
@@ -23,6 +23,8 @@ struct Struct<T, U> {
     clippy::missing_docs_in_private_items,
     clippy::ref_option_ref
 )]
+/**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& Struct> directly rather than this struct*/
 struct ProjRef<'pin, T, U>
 where
     Struct<T, U>: 'pin,
@@ -56,6 +58,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -66,6 +70,8 @@ const _: () = {
     impl<T, U> Struct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -79,6 +85,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {

--- a/tests/expand/naming/struct-ref.expanded.rs
+++ b/tests/expand/naming/struct-ref.expanded.rs
@@ -25,6 +25,7 @@ struct Struct<T, U> {
 )]
 /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& Struct> directly rather than this struct*/
+#[non_exhaustive]
 struct ProjRef<'pin, T, U>
 where
     Struct<T, U>: 'pin,
@@ -60,6 +61,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -86,7 +88,7 @@ You should however consider passing around a Pin<&mut Struct> directly rather th
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {

--- a/tests/expand/naming/struct-ref.expanded.rs
+++ b/tests/expand/naming/struct-ref.expanded.rs
@@ -73,7 +73,7 @@ You should however consider passing around a Pin<&mut Struct> directly rather th
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {

--- a/tests/expand/naming/tuple_struct-all.expanded.rs
+++ b/tests/expand/naming/tuple_struct-all.expanded.rs
@@ -19,6 +19,8 @@ struct TupleStruct<T, U>(#[pin] T, U);
     clippy::missing_docs_in_private_items,
     clippy::mut_mut
 )]
+/**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
 struct Proj<'pin, T, U>(
     ::pin_project::__private::Pin<&'pin mut (T)>,
     &'pin mut (U),
@@ -43,6 +45,8 @@ where
     clippy::missing_docs_in_private_items,
     clippy::ref_option_ref
 )]
+/**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
 struct ProjRef<'pin, T, U>(
     ::pin_project::__private::Pin<&'pin (T)>,
     &'pin (U),
@@ -66,6 +70,7 @@ where
     clippy::type_repetition_in_bounds,
     clippy::missing_docs_in_private_items
 )]
+///A projection that own a TupleStruct.
 struct ProjOwn<T, U>(::pin_project::__private::PhantomData<T>, U);
 #[allow(
     unused_qualifications,
@@ -95,6 +100,8 @@ const _: () = {
     impl<T, U> TupleStruct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {
@@ -105,6 +112,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {
@@ -115,6 +124,7 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        ///Take a Pin<&mut TupleStruct>, and a replacement. Replace the pinned TupleStruct and return an owning projection
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/naming/tuple_struct-all.expanded.rs
+++ b/tests/expand/naming/tuple_struct-all.expanded.rs
@@ -21,6 +21,7 @@ struct TupleStruct<T, U>(#[pin] T, U);
 )]
 /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
+#[non_exhaustive]
 struct Proj<'pin, T, U>(
     ::pin_project::__private::Pin<&'pin mut (T)>,
     &'pin mut (U),
@@ -47,6 +48,7 @@ where
 )]
 /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
+#[non_exhaustive]
 struct ProjRef<'pin, T, U>(
     ::pin_project::__private::Pin<&'pin (T)>,
     &'pin (U),
@@ -71,6 +73,7 @@ where
     clippy::missing_docs_in_private_items
 )]
 ///A projection that own a TupleStruct.
+#[non_exhaustive]
 struct ProjOwn<T, U>(::pin_project::__private::PhantomData<T>, U);
 #[allow(
     unused_qualifications,
@@ -113,7 +116,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {

--- a/tests/expand/naming/tuple_struct-all.expanded.rs
+++ b/tests/expand/naming/tuple_struct-all.expanded.rs
@@ -104,7 +104,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {

--- a/tests/expand/naming/tuple_struct-mut.expanded.rs
+++ b/tests/expand/naming/tuple_struct-mut.expanded.rs
@@ -67,7 +67,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {

--- a/tests/expand/naming/tuple_struct-mut.expanded.rs
+++ b/tests/expand/naming/tuple_struct-mut.expanded.rs
@@ -19,6 +19,8 @@ struct TupleStruct<T, U>(#[pin] T, U);
     clippy::missing_docs_in_private_items,
     clippy::mut_mut
 )]
+/**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
 struct Proj<'pin, T, U>(
     ::pin_project::__private::Pin<&'pin mut (T)>,
     &'pin mut (U),
@@ -51,6 +53,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),
@@ -60,6 +64,8 @@ const _: () = {
     impl<T, U> TupleStruct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> Proj<'pin, T, U> {
@@ -70,6 +76,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/naming/tuple_struct-mut.expanded.rs
+++ b/tests/expand/naming/tuple_struct-mut.expanded.rs
@@ -21,6 +21,7 @@ struct TupleStruct<T, U>(#[pin] T, U);
 )]
 /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
+#[non_exhaustive]
 struct Proj<'pin, T, U>(
     ::pin_project::__private::Pin<&'pin mut (T)>,
     &'pin mut (U),
@@ -55,6 +56,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),
@@ -77,7 +79,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/naming/tuple_struct-none.expanded.rs
+++ b/tests/expand/naming/tuple_struct-none.expanded.rs
@@ -29,6 +29,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
@@ -38,6 +39,7 @@ You should however consider passing around a Pin<&mut TupleStruct> directly rath
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),
@@ -63,7 +65,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/naming/tuple_struct-none.expanded.rs
+++ b/tests/expand/naming/tuple_struct-none.expanded.rs
@@ -50,7 +50,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {

--- a/tests/expand/naming/tuple_struct-none.expanded.rs
+++ b/tests/expand/naming/tuple_struct-none.expanded.rs
@@ -27,6 +27,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
@@ -34,6 +36,8 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),
@@ -43,6 +47,8 @@ const _: () = {
     impl<T, U> TupleStruct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -56,6 +62,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/naming/tuple_struct-own.expanded.rs
+++ b/tests/expand/naming/tuple_struct-own.expanded.rs
@@ -18,6 +18,7 @@ struct TupleStruct<T, U>(#[pin] T, U);
     clippy::type_repetition_in_bounds,
     clippy::missing_docs_in_private_items
 )]
+///A projection that own a TupleStruct.
 struct ProjOwn<T, U>(::pin_project::__private::PhantomData<T>, U);
 #[allow(
     unused_qualifications,
@@ -45,6 +46,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
@@ -52,6 +55,8 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),
@@ -61,6 +66,8 @@ const _: () = {
     impl<T, U> TupleStruct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -74,6 +81,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
@@ -87,6 +96,7 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        ///Take a Pin<&mut TupleStruct>, and a replacement. Replace the pinned TupleStruct and return an owning projection
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/naming/tuple_struct-own.expanded.rs
+++ b/tests/expand/naming/tuple_struct-own.expanded.rs
@@ -70,7 +70,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {

--- a/tests/expand/naming/tuple_struct-own.expanded.rs
+++ b/tests/expand/naming/tuple_struct-own.expanded.rs
@@ -19,6 +19,7 @@ struct TupleStruct<T, U>(#[pin] T, U);
     clippy::missing_docs_in_private_items
 )]
 ///A projection that own a TupleStruct.
+#[non_exhaustive]
 struct ProjOwn<T, U>(::pin_project::__private::PhantomData<T>, U);
 #[allow(
     unused_qualifications,
@@ -48,6 +49,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
@@ -57,6 +59,7 @@ You should however consider passing around a Pin<&mut TupleStruct> directly rath
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),
@@ -82,7 +85,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/naming/tuple_struct-ref.expanded.rs
+++ b/tests/expand/naming/tuple_struct-ref.expanded.rs
@@ -21,6 +21,7 @@ struct TupleStruct<T, U>(#[pin] T, U);
 )]
 /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
+#[non_exhaustive]
 struct ProjRef<'pin, T, U>(
     ::pin_project::__private::Pin<&'pin (T)>,
     &'pin (U),
@@ -55,6 +56,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
@@ -80,7 +82,7 @@ You should however consider passing around a Pin<&mut TupleStruct> directly rath
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {

--- a/tests/expand/naming/tuple_struct-ref.expanded.rs
+++ b/tests/expand/naming/tuple_struct-ref.expanded.rs
@@ -19,6 +19,8 @@ struct TupleStruct<T, U>(#[pin] T, U);
     clippy::missing_docs_in_private_items,
     clippy::ref_option_ref
 )]
+/**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
 struct ProjRef<'pin, T, U>(
     ::pin_project::__private::Pin<&'pin (T)>,
     &'pin (U),
@@ -51,6 +53,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
@@ -60,6 +64,8 @@ const _: () = {
     impl<T, U> TupleStruct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -73,6 +79,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> ProjRef<'pin, T, U> {

--- a/tests/expand/naming/tuple_struct-ref.expanded.rs
+++ b/tests/expand/naming/tuple_struct-ref.expanded.rs
@@ -67,7 +67,7 @@ You should however consider passing around a Pin<&mut TupleStruct> directly rath
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {

--- a/tests/expand/not_unpin/enum.expanded.rs
+++ b/tests/expand/not_unpin/enum.expanded.rs
@@ -89,7 +89,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {

--- a/tests/expand/not_unpin/enum.expanded.rs
+++ b/tests/expand/not_unpin/enum.expanded.rs
@@ -88,6 +88,8 @@ const _: () = {
     impl<T, U> Enum<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
@@ -111,6 +113,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {

--- a/tests/expand/not_unpin/enum.expanded.rs
+++ b/tests/expand/not_unpin/enum.expanded.rs
@@ -114,7 +114,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {

--- a/tests/expand/not_unpin/struct.expanded.rs
+++ b/tests/expand/not_unpin/struct.expanded.rs
@@ -31,6 +31,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -39,6 +41,8 @@ const _: () = {
         unpinned: &'pin mut (U),
     }
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& Struct> directly rather than this struct*/
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -49,6 +53,8 @@ const _: () = {
     impl<T, U> Struct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -62,6 +68,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/not_unpin/struct.expanded.rs
+++ b/tests/expand/not_unpin/struct.expanded.rs
@@ -33,6 +33,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -43,6 +44,7 @@ You should however consider passing around a Pin<&mut Struct> directly rather th
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -69,7 +71,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/not_unpin/struct.expanded.rs
+++ b/tests/expand/not_unpin/struct.expanded.rs
@@ -56,7 +56,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {

--- a/tests/expand/not_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/not_unpin/tuple_struct.expanded.rs
@@ -29,6 +29,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
@@ -38,6 +39,7 @@ You should however consider passing around a Pin<&mut TupleStruct> directly rath
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),
@@ -63,7 +65,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/not_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/not_unpin/tuple_struct.expanded.rs
@@ -50,7 +50,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {

--- a/tests/expand/not_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/not_unpin/tuple_struct.expanded.rs
@@ -27,6 +27,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
@@ -34,6 +36,8 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),
@@ -43,6 +47,8 @@ const _: () = {
     impl<T, U> TupleStruct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -56,6 +62,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/pinned_drop/enum.expanded.rs
+++ b/tests/expand/pinned_drop/enum.expanded.rs
@@ -90,7 +90,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {

--- a/tests/expand/pinned_drop/enum.expanded.rs
+++ b/tests/expand/pinned_drop/enum.expanded.rs
@@ -89,6 +89,8 @@ const _: () = {
     impl<T, U> Enum<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
@@ -112,6 +114,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {

--- a/tests/expand/pinned_drop/enum.expanded.rs
+++ b/tests/expand/pinned_drop/enum.expanded.rs
@@ -115,7 +115,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {

--- a/tests/expand/pinned_drop/struct.expanded.rs
+++ b/tests/expand/pinned_drop/struct.expanded.rs
@@ -32,6 +32,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -40,6 +42,8 @@ const _: () = {
         unpinned: &'pin mut (U),
     }
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& Struct> directly rather than this struct*/
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -50,6 +54,8 @@ const _: () = {
     impl<T, U> Struct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -63,6 +69,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/pinned_drop/struct.expanded.rs
+++ b/tests/expand/pinned_drop/struct.expanded.rs
@@ -57,7 +57,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {

--- a/tests/expand/pinned_drop/struct.expanded.rs
+++ b/tests/expand/pinned_drop/struct.expanded.rs
@@ -34,6 +34,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -44,6 +45,7 @@ You should however consider passing around a Pin<&mut Struct> directly rather th
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -70,7 +72,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/pinned_drop/tuple_struct.expanded.rs
+++ b/tests/expand/pinned_drop/tuple_struct.expanded.rs
@@ -51,7 +51,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {

--- a/tests/expand/pinned_drop/tuple_struct.expanded.rs
+++ b/tests/expand/pinned_drop/tuple_struct.expanded.rs
@@ -30,6 +30,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
@@ -39,6 +40,7 @@ You should however consider passing around a Pin<&mut TupleStruct> directly rath
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),
@@ -64,7 +66,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/pinned_drop/tuple_struct.expanded.rs
+++ b/tests/expand/pinned_drop/tuple_struct.expanded.rs
@@ -28,6 +28,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
@@ -35,6 +37,8 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),
@@ -44,6 +48,8 @@ const _: () = {
     impl<T, U> TupleStruct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -57,6 +63,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/project_replace/enum.expanded.rs
+++ b/tests/expand/project_replace/enum.expanded.rs
@@ -57,6 +57,7 @@ const _: () = {
     impl<T, U> Enum<T, U> {
         #[allow(dead_code)]
         #[inline]
+        ///Take a Pin<&mut Enum>, and a replacement. Replace the pinned Enum and return an owning projection
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/project_replace/struct.expanded.rs
+++ b/tests/expand/project_replace/struct.expanded.rs
@@ -33,6 +33,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -43,6 +44,7 @@ You should however consider passing around a Pin<&mut Struct> directly rather th
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -52,6 +54,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
     }
     #[allow(dead_code, clippy::missing_docs_in_private_items)]
     ///A projection that own a Struct.
+    #[non_exhaustive]
     struct __StructProjectionOwned<T, U> {
         pinned: ::pin_project::__private::PhantomData<T>,
         unpinned: U,
@@ -75,7 +78,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/project_replace/struct.expanded.rs
+++ b/tests/expand/project_replace/struct.expanded.rs
@@ -63,7 +63,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {

--- a/tests/expand/project_replace/struct.expanded.rs
+++ b/tests/expand/project_replace/struct.expanded.rs
@@ -31,6 +31,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -39,6 +41,8 @@ const _: () = {
         unpinned: &'pin mut (U),
     }
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& Struct> directly rather than this struct*/
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -47,6 +51,7 @@ const _: () = {
         unpinned: &'pin (U),
     }
     #[allow(dead_code, clippy::missing_docs_in_private_items)]
+    ///A projection that own a Struct.
     struct __StructProjectionOwned<T, U> {
         pinned: ::pin_project::__private::PhantomData<T>,
         unpinned: U,
@@ -54,6 +59,8 @@ const _: () = {
     impl<T, U> Struct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -67,6 +74,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {
@@ -80,6 +89,7 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        ///Take a Pin<&mut Struct>, and a replacement. Replace the pinned Struct and return an owning projection
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/project_replace/tuple_struct.expanded.rs
+++ b/tests/expand/project_replace/tuple_struct.expanded.rs
@@ -57,7 +57,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {

--- a/tests/expand/project_replace/tuple_struct.expanded.rs
+++ b/tests/expand/project_replace/tuple_struct.expanded.rs
@@ -29,6 +29,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
@@ -38,6 +39,7 @@ You should however consider passing around a Pin<&mut TupleStruct> directly rath
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),
@@ -46,6 +48,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         TupleStruct<T, U>: 'pin;
     #[allow(dead_code, clippy::missing_docs_in_private_items)]
     ///A projection that own a TupleStruct.
+    #[non_exhaustive]
     struct __TupleStructProjectionOwned<T, U>(
         ::pin_project::__private::PhantomData<T>,
         U,
@@ -69,7 +72,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/project_replace/tuple_struct.expanded.rs
+++ b/tests/expand/project_replace/tuple_struct.expanded.rs
@@ -27,6 +27,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
@@ -34,6 +36,8 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),
@@ -41,6 +45,7 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     #[allow(dead_code, clippy::missing_docs_in_private_items)]
+    ///A projection that own a TupleStruct.
     struct __TupleStructProjectionOwned<T, U>(
         ::pin_project::__private::PhantomData<T>,
         U,
@@ -48,6 +53,8 @@ const _: () = {
     impl<T, U> TupleStruct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -61,6 +68,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {
@@ -74,6 +83,7 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        ///Take a Pin<&mut TupleStruct>, and a replacement. Replace the pinned TupleStruct and return an owning projection
         fn project_replace(
             self: _pin_project::__private::Pin<&mut Self>,
             __replacement: Self,

--- a/tests/expand/pub/enum.expanded.rs
+++ b/tests/expand/pub/enum.expanded.rs
@@ -89,7 +89,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         pub(crate) fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {

--- a/tests/expand/pub/enum.expanded.rs
+++ b/tests/expand/pub/enum.expanded.rs
@@ -88,6 +88,8 @@ const _: () = {
     impl<T, U> Enum<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         pub(crate) fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
@@ -111,6 +113,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         pub(crate) fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {

--- a/tests/expand/pub/enum.expanded.rs
+++ b/tests/expand/pub/enum.expanded.rs
@@ -114,7 +114,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         pub(crate) fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {

--- a/tests/expand/pub/struct.expanded.rs
+++ b/tests/expand/pub/struct.expanded.rs
@@ -31,6 +31,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
     pub(crate) struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -39,6 +41,8 @@ const _: () = {
         pub unpinned: &'pin mut (U),
     }
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& Struct> directly rather than this struct*/
     pub(crate) struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -49,6 +53,8 @@ const _: () = {
     impl<T, U> Struct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         pub(crate) fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -62,6 +68,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         pub(crate) fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/pub/struct.expanded.rs
+++ b/tests/expand/pub/struct.expanded.rs
@@ -33,6 +33,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
+    #[non_exhaustive]
     pub(crate) struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -43,6 +44,7 @@ You should however consider passing around a Pin<&mut Struct> directly rather th
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& Struct> directly rather than this struct*/
+    #[non_exhaustive]
     pub(crate) struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -69,7 +71,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         pub(crate) fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/pub/struct.expanded.rs
+++ b/tests/expand/pub/struct.expanded.rs
@@ -56,7 +56,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         pub(crate) fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {

--- a/tests/expand/pub/tuple_struct.expanded.rs
+++ b/tests/expand/pub/tuple_struct.expanded.rs
@@ -29,6 +29,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     pub(crate) struct __TupleStructProjection<'pin, T, U>(
         pub ::pin_project::__private::Pin<&'pin mut (T)>,
         pub &'pin mut (U),
@@ -38,6 +39,7 @@ You should however consider passing around a Pin<&mut TupleStruct> directly rath
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     pub(crate) struct __TupleStructProjectionRef<'pin, T, U>(
         pub ::pin_project::__private::Pin<&'pin (T)>,
         pub &'pin (U),
@@ -63,7 +65,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         pub(crate) fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/pub/tuple_struct.expanded.rs
+++ b/tests/expand/pub/tuple_struct.expanded.rs
@@ -50,7 +50,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         pub(crate) fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {

--- a/tests/expand/pub/tuple_struct.expanded.rs
+++ b/tests/expand/pub/tuple_struct.expanded.rs
@@ -27,6 +27,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
     pub(crate) struct __TupleStructProjection<'pin, T, U>(
         pub ::pin_project::__private::Pin<&'pin mut (T)>,
         pub &'pin mut (U),
@@ -34,6 +36,8 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
     pub(crate) struct __TupleStructProjectionRef<'pin, T, U>(
         pub ::pin_project::__private::Pin<&'pin (T)>,
         pub &'pin (U),
@@ -43,6 +47,8 @@ const _: () = {
     impl<T, U> TupleStruct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         pub(crate) fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -56,6 +62,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         pub(crate) fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/unsafe_unpin/enum.expanded.rs
+++ b/tests/expand/unsafe_unpin/enum.expanded.rs
@@ -89,7 +89,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {

--- a/tests/expand/unsafe_unpin/enum.expanded.rs
+++ b/tests/expand/unsafe_unpin/enum.expanded.rs
@@ -88,6 +88,8 @@ const _: () = {
     impl<T, U> Enum<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> EnumProj<'pin, T, U> {
@@ -111,6 +113,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {

--- a/tests/expand/unsafe_unpin/enum.expanded.rs
+++ b/tests/expand/unsafe_unpin/enum.expanded.rs
@@ -114,7 +114,7 @@ const _: () = {
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Enum> and project it, aka return a Enum-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> EnumProjRef<'pin, T, U> {

--- a/tests/expand/unsafe_unpin/struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/struct.expanded.rs
@@ -31,6 +31,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -39,6 +41,8 @@ const _: () = {
         unpinned: &'pin mut (U),
     }
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& Struct> directly rather than this struct*/
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -49,6 +53,8 @@ const _: () = {
     impl<T, U> Struct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {
@@ -62,6 +68,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/unsafe_unpin/struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/struct.expanded.rs
@@ -33,6 +33,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected Struct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjection<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -43,6 +44,7 @@ You should however consider passing around a Pin<&mut Struct> directly rather th
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected Struct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& Struct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __StructProjectionRef<'pin, T, U>
     where
         Struct<T, U>: 'pin,
@@ -69,7 +71,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __StructProjectionRef<'pin, T, U> {

--- a/tests/expand/unsafe_unpin/struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/struct.expanded.rs
@@ -56,7 +56,7 @@ You should consider passing around a Pin<& Struct> directly rather than this str
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut Struct> and project it, aka return a Struct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __StructProjection<'pin, T, U> {

--- a/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
@@ -29,6 +29,7 @@ const _: () = {
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
     /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
 You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
@@ -38,6 +39,7 @@ You should however consider passing around a Pin<&mut TupleStruct> directly rath
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
     /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
 You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
+    #[non_exhaustive]
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),
@@ -63,7 +65,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinne if necessary) reference to the corresponding field of Self*/
+        each being a (pinned if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
@@ -50,7 +50,7 @@ You should consider passing around a Pin<& TupleStruct> directly rather than thi
         #[allow(dead_code)]
         #[inline]
         /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
-        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
+        each being a (pinned if necessary) mutable reference to the corresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {

--- a/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
+++ b/tests/expand/unsafe_unpin/tuple_struct.expanded.rs
@@ -27,6 +27,8 @@ const _: () = {
     #[allow(unused_extern_crates)]
     extern crate pin_project as _pin_project;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::mut_mut)]
+    /**A projected TupleStruct. Obtained trough the .project() method, useful to access the fields.
+You should however consider passing around a Pin<&mut TupleStruct> directly rather than this struct*/
     struct __TupleStructProjection<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin mut (T)>,
         &'pin mut (U),
@@ -34,6 +36,8 @@ const _: () = {
     where
         TupleStruct<T, U>: 'pin;
     #[allow(dead_code, clippy::missing_docs_in_private_items, clippy::ref_option_ref)]
+    /**A immutably projected TupleStruct. Obtained trough the .project_ref() method, useful to access the fields.
+You should consider passing around a Pin<& TupleStruct> directly rather than this struct*/
     struct __TupleStructProjectionRef<'pin, T, U>(
         ::pin_project::__private::Pin<&'pin (T)>,
         &'pin (U),
@@ -43,6 +47,8 @@ const _: () = {
     impl<T, U> TupleStruct<T, U> {
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<&mut TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinned if necessary) mutable reference to the coresponding field of Self*/
         fn project<'pin>(
             self: _pin_project::__private::Pin<&'pin mut Self>,
         ) -> __TupleStructProjection<'pin, T, U> {
@@ -56,6 +62,8 @@ const _: () = {
         }
         #[allow(dead_code)]
         #[inline]
+        /**Take a Pin<& TupleStruct> and project it, aka return a TupleStruct-like data structure with fields of the same name,
+        each being a (pinne if necessary) reference to the corresponding field of Self*/
         fn project_ref<'pin>(
             self: _pin_project::__private::Pin<&'pin Self>,
         ) -> __TupleStructProjectionRef<'pin, T, U> {

--- a/tests/include/basic-safe-part.rs
+++ b/tests/include/basic-safe-part.rs
@@ -275,10 +275,10 @@ pub enum NotUnpinEnum<T, U> {
 }
 
 /// Testing pub doc
-#[allow(clippy::exhaustive_structs)] // for the type itself
 #[::pin_project::pin_project(pub project = PubStructProj)]
 #[derive(Debug)]
-pub struct PubStruct<T,U> {
+#[allow(clippy::exhaustive_structs)] // for the type itself
+pub struct PubStruct<T, U> {
     /// Pinned field.
     #[pin]
     pub pinned: T,

--- a/tests/include/basic-safe-part.rs
+++ b/tests/include/basic-safe-part.rs
@@ -2,6 +2,7 @@
 
 // default #[pin_project], PinnedDrop, project_replace, !Unpin, and UnsafeUnpin without UnsafeUnpin impl are completely safe.
 
+
 /// Testing default struct.
 #[allow(clippy::exhaustive_structs)] // for the type itself
 #[::pin_project::pin_project]

--- a/tests/include/basic-safe-part.rs
+++ b/tests/include/basic-safe-part.rs
@@ -2,7 +2,6 @@
 
 // default #[pin_project], PinnedDrop, project_replace, !Unpin, and UnsafeUnpin without UnsafeUnpin impl are completely safe.
 
-
 /// Testing default struct.
 #[allow(clippy::exhaustive_structs)] // for the type itself
 #[::pin_project::pin_project]

--- a/tests/include/basic-safe-part.rs
+++ b/tests/include/basic-safe-part.rs
@@ -276,8 +276,8 @@ pub enum NotUnpinEnum<T, U> {
 
 /// Testing pub doc
 #[allow(clippy::exhaustive_structs)] // for the type itself
-#[derive(Debug)]
 #[::pin_project::pin_project(pub project = PubStructProj)]
+#[derive(Debug)]
 pub struct PubStruct<T,U> {
     /// Pinned field.
     #[pin]

--- a/tests/include/basic-safe-part.rs
+++ b/tests/include/basic-safe-part.rs
@@ -275,6 +275,7 @@ pub enum NotUnpinEnum<T, U> {
 }
 
 /// Testing pub doc
+#[allow(clippy::exhaustive_structs)] // for the type itself
 #[derive(Debug)]
 #[::pin_project::pin_project(pub project = PubStructProj)]
 pub struct PubStruct<T,U> {

--- a/tests/include/basic-safe-part.rs
+++ b/tests/include/basic-safe-part.rs
@@ -273,3 +273,14 @@ pub enum NotUnpinEnum<T, U> {
     /// Unit variant.
     Unit,
 }
+
+/// Testing pub doc
+#[derive(Debug)]
+#[::pin_project::pin_project(pub project = PubStructProj)]
+pub struct PubStruct<T,U> {
+    /// Pinned field.
+    #[pin]
+    pub pinned: T,
+    /// Unpinned field.
+    pub unpinned: U,
+}

--- a/tests/ui/pin_project/invalid.rs
+++ b/tests/ui/pin_project/invalid.rs
@@ -197,13 +197,13 @@ mod pin_project_argument {
     #[pin_project(pub)] //~ Error `pub` can only be used on project, project_ref or named project_replace.
     struct Pub1(#[pin] ());
 
-    #[pin_project(pub Unpin)] //~ Error `pub` can only be used on project, project_ref or named project_replace.
+    #[pin_project(pub Unpin)] //~ Error unexpected argument: Unpin
     struct Pub2(#[pin] ());
 
     #[pin_project(pub project_replace)] //~ Error project_replace cannot be pub if it is not named
     struct Pub3(#[pin] ());
 
-    #[pin_project(pub project_replace = Pub4ProjReplace, pub Project = Pub4Proj)] // Ok
+    #[pin_project(pub project_replace = Pub4ProjReplace, pub project = Pub4Proj)] // Ok
     struct Pub4(#[pin] ());
 }
 

--- a/tests/ui/pin_project/invalid.rs
+++ b/tests/ui/pin_project/invalid.rs
@@ -200,7 +200,7 @@ mod pin_project_argument {
     #[pin_project(pub Unpin)] //~ Error unexpected argument: Unpin
     struct Pub2(#[pin] ());
 
-    #[pin_project(pub project_replace)] //~ Error project_replace cannot be pub if it is not named
+    #[pin_project(pub project_replace)] //~ Error `pub` can only be used on project, project_ref or named project_replace.
     struct Pub3(#[pin] ());
 
     #[pin_project(pub project_replace = Pub4ProjReplace, pub project = Pub4Proj)] // Ok

--- a/tests/ui/pin_project/invalid.rs
+++ b/tests/ui/pin_project/invalid.rs
@@ -193,6 +193,18 @@ mod pin_project_argument {
     enum ProjectReplaceEnum {
         V(#[pin] ()),
     }
+
+    #[pin_project(pub)] //~ Error `pub` can only be used on project, project_ref or named project_replace.
+    struct Pub1(#[pin] ());
+
+    #[pin_project(pub Unpin)] //~ Error `pub` can only be used on project, project_ref or named project_replace.
+    struct Pub2(#[pin] ());
+
+    #[pin_project(pub project_replace)] //~ Error project_replace cannot be pub if it is not named
+    struct Pub3(#[pin] ());
+
+    #[pin_project(pub project_replace = Pub4ProjReplace, pub Project = Pub4Proj)] // Ok
+    struct Pub4(#[pin] ());
 }
 
 mod pin_project_conflict_naming {

--- a/tests/ui/pin_project/invalid.stderr
+++ b/tests/ui/pin_project/invalid.stderr
@@ -265,7 +265,7 @@ error: unexpected argument: Unpin
 error: `pub` can only be used on project, project_ref or named project_replace.
    --> tests/ui/pin_project/invalid.rs:203:19
     |
-203 |     #[pin_project(pub project_replace)] //~ Error project_replace cannot be pub if it is not named
+203 |     #[pin_project(pub project_replace)] //~ Error `pub` can only be used on project, project_ref or named project_replace.
     |                   ^^^
 
 error: name `OrigAndProj` is the same as the original type name

--- a/tests/ui/pin_project/invalid.stderr
+++ b/tests/ui/pin_project/invalid.stderr
@@ -250,18 +250,16 @@ error: `project_replace` argument requires a value when used on enums
 192 |     #[pin_project(project_replace)] //~ ERROR `project_replace` argument requires a value when used on enums
     |                   ^^^^^^^^^^^^^^^
 
-error: unexpected end of input, expected identifier
-   --> tests/ui/pin_project/invalid.rs:197:5
+error: `pub` can only be used on project, project_ref or named project_replace
+   --> tests/ui/pin_project/invalid.rs:197:19
     |
 197 |     #[pin_project(pub)] //~ Error `pub` can only be used on project, project_ref or named project_replace.
-    |     ^^^^^^^^^^^^^^^^^^^
-    |
-    = note: this error originates in the derive macro `::pin_project::__private::__PinProjectInternalDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
+    |                   ^^^
 
 error: unexpected argument: Unpin
    --> tests/ui/pin_project/invalid.rs:200:23
     |
-200 |     #[pin_project(pub Unpin)] //~ Error `pub` can only be used on project, project_ref or named project_replace.
+200 |     #[pin_project(pub Unpin)] //~ Error unexpected argument: Unpin
     |                       ^^^^^
 
 error: `pub` can only be used on project, project_ref or named project_replace.
@@ -269,12 +267,6 @@ error: `pub` can only be used on project, project_ref or named project_replace.
     |
 203 |     #[pin_project(pub project_replace)] //~ Error project_replace cannot be pub if it is not named
     |                   ^^^
-
-error: unexpected argument: Project
-   --> tests/ui/pin_project/invalid.rs:206:62
-    |
-206 |     #[pin_project(pub project_replace = Pub4ProjReplace, pub Project = Pub4Proj)] // Ok
-    |                                                              ^^^^^^^
 
 error: name `OrigAndProj` is the same as the original type name
    --> tests/ui/pin_project/invalid.rs:213:29

--- a/tests/ui/pin_project/invalid.stderr
+++ b/tests/ui/pin_project/invalid.stderr
@@ -250,115 +250,141 @@ error: `project_replace` argument requires a value when used on enums
 192 |     #[pin_project(project_replace)] //~ ERROR `project_replace` argument requires a value when used on enums
     |                   ^^^^^^^^^^^^^^^
 
-error: name `OrigAndProj` is the same as the original type name
-   --> tests/ui/pin_project/invalid.rs:201:29
+error: unexpected end of input, expected identifier
+   --> tests/ui/pin_project/invalid.rs:197:5
     |
-201 |     #[pin_project(project = OrigAndProj)] //~ ERROR name `OrigAndProj` is the same as the original type name
+197 |     #[pin_project(pub)] //~ Error `pub` can only be used on project, project_ref or named project_replace.
+    |     ^^^^^^^^^^^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `::pin_project::__private::__PinProjectInternalDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unexpected argument: Unpin
+   --> tests/ui/pin_project/invalid.rs:200:23
+    |
+200 |     #[pin_project(pub Unpin)] //~ Error `pub` can only be used on project, project_ref or named project_replace.
+    |                       ^^^^^
+
+error: `pub` can only be used on project, project_ref or named project_replace.
+   --> tests/ui/pin_project/invalid.rs:203:19
+    |
+203 |     #[pin_project(pub project_replace)] //~ Error project_replace cannot be pub if it is not named
+    |                   ^^^
+
+error: unexpected argument: Project
+   --> tests/ui/pin_project/invalid.rs:206:62
+    |
+206 |     #[pin_project(pub project_replace = Pub4ProjReplace, pub Project = Pub4Proj)] // Ok
+    |                                                              ^^^^^^^
+
+error: name `OrigAndProj` is the same as the original type name
+   --> tests/ui/pin_project/invalid.rs:213:29
+    |
+213 |     #[pin_project(project = OrigAndProj)] //~ ERROR name `OrigAndProj` is the same as the original type name
     |                             ^^^^^^^^^^^
 
 error: name `OrigAndProjRef` is the same as the original type name
-   --> tests/ui/pin_project/invalid.rs:204:33
+   --> tests/ui/pin_project/invalid.rs:216:33
     |
-204 |     #[pin_project(project_ref = OrigAndProjRef)] //~ ERROR name `OrigAndProjRef` is the same as the original type name
+216 |     #[pin_project(project_ref = OrigAndProjRef)] //~ ERROR name `OrigAndProjRef` is the same as the original type name
     |                                 ^^^^^^^^^^^^^^
 
 error: name `OrigAndProjOwn` is the same as the original type name
-   --> tests/ui/pin_project/invalid.rs:207:37
+   --> tests/ui/pin_project/invalid.rs:219:37
     |
-207 |     #[pin_project(project_replace = OrigAndProjOwn)] //~ ERROR name `OrigAndProjOwn` is the same as the original type name
+219 |     #[pin_project(project_replace = OrigAndProjOwn)] //~ ERROR name `OrigAndProjOwn` is the same as the original type name
     |                                     ^^^^^^^^^^^^^^
 
 error: name `A` is already specified by `project` argument
-   --> tests/ui/pin_project/invalid.rs:210:46
+   --> tests/ui/pin_project/invalid.rs:222:46
     |
-210 |     #[pin_project(project = A, project_ref = A)] //~ ERROR name `A` is already specified by `project` argument
+222 |     #[pin_project(project = A, project_ref = A)] //~ ERROR name `A` is already specified by `project` argument
     |                                              ^
 
 error: name `A` is already specified by `project` argument
-   --> tests/ui/pin_project/invalid.rs:213:50
+   --> tests/ui/pin_project/invalid.rs:225:50
     |
-213 |     #[pin_project(project = A, project_replace = A)] //~ ERROR name `A` is already specified by `project` argument
+225 |     #[pin_project(project = A, project_replace = A)] //~ ERROR name `A` is already specified by `project` argument
     |                                                  ^
 
 error: name `A` is already specified by `project_ref` argument
-   --> tests/ui/pin_project/invalid.rs:216:54
+   --> tests/ui/pin_project/invalid.rs:228:54
     |
-216 |     #[pin_project(project_ref = A, project_replace = A)] //~ ERROR name `A` is already specified by `project_ref` argument
+228 |     #[pin_project(project_ref = A, project_replace = A)] //~ ERROR name `A` is already specified by `project_ref` argument
     |                                                      ^
 
 error: duplicate #[pin_project] attribute
-   --> tests/ui/pin_project/invalid.rs:224:5
+   --> tests/ui/pin_project/invalid.rs:236:5
     |
-224 |     #[pin_project] //~ ERROR duplicate #[pin_project] attribute
+236 |     #[pin_project] //~ ERROR duplicate #[pin_project] attribute
     |     ^^^^^^^^^^^^^^
 
 error: #[pin_project] attribute may not be used on structs with zero fields
-   --> tests/ui/pin_project/invalid.rs:232:19
+   --> tests/ui/pin_project/invalid.rs:244:19
     |
-232 |     struct Struct {} //~ ERROR may not be used on structs with zero fields
+244 |     struct Struct {} //~ ERROR may not be used on structs with zero fields
     |                   ^^
 
 error: #[pin_project] attribute may not be used on structs with zero fields
-   --> tests/ui/pin_project/invalid.rs:235:23
+   --> tests/ui/pin_project/invalid.rs:247:23
     |
-235 |     struct TupleStruct(); //~ ERROR may not be used on structs with zero fields
+247 |     struct TupleStruct(); //~ ERROR may not be used on structs with zero fields
     |                       ^^
 
 error: #[pin_project] attribute may not be used on structs with zero fields
-   --> tests/ui/pin_project/invalid.rs:238:12
+   --> tests/ui/pin_project/invalid.rs:250:12
     |
-238 |     struct UnitStruct; //~ ERROR may not be used on structs with zero fields
+250 |     struct UnitStruct; //~ ERROR may not be used on structs with zero fields
     |            ^^^^^^^^^^
 
 error: #[pin_project] attribute may not be used on enums without variants
-   --> tests/ui/pin_project/invalid.rs:241:20
+   --> tests/ui/pin_project/invalid.rs:253:20
     |
-241 |     enum EnumEmpty {} //~ ERROR may not be used on enums without variants
+253 |     enum EnumEmpty {} //~ ERROR may not be used on enums without variants
     |                    ^^
 
 error: #[pin_project] attribute may not be used on enums with discriminants
-   --> tests/ui/pin_project/invalid.rs:245:13
+   --> tests/ui/pin_project/invalid.rs:257:13
     |
-245 |         V = 2, //~ ERROR may not be used on enums with discriminants
+257 |         V = 2, //~ ERROR may not be used on enums with discriminants
     |             ^
 
 error: #[pin_project] attribute may not be used on enums with zero fields
-   --> tests/ui/pin_project/invalid.rs:250:9
+   --> tests/ui/pin_project/invalid.rs:262:9
     |
-250 | /         Unit, //~ ERROR may not be used on enums with zero fields
-251 | |         Tuple(),
-252 | |         Struct {},
+262 | /         Unit, //~ ERROR may not be used on enums with zero fields
+263 | |         Tuple(),
+264 | |         Struct {},
     | |__________________^
 
 error: #[pin_project] attribute may only be used on structs or enums
-   --> tests/ui/pin_project/invalid.rs:256:5
+   --> tests/ui/pin_project/invalid.rs:268:5
     |
-256 | /     union Union {
-257 | |         //~^ ERROR may only be used on structs or enums
-258 | |         f: (),
-259 | |     }
+268 | /     union Union {
+269 | |         //~^ ERROR may only be used on structs or enums
+270 | |         f: (),
+271 | |     }
     | |_____^
 
 error: #[pin_project] attribute may only be used on structs or enums
-   --> tests/ui/pin_project/invalid.rs:262:5
+   --> tests/ui/pin_project/invalid.rs:274:5
     |
-262 |     impl Impl {} //~ ERROR may only be used on structs or enums
+274 |     impl Impl {} //~ ERROR may only be used on structs or enums
     |     ^^^^^^^^^^^^
 
 error: #[pin_project] attribute may not be used on #[repr(packed)] types
-   --> tests/ui/pin_project/invalid.rs:270:12
+   --> tests/ui/pin_project/invalid.rs:282:12
     |
-270 |     #[repr(packed)]
+282 |     #[repr(packed)]
     |            ^^^^^^
 
 error: #[pin_project] attribute may not be used on #[repr(packed)] types
-   --> tests/ui/pin_project/invalid.rs:274:12
+   --> tests/ui/pin_project/invalid.rs:286:12
     |
-274 |     #[repr(packed)]
+286 |     #[repr(packed)]
     |            ^^^^^^
 
 error: #[pin_project] attribute may not be used on #[repr(packed)] types
-   --> tests/ui/pin_project/invalid.rs:278:12
+   --> tests/ui/pin_project/invalid.rs:290:12
     |
-278 |     #[repr(packed)]
+290 |     #[repr(packed)]
     |            ^^^^^^

--- a/tests/ui/pin_project/project_replace_unsized.stderr
+++ b/tests/ui/pin_project/project_replace_unsized.stderr
@@ -101,11 +101,14 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   |
 note: required by an implicit `Sized` bound in `std::ptr::read`
  --> $RUST/core/src/ptr/mod.rs
+  |
+  | pub const unsafe fn read<T>(src: *const T) -> T {
+  |                          ^ required by the implicit `Sized` requirement on this type parameter in `read`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
   |
-6 - struct Struct<T: ?Sized> {
-6 + struct Struct<T> {
-  |
+   6 - struct Struct<T: ?Sized> {
+   6 + struct Struct<T> {
+     |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> tests/ui/pin_project/project_replace_unsized.rs:10:15

--- a/tests/ui/pin_project/project_replace_unsized.stderr
+++ b/tests/ui/pin_project/project_replace_unsized.stderr
@@ -101,14 +101,11 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   |
 note: required by an implicit `Sized` bound in `std::ptr::read`
  --> $RUST/core/src/ptr/mod.rs
-  |
-  | pub const unsafe fn read<T>(src: *const T) -> T {
-  |                          ^ required by the implicit `Sized` requirement on this type parameter in `read`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
   |
-   6 - struct Struct<T: ?Sized> {
-   6 + struct Struct<T> {
-     |
+6 - struct Struct<T: ?Sized> {
+6 + struct Struct<T> {
+  |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> tests/ui/pin_project/project_replace_unsized.rs:10:15

--- a/tests/ui/pin_project/project_replace_unsized_fn_params.stderr
+++ b/tests/ui/pin_project/project_replace_unsized_fn_params.stderr
@@ -77,11 +77,14 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
    |
 note: required by an implicit `Sized` bound in `std::ptr::read`
   --> $RUST/core/src/ptr/mod.rs
+   |
+   | pub const unsafe fn read<T>(src: *const T) -> T {
+   |                          ^ required by the implicit `Sized` requirement on this type parameter in `read`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
- 9 - struct Struct<T: ?Sized> {
- 9 + struct Struct<T> {
-   |
+   9 - struct Struct<T: ?Sized> {
+   9 + struct Struct<T> {
+     |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> tests/ui/pin_project/project_replace_unsized_fn_params.rs:13:1

--- a/tests/ui/pin_project/project_replace_unsized_fn_params.stderr
+++ b/tests/ui/pin_project/project_replace_unsized_fn_params.stderr
@@ -77,14 +77,11 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
    |
 note: required by an implicit `Sized` bound in `std::ptr::read`
   --> $RUST/core/src/ptr/mod.rs
-   |
-   | pub const unsafe fn read<T>(src: *const T) -> T {
-   |                          ^ required by the implicit `Sized` requirement on this type parameter in `read`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
-   9 - struct Struct<T: ?Sized> {
-   9 + struct Struct<T> {
-     |
+ 9 - struct Struct<T: ?Sized> {
+ 9 + struct Struct<T> {
+   |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> tests/ui/pin_project/project_replace_unsized_fn_params.rs:13:1

--- a/tests/ui/pin_project/remove-attr-from-struct.stderr
+++ b/tests/ui/pin_project/remove-attr-from-struct.stderr
@@ -77,6 +77,12 @@ note: required because it appears within the type `A`
    |        ^
 note: required by a bound in `Pin::<Ptr>::new`
   --> $RUST/core/src/pin.rs
+   |
+   | impl<Ptr: Deref<Target: Unpin>> Pin<Ptr> {
+   |                         ^^^^^ required by this bound in `Pin::<Ptr>::new`
+...
+   |     pub const fn new(pointer: Ptr) -> Pin<Ptr> {
+   |                  --- required by a bound in this associated function
 
 error[E0599]: no method named `project` found for struct `Pin<&mut A>` in the current scope
   --> tests/ui/pin_project/remove-attr-from-struct.rs:42:30
@@ -101,6 +107,12 @@ note: required because it appears within the type `B`
    |        ^
 note: required by a bound in `Pin::<Ptr>::new`
   --> $RUST/core/src/pin.rs
+   |
+   | impl<Ptr: Deref<Target: Unpin>> Pin<Ptr> {
+   |                         ^^^^^ required by this bound in `Pin::<Ptr>::new`
+...
+   |     pub const fn new(pointer: Ptr) -> Pin<Ptr> {
+   |                  --- required by a bound in this associated function
 
 error[E0599]: no method named `project` found for struct `Pin<&mut B>` in the current scope
   --> tests/ui/pin_project/remove-attr-from-struct.rs:45:30

--- a/tests/ui/pin_project/remove-attr-from-struct.stderr
+++ b/tests/ui/pin_project/remove-attr-from-struct.stderr
@@ -77,12 +77,6 @@ note: required because it appears within the type `A`
    |        ^
 note: required by a bound in `Pin::<Ptr>::new`
   --> $RUST/core/src/pin.rs
-   |
-   | impl<Ptr: Deref<Target: Unpin>> Pin<Ptr> {
-   |                         ^^^^^ required by this bound in `Pin::<Ptr>::new`
-...
-   |     pub const fn new(pointer: Ptr) -> Pin<Ptr> {
-   |                  --- required by a bound in this associated function
 
 error[E0599]: no method named `project` found for struct `Pin<&mut A>` in the current scope
   --> tests/ui/pin_project/remove-attr-from-struct.rs:42:30
@@ -107,12 +101,6 @@ note: required because it appears within the type `B`
    |        ^
 note: required by a bound in `Pin::<Ptr>::new`
   --> $RUST/core/src/pin.rs
-   |
-   | impl<Ptr: Deref<Target: Unpin>> Pin<Ptr> {
-   |                         ^^^^^ required by this bound in `Pin::<Ptr>::new`
-...
-   |     pub const fn new(pointer: Ptr) -> Pin<Ptr> {
-   |                  --- required by a bound in this associated function
 
 error[E0599]: no method named `project` found for struct `Pin<&mut B>` in the current scope
   --> tests/ui/pin_project/remove-attr-from-struct.rs:45:30


### PR DESCRIPTION
Behavior on existing syntax is kept as is.
The new syntax look like this:

```rust
# use pin_project::pin_project
#[pin_project(pub project = StructProj)] //force the project method and StructProj to be pub
pub struct Struct<T> {
    #[pin]
    field: T,
}
```
pub prefix can also be used on project_ref and (named) project_replace

fix #361